### PR TITLE
Store task types with task ids in the materials doc

### DIFF
--- a/emmet/vasp/builders/materials.py
+++ b/emmet/vasp/builders/materials.py
@@ -166,7 +166,7 @@ class MaterialsBuilder(Builder):
 
         # Temp document with basic information
         d = {"created_at": datetime.utcnow(),
-             "task_ids": [t_id],
+             "task_ids": {t_id: TaskTagger.task_type(task)},
              "material_id": t_id,
              "origins": origins
              }


### PR DESCRIPTION
@shyamd not sure if this needs to be changed anywhere else, but would be really useful to have