### PR TITLE
fix: snl history is a list

### DIFF
--- a/emmet/materials/snls.py
+++ b/emmet/materials/snls.py
@@ -32,11 +32,11 @@ mp_default_snl_fields = {
         "name": "Materials Project",
         "email": "feedback@materialsproject.org"
     }],
-    "history": {
+    "history": [{
         "name": "Materials Project Optimized Structure",
         "url": "http://www.materialsproject.org",
         "description": {}
-    }
+    }]
 }
 
 DB_indexes = {"ICSD": "icsd_ids", "Pauling": "pf_ids"}


### PR DESCRIPTION
Document currently fail to deserialize because history is expected to be a list of dicts. Also, this bug causes the "# Aggregate all the database IDs" section of this builder may never aggregate IDs because `len(snl["about"]["history"])` will be `3` by default (three keys in the dict).