### PR TITLE
Copybuilder additions

### DIFF
--- a/emmet/common/copybuilder.py
+++ b/emmet/common/copybuilder.py
@@ -10,20 +10,26 @@ class CopyBuilder(Builder):
     Can override `target.key` field to filter for target document to update.
     """
 
-    def __init__(self, source, target, key=None, **kwargs):
+    def __init__(self, source, target, key=None, query=None,
+                 incremental=True, **kwargs):
         self.source = source
         self.target = target
         self.key = key if key else target.key
+        self.incremental = incremental
+        self.query = query if query else {}
         super().__init__(sources=[source], targets=[target], **kwargs)
 
     def get_items(self):
         source, target = self.source, self.target
         lu_filter = source.lu_filter(target)
+        if self.incremental:
+            self.query.update(lu_filter)
+
         self.logger.debug("lu_filter: {}".format(lu_filter))
         confirm_field_index(source, source.lu_field)
         confirm_field_index(target, target.lu_field)
         confirm_field_index(target, self.key)
-        cursor = source.query(criteria=lu_filter,
+        cursor = source.query(criteria=self.query,
                               sort=[(source.lu_field, 1)])
         self.logger.info("Will copy {} items".format(cursor.count()))
 

--- a/emmet/common/tests/test_copybuilder.py
+++ b/emmet/common/tests/test_copybuilder.py
@@ -80,3 +80,13 @@ class TestCopyBuilder(TestCase):
         runner.run()
         self.assertEqual(self.target.query_one(criteria={"k": 0})["v"], "new")
         self.assertEqual(self.target.query_one(criteria={"k": 10})["v"], "old")
+
+    def test_query(self):
+        self.builder.query = {"k": {"$gt": 5}}
+        self.source.collection.insert_many(self.old_docs)
+        self.source.update(self.new_docs, update_lu=False)
+        runner = Runner([self.builder])
+        runner.run()
+        all_docs = list(self.target.query(criteria={}))
+        self.assertEqual(len(all_docs), 14)
+        self.assertTrue(min([d['k'] for d in all_docs]), 6)

--- a/emmet/vasp/tests/test_elastic.py
+++ b/emmet/vasp/tests/test_elastic.py
@@ -38,6 +38,12 @@ class ElasticBuilderTest(unittest.TestCase):
         } for n, opt_doc in enumerate(opt_docs)]
         cls.test_materials.update(mat_docs, update_lu=False)
 
+    @classmethod
+    def tearDownClass(cls):
+        cls.test_tasks.collection.drop()
+        cls.test_elasticity.collection.drop()
+        cls.test_materials.collection.drop()
+
     def test_builder(self):
         ec_builder = ElasticBuilder(self.test_tasks, self.test_elasticity, self.test_materials, incremental=False)
         ec_builder.connect()


### PR DESCRIPTION
Adds non-incremental and global filter functionality for the copybuilder (essentially enables user to copy only documents matching a certain filter criteria or to operate builder in non-incremental mode if a more "global" sync is desired).  Default operation is unchanged.

Also adds a test db cleanup to the tearDown method in the elastic builder that was missing previously.