### PR TITLE
Add CalcDB based on Maggma Stores

### DIFF
--- a/emmet-cli/emmet/cli/calcdb.py
+++ b/emmet-cli/emmet/cli/calcdb.py
@@ -3,7 +3,7 @@
 This modules defines a base class of a calculation database
 """
 
-import regex
+import re
 import logging
 
 from datetime import datetime
@@ -20,12 +20,45 @@ from emmet.core.utils import jsanitize
 logger = logging.getLogger("emmet")
 
 
+class KeyTransformer(MSONable, metaclass=ABCMeta):
+    @abstractmethod
+    def get_max(self, keys: List):
+        pass
+
+    @abstractmethod
+    def to_key(self, id):
+        pass
+
+
+class MPKeyTransformer(KeyTransformer):
+
+    _to_id = re.compile(r"mp-(\d*)")
+    _to_key = "mp-{}"
+
+    def get_max(self, keys: List):
+        ids = []
+
+        for key in keys:
+            try:
+                _id = int(self._to_id.search(key).group(1))
+            except IndexError:
+                _id = 0
+            finally:
+                ids.append(_id)
+
+        ids = ids if len(ids) > 0 else [0]
+        return max(ids)
+
+    def to_key(self, id: List):
+        return self._to_key.format(id)
+
+
 class CalcDB(MSONable, metaclass=ABCMeta):
     def __init__(
         self,
         documents: MongoStore,
         data: Store,
-        key_regex: Tuple[str, str] = ("mp-{id}", r"mp-(\d*)|0$"),
+        key_regex: KeyTransformer = MPKeyTransformer(),
         doc_keys: Dict[str, str] = {
             "bandstructure": "calcs_reversed.0.bandstructure",
             "dos": "calcs_reversed.0.dos",
@@ -40,7 +73,7 @@ class CalcDB(MSONable, metaclass=ABCMeta):
 
         self.documents = documents
         self.data = data
-        self.key_regex = key_regex
+        self.key_regex = key_regex  # TODO: Make this a transformer class
         self.doc_keys = doc_keys
         self.removed_keys = removed_keys
 
@@ -64,7 +97,7 @@ class CalcDB(MSONable, metaclass=ABCMeta):
         self.documents.ensure_index("last_updated")
         self.documents.ensure_index("type")
 
-    def insert(self, tasks: Union[Dict, List[Dict]], update_duplicates=True):
+    def insert(self, tasks: Union[Dict, List[Dict]], update_duplicates=False):
         """
         Insert the task documents to the documents store
         Args:
@@ -86,48 +119,51 @@ class CalcDB(MSONable, metaclass=ABCMeta):
             )
         }
 
-        to_update = []
+        # Group by new items vs replacements
+        to_update = []  # needs task_ids assigned
+        to_replace = []  # can just be inserted into the DB
         for doc in tasks:
             doc["last_updated"] = datetime.utcnow()
-            if doc["dir_name"] not in result and "task_id" not in doc:
+            if "task_id" in doc:  # Forcing a task_id
+                to_replace.append(jsanitize(doc, allow_bson=True))
+            elif doc["dir_name"] not in result:
                 to_update.append(jsanitize(doc, allow_bson=True))
             elif update_duplicates:
-                doc["task_id"] = result["task_id"]
+                doc["task_id"] = result[doc["dir_name"]]
                 logger.info(
-                    "Updating {} with taskid = {}".format(d["dir_name"], d["task_id"])
+                    "Updating {} with taskid = {}".format(
+                        doc["dir_name"], doc["task_id"]
+                    )
                 )
-                to_update.append(jsanitize(doc, allow_bson=True))
+                to_replace.append(jsanitize(doc, allow_bson=True))
 
         all_task_ids = self.documents.distinct("task_id")
-        all_task_ids = {
-            self.key_regex[1].search(tid).group() for tid in all_task_ids
-        } - {
-            0,
-        }  # Remove task_id 0
+        max_tid = self.key_regex.get_max(all_task_ids)
 
-        sep_tid = max(all_task_ids) + len(to_update)
-        next_tid = max(all_task_ids) + 1
-        self.documents.update({"task_id": sep_tid}, key="task_id")
-        logger.debug(f"Inserted separator task with task_id {sep_tid}.")
+        seperator_tid = max_tid + len(to_update)
+        next_tid = max_tid + 1
+        self.documents.update(
+            {"task_id": self.key_regex.to_key(seperator_tid)}, key="task_id"
+        )
+        logger.debug(f"Inserted separator task with task_id {seperator_tid}.")
 
         all_task_ids = self.documents.distinct("task_id")
-        all_task_ids = {
-            self.key_regex[1].search(tid).group() for tid in all_task_ids
-        } - {
-            0,
-        }  # Remove task_id 0
+        max_tid = self.key_regex.get_max(all_task_ids)
 
         assert (
-            max(all_task_ids) == sep_tid
+            max_tid == seperator_tid
         ), f"Failed reserving block of {len(to_update)} task_ids"
         for d in to_update:
-            if "task_id" not in d:
-                d["task_id"] = self.key_regex[0].format(next_tid)
+            if "task_id" not in d:  # Not forcing a task_id
+                d["task_id"] = self.key_regex.to_key(next_tid)
                 next_tid += 1
 
-        data = self.extract_data(to_update)
+        data = self.extract_data(to_update + to_replace)
         self.documents.update(to_update, key="task_id")
-        self.data.update(data, key=("task_id", "type"))
+        self.documents.update(to_replace, key="task_id")
+        self.data.update(data, key=["task_id", "type"])
+
+        return to_update + to_replace
 
     def extract_data(self, docs) -> List[Dict]:
         """
@@ -140,6 +176,9 @@ class CalcDB(MSONable, metaclass=ABCMeta):
             for doc_type, path in self.doc_keys.items():
                 if has(d, path):
                     new_blob = get(d, path)
+                    if not isinstance(new_blob, dict):
+                        new_blob = {"data": new_blob}
+
                     new_blob["type"] = doc_type
                     new_blob["task_id"] = d["task_id"]
                     new_blob["last_updated"] = d["last_updated"]

--- a/emmet-cli/emmet/cli/calcdb.py
+++ b/emmet-cli/emmet/cli/calcdb.py
@@ -1,0 +1,150 @@
+# coding: utf-8
+"""
+This modules defines a base class of a calculation database
+"""
+
+import regex
+import logging
+
+from datetime import datetime
+from typing import Dict, List, Union, Tuple
+from abc import ABCMeta, abstractmethod
+from pydash.objects import has, get, unset
+
+from monty.json import MSONable
+from monty.serialization import loadfn
+from maggma.stores import Store, MongoStore
+
+from emmet.core.utils import jsanitize
+
+logger = logging.getLogger("emmet")
+
+
+class CalcDB(MSONable, metaclass=ABCMeta):
+    def __init__(
+        self,
+        documents: MongoStore,
+        data: Store,
+        key_regex: Tuple[str, str] = ("mp-{id}", r"mp-(\d*)|0$"),
+        doc_keys: Dict[str, str] = {
+            "bandstructure": "calcs_reversed.0.bandstructure",
+            "dos": "calcs_reversed.0.dos",
+        },
+        removed_keys: List[str] = [
+            "calcs_reversed.1.bandstructure",
+            "calcs_reversed.2.bandstructure",
+            "calcs_reversed.1.dos",
+            "calcs_reversed.2.dos",
+        ],
+    ):
+
+        self.documents = documents
+        self.data = data
+        self.key_regex = key_regex
+        self.doc_keys = doc_keys
+        self.removed_keys = removed_keys
+
+        self._key_name = self.documents.key
+
+    def build_indexes(self, indexes=None, background=True):
+        """
+         Build the indexes.
+         Args:
+             indexes (list): list of single field indexes to be built.
+             background (bool): Run in the background or not.
+         """
+        self.documents.connect()
+        self.data.connect()
+
+        self.documents.ensure_index("task_id")
+        self.documents.ensure_index("last_updated")
+        self.documents.ensure_index("dir_name")
+
+        self.documents.ensure_index("task_id")
+        self.documents.ensure_index("last_updated")
+        self.documents.ensure_index("type")
+
+    def insert(self, tasks: Union[Dict, List[Dict]], update_duplicates=True):
+        """
+        Insert the task documents to the documents store
+        Args:
+            d (dict): task document
+            update_duplicates (bool): whether to update the duplicates
+        """
+
+        self.documents.connect()
+        self.data.connect()
+        self.build_indexes()
+
+        tasks = [tasks] if isinstance(tasks, Dict) else tasks
+
+        result = {
+            d["dir_name"]: d[self._key_name]
+            for d in self.documents.query(
+                {"dir_name": {"$in": [d["dir_name"] for d in tasks]}},
+                ["dir_name", self._key_name],
+            )
+        }
+
+        to_update = []
+        for doc in tasks:
+            doc["last_updated"] = datetime.utcnow()
+            if doc["dir_name"] not in result and "task_id" not in doc:
+                to_update.append(jsanitize(doc, allow_bson=True))
+            elif update_duplicates:
+                doc["task_id"] = result["task_id"]
+                logger.info(
+                    "Updating {} with taskid = {}".format(d["dir_name"], d["task_id"])
+                )
+                to_update.append(jsanitize(doc, allow_bson=True))
+
+        all_task_ids = self.documents.distinct("task_id")
+        all_task_ids = {
+            self.key_regex[1].search(tid).group() for tid in all_task_ids
+        } - {
+            0,
+        }  # Remove task_id 0
+
+        sep_tid = max(all_task_ids) + len(to_update)
+        next_tid = max(all_task_ids) + 1
+        self.documents.update({"task_id": sep_tid}, key="task_id")
+        logger.debug(f"Inserted separator task with task_id {sep_tid}.")
+
+        all_task_ids = self.documents.distinct("task_id")
+        all_task_ids = {
+            self.key_regex[1].search(tid).group() for tid in all_task_ids
+        } - {
+            0,
+        }  # Remove task_id 0
+
+        assert (
+            max(all_task_ids) == sep_tid
+        ), f"Failed reserving block of {len(to_update)} task_ids"
+        for d in to_update:
+            if "task_id" not in d:
+                d["task_id"] = self.key_regex[0].format(next_tid)
+                next_tid += 1
+
+        data = self.extract_data(to_update)
+        self.documents.update(to_update, key="task_id")
+        self.data.update(data, key=("task_id", "type"))
+
+    def extract_data(self, docs) -> List[Dict]:
+        """
+        Extracts the data blobs in-place, removing them from the provided documents
+        """
+
+        data = []
+
+        for d in docs:
+            for doc_type, path in self.doc_keys.items():
+                if has(d, path):
+                    new_blob = get(d, path)
+                    new_blob["type"] = doc_type
+                    new_blob["task_id"] = d["task_id"]
+                    new_blob["last_updated"] = d["last_updated"]
+                    data.append(new_blob)
+                    unset(d, path)
+            for path in self.removed_keys:
+                unset(d, path)
+        return data

--- a/emmet-cli/requirements.txt
+++ b/emmet-cli/requirements.txt
@@ -14,3 +14,4 @@ slurmpy==0.0.8
 github3.py==1.3.0
 hpsspy==0.5.1
 multiprocessing-logging==0.3.1
+maggma==0.20.0

--- a/tests/emmet-cli/test_calcdb.py
+++ b/tests/emmet-cli/test_calcdb.py
@@ -1,0 +1,100 @@
+import pytest
+from datetime import datetime
+from maggma.stores import MemoryStore
+
+from emmet.cli.calcdb import CalcDB
+
+
+@pytest.fixture
+def db():
+    data = MemoryStore()
+    documents = MemoryStore()
+
+    return CalcDB(
+        data=data,
+        documents=documents,
+        doc_keys={"blob": "calcs_reversed.1.blob"},
+        removed_keys=["calcs_reversed.0.blob"],
+    )
+
+
+def test_extract_data(db):
+
+    dummy_data1 = {
+        "dir_name": "dir1",
+        "calcs_reversed": [
+            {"blob": "Data to remove", "name": "blob1"},
+            {"blob": "Data to extract", "name": "blob2"},
+        ],
+        "task_id": 1,
+        "last_updated": datetime.utcnow(),
+    }
+
+    processed = db.extract_data([dummy_data1])
+
+    assert ["blob" not in calc for calc in dummy_data1]
+    assert len(processed) == 1
+    assert processed[0]["type"] == "blob"
+    assert processed[0]["data"] == "Data to extract"
+    assert processed[0]["task_id"] == 1
+    assert "last_updated" in processed[0]
+
+
+def test_insert(db):
+
+    dummy_data1 = {
+        "dir_name": "dir1",
+        "calcs_reversed": [
+            {"blob": "Data to remove 1", "name": "blob1"},
+            {"blob": "Data to extract 1", "name": "blob2"},
+        ],
+    }
+
+    processed = db.insert([dummy_data1])
+    assert processed[0]["task_id"] == "mp-1"
+
+    dummy_data2 = {
+        "dir_name": "dir2",
+        "calcs_reversed": [
+            {"blob": "Data to remove 2", "name": "blob1"},
+            {"blob": "Data to extract 2", "name": "blob2"},
+        ],
+    }
+
+    processed = db.insert([dummy_data2])
+
+    assert processed[0]["task_id"] == "mp-2"
+
+
+def test_insert_duplicates(db):
+
+    dummy_data2 = {
+        "dir_name": "dir2",
+        "calcs_reversed": [
+            {"blob": "Data to remove 2", "name": "blob1"},
+            {"blob": "Data to extract 2", "name": "blob2"},
+        ],
+    }
+
+    processed = db.insert([dummy_data2])
+
+    assert processed[0]["task_id"] == "mp-1"
+
+    assert len(db.insert([dummy_data2])) == 0
+    assert len(db.insert([dummy_data2], update_duplicates=True)) == 1
+
+
+def test_insert_force_task_id(db):
+
+    dummy_data3 = {
+        "dir_name": "dir2",
+        "task_id": "mp-343",
+        "calcs_reversed": [
+            {"blob": "Data to remove 2", "name": "blob1"},
+            {"blob": "Data to extract 2", "name": "blob2"},
+        ],
+    }
+
+    processed = db.insert([dummy_data3])
+    assert len(processed) == 1
+    assert processed[0]["task_id"] == "mp-343"


### PR DESCRIPTION
This adds a preliminary implementation of the CalcDB that should handle most use case for `emmet-cli` using Maggma `Store`.