### PR TITLE
Property workflow builder

### DIFF
--- a/emmet/materials/property_workflows.py
+++ b/emmet/materials/property_workflows.py
@@ -52,7 +52,9 @@ class PropertyWorkflowBuilder(Builder):
                 can be a string to be loaded or a custom method.
                 Note that the builder/runner will not be serializable
                 with custom methods.
-            lpad (LaunchPad): fireworks launchpad to use for adding workflows
+            lpad (LaunchPad or dict): fireworks launchpad to use for adding
+                workflows, can either be None (autoloaded), a LaunchPad
+                instance, or a dict from which the LaunchPad will be invoked
             **kwargs (kwargs): kwargs for builder
         """
         self.source = source
@@ -69,7 +71,12 @@ class PropertyWorkflowBuilder(Builder):
             raise ValueError("wf_function must be callable or a string "
                              "corresponding to a loadable method")
         self.material_filter = material_filter
-        self.lpad = lpad or LaunchPad.auto_load()
+        if lpad is None:
+            self.lpad = LaunchPad.auto_load()
+        elif isinstance(lpad, dict):
+            self.lpad = LaunchPad.from_dict(lpad)
+        else:
+            self.lpad = lpad
 
         super().__init__(sources=[source, materials],
                          targets=[], **kwargs)
@@ -95,10 +102,10 @@ class PropertyWorkflowBuilder(Builder):
         Processes items into workflows
 
         Args:
-            item:
+            item ((dict, list)): pair of doc and material_ids to filter
 
         Returns:
-
+            Workflow
         """
         wf_input, ids_to_filter = item
         mat_id = wf_input["material_id"]

--- a/emmet/materials/property_workflows.py
+++ b/emmet/materials/property_workflows.py
@@ -1,0 +1,162 @@
+"""
+This module is intended to allow building derivative workflows
+for material properties based on missing properties in a
+materials collection
+"""
+
+from maggma.builder import Builder
+from atomate.vasp.workflows.presets.core import wf_elastic_constant
+from atomate.vasp.powerups import add_tags, add_modify_incar, add_priority
+from atomate.utils.utils import get_fws_and_tasks
+from pymatgen.analysis.elasticity.tensors import Tensor, SquareTensor,\
+        get_tkd_value, symmetry_reduce
+from pymatgen.analysis.elasticity.strain import Strain
+from pymatgen.core.operations import SymmOp
+from pymatgen import Structure
+from fireworks import LaunchPad
+import numpy as np
+import logging
+
+logger = logging.getLogger(__name__)
+
+__author__ = "Joseph Montoya"
+__maintainer__ = "Joseph Montoya"
+__email__ = "montoyjh@lbl.gov"
+
+
+# TODO: kind of specific to vasp in the add_tags, improve metadata handling
+# TODO: I'm a bit wary to implement an incremental strategy here,
+#       but I think it can be done
+class PropertyWorkflowBuilder(Builder):
+    def __init__(self, materials, wf_function, filter=None, lpad=None,
+                 **kwargs):
+        """
+        Creates a elastic collection for materials
+
+        Args:
+            materials (Store): Store of materials properties
+
+            filter (dict): dict filter for getting items to process
+                e. g. {"elasticity": None}
+            wf_function (method): method to generate a workflow
+                based on structure in document with missing property
+                can be custom method or atomate preset wf generator
+            lpad (LaunchPad): fireworks launchpad to use for adding workflows
+        """
+        self.materials = materials
+        self.wf_function = wf_function
+        self.filter = filter
+        self.lpad = lpad or LaunchPad.auto_load()
+
+        super().__init__(sources=[materials], targets=[], **kwargs)
+
+    def get_items(self):
+        """
+        Gets all items to create new workflows for
+
+        Returns:
+
+        """
+        noprop_mats = self.materials.query(["structure", "material_id"],
+                                           self.filter)
+        # find existing tags in workflows
+        current_wf_tags = self.lpad.workflows.distinct("metadata.tags")
+        for mat in noprop_mats:
+            yield mat, current_wf_tags
+
+    def process_item(self, item):
+        mat, current_wf_tags = item
+        if mat['material_id'] in current_wf_tags:
+            return None
+        else:
+            structure = Structure.from_dict(mat["structure"])
+            wf = self.wf_function(structure)
+            wf = add_tags(wf, [mat['material_id']])
+            return wf
+
+    def update_targets(self, items):
+        """
+        Filters items and updates the launchpad
+
+        Args:
+            items ([Workflow]): list of workflows to be added
+        """
+        items = filter(bool, items)
+        self.lpad.bulk_add_wfs(items)
+
+# TODO: build priorities?
+def PriorityBuilder(Builder):
+    def __init__(self, lpad, propjockey, **kwargs):
+        self.lpad = lpad
+        self.propjockey = propjockey
+        pass
+
+
+# TODO: maybe this should be somewhere else?
+def generate_elastic_workflow(structure, tags=[]):
+    """
+    Generates a standard production workflow.
+
+    Notes:
+        Uses a primitive structure transformed into
+        the conventional basis (for equivalent deformations).
+
+        Adds the "minimal" category to the minimal portion
+        of the workflow necessary to generate the elastic tensor,
+        and the "minimal_full_stencil" category to the portion that
+        includes all of the strain stencil, but is symmetrically complete
+    """
+    # transform the structure
+    ieee_rot = Tensor.get_ieee_rotation(structure)
+    assert SquareTensor(ieee_rot).is_rotation(tol=0.005)
+    symm_op = SymmOp.from_rotation_and_translation(ieee_rot)
+    ieee_structure = structure.copy()
+    ieee_structure.apply_operation(symm_op)
+
+    # construct workflow
+    wf = wf_elastic_constant(ieee_structure)
+
+    # Set categories, starting with optimization
+    opt_fws = get_fws_and_tasks(wf, fw_name_constraint="optimization")
+    wf.fws[opt_fws[0][0]].spec['elastic_category'] = "minimal"
+
+    # find minimal set of fireworks using symmetry reduction
+    fws_by_strain = {Strain(fw.tasks[-1]['pass_dict']['strain']): n
+                     for n, fw in enumerate(wf.fws) if 'deformation' in fw.name}
+    unique_tensors = symmetry_reduce(fws_by_strain.keys(), ieee_structure)
+    for unique_tensor in unique_tensors:
+        fw_index = get_tkd_value(fws_by_strain, unique_tensor)
+        if np.isclose(unique_tensor, 0.005).any():
+            wf.fws[fw_index].spec['elastic_category'] = "minimal"
+        else:
+            wf.fws[fw_index].spec['elastic_category'] = "minimal_full_stencil"
+
+    # Add tags
+    if tags:
+        wf = add_tags(wf, tags)
+
+    wf = add_modify_incar(wf)
+    priority = 500 - structure.num_sites
+    wf = add_priority(wf, priority)
+    for fw in wf.fws:
+        if fw.spec['elastic_category'] == 'minimal':
+            fw.spec['_priority'] += 2000
+        elif fw.spec['elastic_category'] == 'minimal_full_stencil':
+            fw.spec['_priority'] += 1000
+    return wf
+
+
+def get_elastic_builder(materials, lpad=None, filter=None):
+    """
+    Args:
+        materials (Store): materials store
+        lpad (LaunchPad): LaunchPad to add workflows
+
+    Returns:
+        PropertyWorkflowBuilder for elastic workflow
+    """
+    if filter is None:
+        filter = {"elasticity": None}
+    return PropertyWorkflowBuilder(materials, filter,
+                                   generate_elastic_workflow, lpad)
+

--- a/emmet/materials/property_workflows.py
+++ b/emmet/materials/property_workflows.py
@@ -91,7 +91,7 @@ class PropertyWorkflowBuilder(Builder):
         wf_inputs = self.materials.query(["structure", "task_id"],
                                          self.material_filter)
         # find existing tags in workflows
-        current_prop_ids = self.source.distinct("material_id")
+        current_prop_ids = self.source.distinct("task_id")
         current_wf_tags = self.lpad.workflows.distinct("metadata.tags")
         ids_to_filter = list(set(current_prop_ids + current_wf_tags))
         for wf_input in wf_inputs:
@@ -103,7 +103,7 @@ class PropertyWorkflowBuilder(Builder):
         Processes items into workflows
 
         Args:
-            item ((dict, list)): pair of doc and material_ids to filter
+            item ((dict, list)): pair of doc and task_ids to filter
 
         Returns:
             Workflow

--- a/emmet/materials/property_workflows.py
+++ b/emmet/materials/property_workflows.py
@@ -43,7 +43,7 @@ class PropertyWorkflowBuilder(Builder):
         Args:
             source (Store): store of properties
             materials (Store): Store of materials properties
-            filter (dict): dict filter for getting items to process
+            material_filter (dict): dict filter for getting items to process
                 e. g. {"elasticity": None}
             wf_function (string or method): method to generate a workflow
                 based on structure in document with missing property
@@ -151,7 +151,8 @@ def generate_elastic_workflow(structure, tags=None):
         tags = []
     # transform the structure
     ieee_rot = Tensor.get_ieee_rotation(structure)
-    assert SquareTensor(ieee_rot).is_rotation(tol=0.005)
+    if not SquareTensor(ieee_rot).is_rotation(tol=0.005):
+        raise ValueError("Rotation matrix does not satisfy rotation conditions")
     symm_op = SymmOp.from_rotation_and_translation(ieee_rot)
     ieee_structure = structure.copy()
     ieee_structure.apply_operation(symm_op)
@@ -189,10 +190,11 @@ def generate_elastic_workflow(structure, tags=None):
     return wf
 
 
-def get_elastic_wf_builder(elasticity, materials, lpad=None, filter=None):
+def get_elastic_wf_builder(elasticity, materials, lpad=None, material_filter=None):
     """
     Args:
-        materials (Store): materials store
+        elasticity (Store): Elasticity store
+        materials (Store): Materials store
         lpad (LaunchPad): LaunchPad to add workflows
 
     Returns:
@@ -200,4 +202,4 @@ def get_elastic_wf_builder(elasticity, materials, lpad=None, filter=None):
     """
     wf_method = "emmet.materials.property_workflows.generate_elastic_workflow"
     return PropertyWorkflowBuilder(elasticity, materials, wf_method,
-                                   filter, lpad)
+                                   material_filter, lpad)

--- a/emmet/materials/property_workflows.py
+++ b/emmet/materials/property_workflows.py
@@ -31,8 +31,6 @@ __email__ = "montoyjh@lbl.gov"
 #       collections generally
 # TODO: I'm a bit wary to implement an incremental strategy here,
 #       but I think it can be done
-# TODO: This isn't completely serializable because of the workflow function,
-#       could use a string identifier like atomate does
 class PropertyWorkflowBuilder(Builder):
     def __init__(self, source, materials, wf_function,
                  material_filter=None, lpad=None, **kwargs):

--- a/emmet/materials/property_workflows.py
+++ b/emmet/materials/property_workflows.py
@@ -133,16 +133,8 @@ class PropertyWorkflowBuilder(Builder):
         return d
 
 
-# TODO: build priorities?
-def PriorityBuilder(Builder):
-    def __init__(self, lpad, propjockey, **kwargs):
-        self.lpad = lpad
-        self.propjockey = propjockey
-        pass
-
-
 # TODO: maybe this should be somewhere else, atomate?
-def generate_elastic_workflow(structure, tags=[]):
+def generate_elastic_workflow(structure, tags=None):
     """
     Generates a standard production workflow.
 
@@ -155,6 +147,8 @@ def generate_elastic_workflow(structure, tags=[]):
         and the "minimal_full_stencil" category to the portion that
         includes all of the strain stencil, but is symmetrically complete
     """
+    if tags == None:
+        tags = []
     # transform the structure
     ieee_rot = Tensor.get_ieee_rotation(structure)
     assert SquareTensor(ieee_rot).is_rotation(tol=0.005)
@@ -172,7 +166,7 @@ def generate_elastic_workflow(structure, tags=[]):
     # find minimal set of fireworks using symmetry reduction
     fws_by_strain = {Strain(fw.tasks[-1]['pass_dict']['strain']): n
                      for n, fw in enumerate(wf.fws) if 'deformation' in fw.name}
-    unique_tensors = symmetry_reduce(fws_by_strain.keys(), ieee_structure)
+    unique_tensors = symmetry_reduce(list(fws_by_strain.keys()), ieee_structure)
     for unique_tensor in unique_tensors:
         fw_index = get_tkd_value(fws_by_strain, unique_tensor)
         if np.isclose(unique_tensor, 0.005).any():

--- a/emmet/materials/tests/test_property_workflows.py
+++ b/emmet/materials/tests/test_property_workflows.py
@@ -53,6 +53,12 @@ class TestPropertyWorkflowBuilder(unittest.TestCase):
         new = PropertyWorkflowBuilder.from_dict(serialized)
         self.assertEqual(new._wf_function_string,
                          "emmet.materials.property_workflows.generate_elastic_workflow")
+        runner = Runner([builder])
+        from monty.serialization import dumpfn, loadfn
+        from monty.json import jsanitize
+        dumpfn(jsanitize(runner, strict=True), "elastic_wf_runner.yaml")
+        new = loadfn("elastic_wf_runner.yaml")
+        import nose; nose.tools.set_trace()
 
     def test_get_items(self):
         # No filter

--- a/emmet/materials/tests/test_property_workflows.py
+++ b/emmet/materials/tests/test_property_workflows.py
@@ -92,17 +92,6 @@ class TestPropertyWorkflowBuilder(unittest.TestCase):
         runner.run()
         self.assertEqual(self.lpad.workflows.count(), 3)
 
-    def test_mystuff(self):
-        from monty.serialization import dumpfn, loadfn
-        from maggma.stores import MongoStore
-
-        materials = MongoStore.from_db_file("materials.yaml")
-        elasticity = MongoStore.from_db_file("elasticity.yaml")
-        mpworks_tasks = MongoStore.from_db_file("mpworks_tasks.yaml")
-        lpad = LaunchPad.from_file("/Users/josephmontoya/fw_config/config_kpoints/my_launchpad.yaml")
-        ewf_builder = get_elastic_builder(elasticity, materials, lpad)
-        runner = Runner([ewf_builder])
-        dumpfn([ewf_builder], "elastic_wf_builder.yaml")
 
 if __name__ == "__main__":
     unittest.main()

--- a/emmet/materials/tests/test_property_workflows.py
+++ b/emmet/materials/tests/test_property_workflows.py
@@ -1,0 +1,72 @@
+import os
+import unittest
+from maggma.stores import MemoryStore
+from maggma.runner import Runner
+from emmet.materials.property_workflows import PropertyWorkflowBuilder,\
+    get_elastic_builder
+from pymatgen.util.testing import PymatgenTest
+from atomate.vasp.workflows.presets.core import wf_elastic_constant
+from atomate.vasp.powerups import add_tags
+from fireworks import LaunchPad, Workflow
+
+__author__ = "Joseph Montoya"
+__email__ = "montoyjh@lbl.gov"
+
+module_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)))
+
+class TestPropertyWorkflowBuilder(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        materials = MemoryStore("materials")
+        materials.connect()
+        docs = []
+        for n, mat_string in enumerate(["Si", "Sn", "TiO2", "VO2"]):
+            docs.append({"material_id": "mp-{}".format(n),
+                         "structure": PymatgenTest.get_structure(mat_string).as_dict()})
+        docs[0].update({"elasticity": 10})
+        materials.update(docs, key='material_id')
+        cls.materials = materials
+
+    def setUp(self):
+        lpad = LaunchPad(name="test_emmet")
+        lpad.reset('', require_password=False)
+        self.lpad = lpad
+
+        self.nofilter = PropertyWorkflowBuilder(self.materials, wf_elastic_constant,
+                                                filter=None, lpad=self.lpad)
+        self.nofilter.connect()
+        self.filter = PropertyWorkflowBuilder(self.materials, wf_elastic_constant,
+                                              filter={"elasticity": {"$exists": False}},
+                                              lpad=self.lpad)
+        self.filter.connect()
+
+    def test_get_items(self):
+        # No filter
+        self.assertEqual(len(list(self.nofilter.get_items())), 4)
+
+        # elasticity filter
+        self.assertEqual(len(list(self.filter.get_items())), 3)
+
+    def test_process_items(self):
+        for item in self.nofilter.get_items():
+            processed = self.nofilter.process_item(item)
+            self.assertTrue(isinstance(processed, Workflow))
+            self.assertTrue(item[0]['material_id'] in processed.metadata['tags'])
+
+    def test_update_targets(self):
+        processed = [self.nofilter.process_item(item)
+                     for item in self.nofilter.get_items()]
+        self.nofilter.update_targets(processed)
+        self.assertEqual(self.lpad.workflows.count(), 4)
+
+    def test_runner_pipeline(self):
+        runner = Runner([self.nofilter])
+        runner.run()
+        self.assertEqual(self.lpad.workflows.count(), 4)
+
+        # Ensure no further updates
+        runner.run()
+        self.assertEqual(self.lpad.workflows.count(), 4)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/emmet/materials/tests/test_property_workflows.py
+++ b/emmet/materials/tests/test_property_workflows.py
@@ -6,7 +6,6 @@ from emmet.materials.property_workflows import PropertyWorkflowBuilder,\
     get_elastic_builder
 from pymatgen.util.testing import PymatgenTest
 from atomate.vasp.workflows.presets.core import wf_elastic_constant
-from atomate.vasp.powerups import add_tags
 from fireworks import LaunchPad, Workflow
 
 __author__ = "Joseph Montoya"

--- a/emmet/materials/tests/test_property_workflows.py
+++ b/emmet/materials/tests/test_property_workflows.py
@@ -93,6 +93,11 @@ class TestPropertyWorkflowBuilder(unittest.TestCase):
         runner.run()
         self.assertEqual(self.lpad.workflows.count(), 3)
 
+    def test_elastic_wf_builder(self):
+        el_wf_builder = get_elastic_wf_builder(self.elasticity, self.materials,
+                                               self.lpad)
+        self.assertEqual(len(list(el_wf_builder.get_items())), 4)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/emmet/materials/tests/test_property_workflows.py
+++ b/emmet/materials/tests/test_property_workflows.py
@@ -1,6 +1,5 @@
 import os
 import unittest
-import monty
 
 from maggma.stores import MemoryStore
 from maggma.runner import Runner
@@ -10,6 +9,10 @@ from emmet.materials.property_workflows import PropertyWorkflowBuilder,\
 from pymatgen.util.testing import PymatgenTest
 from atomate.vasp.workflows.presets.core import wf_elastic_constant
 from fireworks import LaunchPad, Workflow
+from monty.tempfile import ScratchDir
+from monty.serialization import dumpfn, loadfn
+from monty.os import cd
+
 
 __author__ = "Joseph Montoya"
 __email__ = "montoyjh@lbl.gov"
@@ -56,10 +59,10 @@ class TestPropertyWorkflowBuilder(unittest.TestCase):
         new = PropertyWorkflowBuilder.from_dict(serialized)
         self.assertEqual(new._wf_function_string,
                          "emmet.materials.property_workflows.generate_elastic_workflow")
-        with monty.tempfile.ScratchDir('.') as sdir:
-            with monty.os.cd(sdir):
-                monty.serialization.dumpfn(builder, "builder.yaml")
-                new = monty.serialization.loadfn("builder.yaml")
+        with ScratchDir('.') as sdir:
+            with cd(sdir):
+                dumpfn(builder, "builder.yaml")
+                new = loadfn("builder.yaml")
         self.assertTrue(isinstance(new, Builder))
 
     def test_get_items(self):

--- a/emmet/vasp/mpworks.py
+++ b/emmet/vasp/mpworks.py
@@ -65,7 +65,7 @@ class MPWorksCompatibilityBuilder(Builder):
             to process into materials documents
         """
 
-        self.logger.info("MPWorks Elastic Compatibility Builder Started")
+        logger.info("MPWorks Elastic Compatibility Builder Started")
 
         # Get only successful tasks
         q = dict(self.query)
@@ -73,7 +73,7 @@ class MPWorksCompatibilityBuilder(Builder):
 
         # only consider tasks that have been updated since tasks was last updated
         if self.incremental:
-            self.logger.info("Ensuring indices on lu_field")
+            logger.info("Ensuring indices on lu_field")
             self.mpworks_tasks.ensure_index(self.mpworks_tasks.lu_field)
             self.atomate_tasks.ensure_index(self.atomate_tasks.lu_field)
             q.update(self.mpworks_tasks.lu_filter(self.atomate_tasks))
@@ -81,7 +81,7 @@ class MPWorksCompatibilityBuilder(Builder):
         # No cursor timeout should probably be fixed with smaller batch sizes
         tasks_to_convert = self.mpworks_tasks.query(criteria=q, no_cursor_timeout=True)
         count = tasks_to_convert.count()
-        self.logger.info("Found {} new/updated tasks to process".format(count))
+        logger.info("Found {} new/updated tasks to process".format(count))
 
         # Redo all task ids at the beginning
         if self.redo_task_ids:
@@ -97,7 +97,7 @@ class MPWorksCompatibilityBuilder(Builder):
 
         for n, task in enumerate(tasks_to_convert):
             new_task_id = n + starting_taskid
-            self.logger.debug("Processing item: {}->{}, {} of {}".format(
+            logger.debug("Processing item: {}->{}, {} of {}".format(
                 task['task_id'], new_task_id, n, count))
             yield task, new_task_id
 
@@ -128,7 +128,7 @@ class MPWorksCompatibilityBuilder(Builder):
             items ([([dict],[int])]): A list of tuples of materials to
                 update and the corresponding processed task_ids
         """
-        self.logger.info("Updating {} atomate documents".format(len(items)))
+        logger.info("Updating {} atomate documents".format(len(items)))
 
         self.atomate_tasks.update(items, key='task_id')
 

--- a/emmet/vasp/tests/test_elastic.py
+++ b/emmet/vasp/tests/test_elastic.py
@@ -27,15 +27,16 @@ class ElasticBuilderTest(unittest.TestCase):
         # Generate test materials collection
         cls.test_materials = MongoStore("test_emmet", "materials")
         cls.test_materials.connect()
+        cls.test_materials.collection.drop()
         opt_docs = cls.test_tasks.query(["output.structure", "formula_pretty"], {
             "task_label": "structure optimization"
         })
         mat_docs = [{
-            "material_id": "mp-{}".format(n),
+            "task_id": "mp-{}".format(n),
             "structure": opt_doc['output']['structure'],
             "pretty_formula": opt_doc['formula_pretty']
         } for n, opt_doc in enumerate(opt_docs)]
-        cls.test_materials.update(mat_docs, key='material_id', update_lu=False)
+        cls.test_materials.update(mat_docs, update_lu=False)
 
     def test_builder(self):
         ec_builder = ElasticBuilder(self.test_tasks, self.test_elasticity, self.test_materials, incremental=False)
@@ -58,7 +59,7 @@ class ElasticBuilderTest(unittest.TestCase):
         self.assertEqual(len(grouped_by_opt), 1)
 
         materials_dict = generate_formula_dict(self.test_materials)
-        grouped_by_mpid = group_by_material_id(materials_dict['NaN3'], docs1)
+        grouped_by_mpid = group_by_task_id(materials_dict['NaN3'], docs1)
         self.assertEqual(len(grouped_by_mpid), 1)
 
         docs2 = self.test_tasks.query(criteria={"task_label": "elastic deformation"})


### PR DESCRIPTION
Adds a PropertyWorkflowBuilder class.  If you have a property collection with task_ids corresponding to a materials collection, this builder will generate workflows that will generate the remaining data.  Generated workflows are tagged with material task_ids such that they aren't duplicated and use bulk_insert_wfs for efficiency.  The main idea is to streamline the creation of production workflows for materials properties other than structure (e. g. bandstructure, elasticity, etc.).

* Takes around 24 hours for the full elastic workflow collection to be built.  It seems like the primary bottleneck here is in bulk workflow insertion, but I'm not sure if there's a way to make it more efficient.
* In order for the workflow to be completely serializable, workflow functions must be specified as a string, which uses atomate's load_class functionality to generate the associated method.  Similarly, the serialization of the LaunchPad is handled separately because it's not MSONable.

Also includes a bit of cleanup to both the mpworks compatibility builder and the elasticity builders to ensure "task_id" is used rather than "material_id".