### PR TITLE
Added composition descritpors for similarity toolbox

### DIFF
--- a/emmet/materials/basic_descriptors.py
+++ b/emmet/materials/basic_descriptors.py
@@ -31,7 +31,7 @@ class BasicDescriptorsBuilder(Builder):
         useful as a definition of a structure fingerprint
         on the basis of local coordination information.
         Furthermore, composition descriptors are calculated
-        (Magpie element property vector). 
+        (Magpie element property vector).
 
         Args:
             materials (Store): Store of materials documents.

--- a/emmet/materials/site_descriptors.py
+++ b/emmet/materials/site_descriptors.py
@@ -4,6 +4,7 @@ from pymatgen.core.structure import Structure
 import pymatgen.analysis
 from pymatgen.analysis.local_env import *
 from matminer.featurizers.site import CrystalNNFingerprint, CoordinationNumber
+from matminer.featurizers.composition import ElementProperty
 
 # TODO:
 # 1) Add checking OPs present in current implementation of site fingerprints.
@@ -21,7 +22,7 @@ nn_target_classes = ["MinimumDistanceNN", "VoronoiNN", \
 
 class SiteDescriptorsBuilder(Builder):
 
-    def __init__(self, materials, site_descriptors, mat_query=None, **kwargs):
+    def __init__(self, materials, comp_descriptors, site_descriptors, mat_query=None, **kwargs):
         """
         Calculates site-based descriptors (e.g., coordination numbers
         with different near-neighbor finding approaches) for materials and
@@ -32,6 +33,8 @@ class SiteDescriptorsBuilder(Builder):
 
         Args:
             materials (Store): Store of materials documents.
+            comp_descriptors (store): Store of composition-descriptors data
+                                      such as Magpie element property.
             site_descriptors (Store): Store of site-descriptors data such
                                       as tetrahedral order parameter or
                                       fraction of being 8-fold coordinated.
@@ -40,6 +43,7 @@ class SiteDescriptorsBuilder(Builder):
 
         self.materials = materials
         self.site_descriptors = site_descriptors
+        self.comp_descriptors = comp_descriptors
         self.mat_query = mat_query if mat_query else {}
 
         # Set up all targeted site descriptors.
@@ -55,6 +59,10 @@ class SiteDescriptorsBuilder(Builder):
                                                            distance_cutoffs=None,
                                                            x_diff_weight=None)
         self.all_output_pieces['statistics'] = ['csf']
+
+        # Set up all targeted composition descriptors.
+        self.cds = {}
+        self.cds["magpie"] = ElementProperty.from_preset('magpie')
 
         super().__init__(sources=[materials],
                          targets=[site_descriptors],

--- a/emmet/materials/tests/test_basic_descriptors.py
+++ b/emmet/materials/tests/test_basic_descriptors.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 
-from emmet.materials.site_descriptors import *
+from emmet.materials.basic_descriptors import *
 from maggma.stores import MemoryStore
 
 from monty.serialization import loadfn
@@ -13,19 +13,19 @@ module_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)))
 test_structs = os.path.join(module_dir, "..", "..", "..", "test_files", "simple_structs.json")
 
 
-class SiteDescriptorsBuilderTest(unittest.TestCase):
+class BasicDescriptorsBuilderTest(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         # Set up test db, etc.
-        self.test_materials = MemoryStore("mat_site_fingerprint")
+        self.test_materials = MemoryStore("mat_descriptors")
 
         self.test_materials.connect()
         struct_docs = loadfn(test_structs, cls=None)
         self.test_materials.update(struct_docs)
 
     def test_builder(self):
-        test_site_descriptors = MemoryStore("test_site_descriptors")
-        sd_builder = SiteDescriptorsBuilder(self.test_materials, test_site_descriptors)
+        test_basic_descriptors = MemoryStore("test_basic_descriptors")
+        sd_builder = BasicDescriptorsBuilder(self.test_materials, test_basic_descriptors)
         sd_builder.connect()
         for t in sd_builder.get_items():
             processed = sd_builder.process_item(t)
@@ -37,14 +37,14 @@ class SiteDescriptorsBuilderTest(unittest.TestCase):
         self.assertEqual(len([t for t in sd_builder.get_items()]), 0)
 
         # Remove one data piece in diamond entry and test partial update.
-        test_site_descriptors.collection.find_one_and_update(
+        test_basic_descriptors.collection.find_one_and_update(
                 {'task_id': 'mp-66'}, {'$unset': {'site_descriptors': 1}})
         items = [e for e in list(sd_builder.get_items())]
         self.assertEqual(len(items), 1)
 
-    def test_get_all_site_descriptors(self):
-        test_site_descriptors = MemoryStore("test_site_descriptors")
-        sd_builder = SiteDescriptorsBuilder(self.test_materials, test_site_descriptors)
+    def test_get_all_basic_descriptors(self):
+        test_basic_descriptors = MemoryStore("test_basic_descriptors")
+        sd_builder = BasicDescriptorsBuilder(self.test_materials, test_basic_descriptors)
 
         C = self.test_materials.query_one(criteria={"task_id": "mp-66"})
         NaCl = self.test_materials.query_one(criteria={"task_id": "mp-22862"})


### PR DESCRIPTION
Since the site-descriptor builder actually was always also a structure descriptor builder because of the structure fingerprint that was computed and because I added computation of composition descriptors that are required for the MP website's anticipated similarity toolbox, I renamed the builder to "basic_descriptors.py".  Since it is part of the materials module in emmet, it's effectively a basic materials descriptor builder.  I hope that this makes sense to the maintainers, but I'm also happy to discuss any other suggestion.

So, most of this PR is mainly renaming things, and including the 4 or 5 lines for the composition descriptor calculation.