### PR TITLE
Copybuilder bug - tqdm doesn't play nicely with next()

### DIFF
--- a/emmet/common/copybuilder.py
+++ b/emmet/common/copybuilder.py
@@ -27,7 +27,7 @@ class CopyBuilder(Builder):
         cursor = source.query(criteria=lu_filter,
                               sort=[(source.lu_field, 1)])
         self.logger.info("Will copy {} items".format(cursor.count()))
-        return tqdm(cursor, total=cursor.count())
+        return iter(tqdm(cursor, total=cursor.count()))
 
     def process_item(self, item):
         return item

--- a/emmet/common/tests/test_copybuilder.py
+++ b/emmet/common/tests/test_copybuilder.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from uuid import uuid4
 
 from maggma.stores import MongoStore
+from maggma.runner import Runner
 from emmet.common.copybuilder import CopyBuilder
 
 
@@ -69,3 +70,10 @@ class TestCopyBuilder(TestCase):
             self.builder.get_items()
         self.assertTrue(cm.exception.args[0].startswith("Need index"))
         self.source.collection.create_index("lu")
+
+    def test_runner(self):
+        self.source.update(self.old_docs)
+        runner = Runner([self.builder])
+        runner.run()
+        self.assertTrue(self.target.query_one(criteria={"k": 0})["v"], "new")
+        self.assertTrue(self.target.query_one(criteria={"k": 10})["v"], "old")

--- a/emmet/common/tests/test_copybuilder.py
+++ b/emmet/common/tests/test_copybuilder.py
@@ -34,6 +34,7 @@ class TestCopyBuilder(TestCase):
         self.source.connect()
         self.source.collection.create_index("lu")
         self.target.connect()
+        self.target.collection.create_index("lu")
         self.target.collection.create_index("k")
 
     def tearDown(self):


### PR DESCRIPTION
Somewhat weirdly, tqdm objects aren't iterators, so they throw a type error with next(), which gets called in the Multiprocessor in the runner.  I'm skeptical that what I've done here is the best way to solve the issue, but casting the tqdm object to an iterator in CopyBuilder.get_items() seems to fix the test.

Also, the unittest wasn't working for me initially because there wasn't an index on the "lu" field on the targets.  Added that and a test for runner compatibility.