### PR TITLE
Fix diffraction builder. Add test for fixed method.

### DIFF
--- a/emmet/materials/diffraction.py
+++ b/emmet/materials/diffraction.py
@@ -94,7 +94,7 @@ class DiffractionBuilder(Builder):
             xrdcalc = XRDCalculator(wavelength="".join([xs['target'], xs['edge']]),
                                     symprec=xs.get('symprec', 0))
 
-            pattern = jsanitize(xrdcalc.get_xrd_pattern(
+            pattern = jsanitize(xrdcalc.get_pattern(
                 structure, two_theta_range=xs['two_theta']).as_dict())
             d = {'wavelength': {'element': xs['target'],
                                 'in_angstroms': WAVELENGTHS["".join([xs['target'], xs['edge']])]},

--- a/emmet/materials/tests/test_diffraction.py
+++ b/emmet/materials/tests/test_diffraction.py
@@ -1,0 +1,39 @@
+from maggma.stores import MongoStore
+from pymatgen.util.testing import PymatgenTest
+from unittest import TestCase
+from uuid import uuid4
+
+from emmet.materials.diffraction import DiffractionBuilder
+
+
+class TestDiffractionBuilder(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.dbname = "test_" + uuid4().hex
+        s = MongoStore(cls.dbname, "test")
+        s.connect()
+        cls.client = s.collection.database.client
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.client.drop_database(cls.dbname)
+
+    def setUp(self):
+        kwargs = dict(key="k", lu_field="lu")
+        self.source = MongoStore(self.dbname, "source", **kwargs)
+        self.target = MongoStore(self.dbname, "target", **kwargs)
+        self.source.connect()
+        self.source.collection.create_index("lu")
+        self.source.collection.create_index("k", unique=True)
+        self.target.connect()
+        self.target.collection.create_index("lu")
+        self.target.collection.create_index("k", unique=True)
+
+    def tearDown(self):
+        self.source.collection.drop()
+        self.target.collection.drop()
+
+    def test_get_xrd_from_struct(self):
+        builder = DiffractionBuilder(self.source, self.target)
+        structure = PymatgenTest.get_structure("Si")
+        self.assertIn("Cu", builder.get_xrd_from_struct(structure))


### PR DESCRIPTION
I guess `XRDCalculator.get_xrd_pattern` was changed to `XRDCalculator.get_pattern` in pymatgen. Roughly ~200 materials in dev db (matgen2/mp_prod) don't have xrd patterns built, hopefully due to this error only. @shyamd please confirm this PR fixes the builder, adding commits + tests if necessary before merge. I don't know if other things in `XRDCalculator` changed as well.