### PR TITLE
Sanitize Enums

### DIFF
--- a/emmet-core/emmet/core/utils.py
+++ b/emmet-core/emmet/core/utils.py
@@ -94,6 +94,8 @@ def jsanitize(obj, strict=False, allow_bson=False):
         return [
             jsanitize(i, strict=strict, allow_bson=allow_bson) for i in obj.tolist()
         ]
+    if isinstance(obj, Enum):
+        return obj.value
     if isinstance(obj, dict):
         return {
             k.__str__(): jsanitize(v, strict=strict, allow_bson=allow_bson)


### PR DESCRIPTION
This PR makes serialisation of pydantic models with Enums much easier. 

## Problem

Currently the situation is quite painful. For example, this code:

```python
from enum import Enum
from emmet.core.utils import jsanitize
from pydantic import BaseModel

class TestEnum(Enum):

    TEST = "test"

class Model(BaseModel):

    enum: TestEnum

m = Model(enum=TestEnum.TEST)
sanitized = jsanitize(m.dict())
Model(**sanitized)
```

Results in:

```python
Traceback (most recent call last):
  File "...", line 39, in <module>
    Model(**sanitized)
  File "pydantic/main.py", line 346, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for Model
enum
  value is not a valid enumeration member; permitted: 'test' (type=type_error.enum; enum_values=[<TestEnum.TEST: 'test'>])
```

Trying to use the use the pydantic `use_enum_values` configuration unfortunately casts the enum type to a string in the validated model, which defeats the point of using enums in the first place:
```python
class Model(BaseModel):

    enum: TestEnum

    class Config:
        use_enum_values = True

m = Model(enum=TestEnum.TEST)
print(m)

# > enum='test'
```

## Solution

By sanitising enums to their values, this allows the automatic casting of enums from string upon model validation. This allows for the best of both worlds: (i) Serialisation of models containing enums, and (ii) models containing actual enums rather than strings.

```python
from enum import Enum
from emmet.core.utils import jsanitize
from pydantic import BaseModel

class TestEnum(Enum):

    TEST = "test"

class Model(BaseModel):

    enum: TestEnum

m = Model(enum=TestEnum.TEST)
print(m)
# > enum=<TestEnum.TEST: 'test'>

sanitized = jsanitize(m.dict())
Model(**sanitized)  # works fine
```