### PR TITLE
mp website update for propnet and toecs

### DIFF
--- a/emmet/common/tests/test_utils.py
+++ b/emmet/common/tests/test_utils.py
@@ -1,0 +1,22 @@
+from unittest import TestCase
+from copy import copy
+from emmet.common.utils import scrub_class_and_module
+
+
+class TestUtils(TestCase):
+    def test_scrub_class_and_module(self):
+        doc = {"@class": 1, "@module": 1, "this": 5}
+        new = scrub_class_and_module(doc)
+        self.assertEqual(new, {"this": 5})
+
+        list_of_docs = [copy(doc) for n in range(5)]
+        new = scrub_class_and_module(list_of_docs)
+        for new_doc in new:
+            self.assertEqual(new_doc, {"this": 5})
+
+        nested_dict = {"this": {"that": {"@class": 1, "@module": 2, "those": 3}},
+                       "these": list_of_docs}
+        new = scrub_class_and_module(nested_dict)
+        self.assertEqual(new['this'], {"that": {"those": 3}})
+        for new_doc in new['these']:
+            self.assertEqual(new_doc, {"this": 5})

--- a/emmet/common/utils.py
+++ b/emmet/common/utils.py
@@ -11,3 +11,24 @@ def load_settings(settings, default_settings):
         return settings
     else:
         raise Exception("No settings provided")
+
+
+def scrub_class_and_module(doc):
+    """
+    This utility method scrubs a document of it's class and
+    module entries.  Note that this works on the doc **in place**.
+
+    Args:
+        doc (dict): a nested dictionary to be scrubbed
+
+    Returns:
+        A nested dictionary with the module and class attributes
+        removed from all subdocuments
+    """
+    if isinstance(doc, dict):
+        return {k: scrub_class_and_module(v) for k, v in doc.items()
+                if not k in ['@class', '@module']}
+    elif isinstance(doc, list):
+        return [scrub_class_and_module(k) for k in doc]
+    else:
+        return doc

--- a/emmet/materials/mp_website.py
+++ b/emmet/materials/mp_website.py
@@ -6,20 +6,18 @@ import copy
 import nltk
 import numpy as np
 from ast import literal_eval
-from pymongo import ASCENDING, DESCENDING
 
-from monty.serialization import loadfn
 from monty.json import jsanitize
 
 from maggma.builder import Builder
 from pydash.objects import get, set_, has
 
 from emmet.materials.snls import mp_default_snl_fields
+from emmet.common.utils import scrub_class_and_module
 
 # Import for crazy things this builder needs
 from pymatgen.io.cif import CifWriter
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
-from pymatgen.core.composition import Composition
 from pymatgen import Structure
 from pymatgen.analysis.structure_analyzer import oxide_type
 from pymatgen.analysis.structure_analyzer import RelaxationAnalyzer
@@ -449,8 +447,8 @@ def add_propnet(mat, propnet):
                     'pretty_formula', 'input_quantities', 'last_updated']
     for e in exclude_list:
         if e in propnet:
-            propnet.pop(e)
-    mat["propnet"] = propnet
+            del propnet[e]
+    mat["propnet"] = scrub_class_and_module(propnet)
 
 
 def check_relaxation(mat, new_style_mat):


### PR DESCRIPTION
A few minor tweaks to the website builder to allow for propnet and TOEC building.

* Adds a propnet kwarg and some functionality to include data from a propnet collection in a web materials build
* Adds some functionality to recursively scrub the MSONable @class and @module from a document if desired.  I'm doing this for now because I don't want the pymatgen interface to the API to deserialize these automatically (I imagine most users won't have propnet installed).
* Adds an additional alias in the add_elastic function to get the TOEC values.