### PR TITLE
Fix a bug in bond_valence

### DIFF
--- a/emmet/materials/bond_valence.py
+++ b/emmet/materials/bond_valence.py
@@ -50,7 +50,7 @@ class BondValenceBuilder(MapBuilder):
             }
 
             d["successful"] = True
-            s = s.add_oxidation_state_by_site(valences)
+            s.add_oxidation_state_by_site(valences)
 
             d["bond_valence"] = {
                 "possible_species": list(possible_species),
@@ -73,7 +73,7 @@ class BondValenceBuilder(MapBuilder):
                 }
 
                 d["successful"] = True
-                s = s.add_oxidation_state_by_site(valences)
+                s.add_oxidation_state_by_site(valences)
 
                 d["bond_valence"] = {
                     "possible_species": list(possible_species),


### PR DESCRIPTION
`pymatgen.core.structure.add_oxidation_state_by_site` does not return decorated structure but updates itself.
This patch solves an error happened in `test_bond_valence.py`