### PR TITLE
Add tests for copybuilder. Was using old store attr `lu_key`.

### DIFF
--- a/emmet/common/copybuilder.py
+++ b/emmet/common/copybuilder.py
@@ -64,6 +64,5 @@ def confirm_field_index(store, fields):
         for field in fields:
             if spec[0][0] == field:
                 return
-    else:
-        raise Exception("Need index on one of '{}' for {}".format(
-            fields, store.collection))
+    raise Exception("Need index on one of '{}' for {}".format(
+        fields, store.collection))

--- a/emmet/common/copybuilder.py
+++ b/emmet/common/copybuilder.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 from maggma.builder import Builder
-from pydash import py_
 from tqdm import tqdm
 
 
@@ -24,7 +23,10 @@ class CopyBuilder(Builder):
         source, target = self.source, self.target
         lu_filter = source.lu_filter(target)
         self.logger.debug("lu_filter: {}".format(lu_filter))
-        self.confirm_lu_field_index()
+        confirm_field_index(source, source.lu_field)
+        if isinstance(self.key, str):
+            target.ensure_index(self.key)
+        confirm_field_index(target, self.key)
         cursor = source.query(criteria=lu_filter,
                               sort=[(source.lu_field, 1)])
         self.logger.info("Will copy {} items".format(cursor.count()))
@@ -37,28 +39,31 @@ class CopyBuilder(Builder):
         source, target = self.source, self.target
         for item in items:
             # Use source last-updated value, ensuring `datetime` type.
-            item[target.lu_field] = source.lu_key[0](item[source.lu_field])
+            item[target.lu_field] = source.lu_func[0](item[source.lu_field])
             if source.lu_field != target.lu_field:
                 del item[source.lu_field]
         target.update(items, update_lu=False, key=self.key)
 
-    def confirm_lu_field_index(self):
-        """Confirm index on `lu_field`.
 
-        One can't simply ensure an index exists via
-        `self.source.collection.create_index` because a Builder must assume
-        read-only access to source Stores. The MongoDB `read` built-in role
-        does not include the `createIndex` action.
+def confirm_field_index(store, fields):
+    """Confirm index on store for at least one of fields
 
-        Raises:
-            Exception: If there is no index on `lu_field`.
+    One can't simply ensure an index exists via
+    `store.collection.create_index` because a Builder must assume
+    read-only access to source Stores. The MongoDB `read` built-in role
+    does not include the `createIndex` action.
 
-        """
-        source = self.source
-        info = source.collection.index_information().values()
-        for spec in (index['key'] for index in info):
-            if spec[0][0] == source.lu_field:
-                break
-        else:
-            raise Exception("Need index on '{}' for {}".format(
-                source.lu_field, source.collection))
+    Raises:
+        Exception: If there is no index on any of fields.
+
+    """
+    if not isinstance(fields, list):
+        fields = [fields]
+    info = store.collection.index_information().values()
+    for spec in (index['key'] for index in info):
+        for field in fields:
+            if spec[0][0] == field:
+                return
+    else:
+        raise Exception("Need index on one of '{}' for {}".format(
+            fields, store.collection))

--- a/emmet/common/tests/test_copybuilder.py
+++ b/emmet/common/tests/test_copybuilder.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from itertools import cycle, islice
 from unittest import TestCase
 from uuid import uuid4
 

--- a/emmet/common/tests/test_copybuilder.py
+++ b/emmet/common/tests/test_copybuilder.py
@@ -1,0 +1,72 @@
+from datetime import datetime, timedelta
+from itertools import cycle, islice
+from unittest import TestCase
+from uuid import uuid4
+
+from maggma.stores import MongoStore
+from emmet.common.copybuilder import CopyBuilder
+
+
+class TestCopyBuilder(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.dbname = "test_" + uuid4().hex
+        s = MongoStore(cls.dbname, "test")
+        s.connect()
+        cls.client = s.collection.database.client
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.client.drop_database(cls.dbname)
+
+    def setUp(self):
+        tic = datetime.now()
+        toc = tic + timedelta(seconds=1)
+        keys = list(range(20))
+        self.old_docs = [{"lu": tic, "k": k, "v": "old"}
+                         for k in keys]
+        self.new_docs = [{"lu": toc, "k": k, "v": "new"}
+                         for k in keys[:10]]
+        kwargs = dict(key="k", lu_field="lu")
+        self.source = MongoStore(self.dbname, "source", **kwargs)
+        self.target = MongoStore(self.dbname, "target", **kwargs)
+        self.builder = CopyBuilder(self.source, self.target)
+        self.source.connect()
+        self.source.collection.create_index("lu")
+        self.target.connect()
+        self.target.collection.create_index("k")
+
+    def tearDown(self):
+        self.source.collection.drop()
+        self.target.collection.drop()
+
+    def test_get_items(self):
+        self.source.collection.insert_many(self.old_docs)
+        self.assertEqual(len(list(self.builder.get_items())),
+                         len(self.old_docs))
+        self.target.collection.insert_many(self.old_docs)
+        self.assertEqual(len(list(self.builder.get_items())), 0)
+        self.source.update(self.new_docs, update_lu=False)
+        self.assertEqual(len(list(self.builder.get_items())),
+                         len(self.new_docs))
+
+    def test_process_item(self):
+        self.source.collection.insert_many(self.old_docs)
+        items = list(self.builder.get_items())
+        self.assertCountEqual(items, map(self.builder.process_item, items))
+
+    def test_update_targets(self):
+        self.source.collection.insert_many(self.old_docs)
+        self.source.update(self.new_docs, update_lu=False)
+        self.target.collection.insert_many(self.old_docs)
+        items = list(map(self.builder.process_item, self.builder.get_items()))
+        self.builder.update_targets(items)
+        self.assertTrue(self.target.query_one(criteria={"k": 0})["v"], "new")
+        self.assertTrue(self.target.query_one(criteria={"k": 10})["v"], "old")
+
+    def test_confirm_lu_field_index(self):
+        self.source.collection.drop_index("lu_1")
+        with self.assertRaises(Exception) as cm:
+            self.builder.get_items()
+        self.assertTrue(cm.exception.args[0].startswith("Need index"))
+        self.source.collection.create_index("lu")


### PR DESCRIPTION
CopyBuilder depended on an old version of the maggma Store class. Adding tests so that breaking changes are noticed immediately.