### PR TITLE
Default MP build pipeline to MP2020 corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The VASP builders all operate on a `tasks` Store which is parsed from *any* VASP
 
 2. Filters out materials that can not be directly compared to each other, e.g. they've been calculated by different methods such that their total energies are on different scales.
 
-	By default, this is done by using [`MaterialsProjectCompatibility('Advanced')`](http://pymatgen.org/pymatgen.entries.compatibility.html#pymatgen.entries.compatibility.MaterialsProjectCompatibility) in pymatgen, which intelligently mixes GGA and GGA+U calculations depending on the elements present, and performs corrections to the total energy as appropriate.
+	By default, this is done by using [`MaterialsProject2020Compatibility('Advanced')`](http://pymatgen.org/pymatgen.entries.compatibility.html#pymatgen.entries.compatibility.MaterialsProject2020Compatibility) in pymatgen, which intelligently mixes GGA and GGA+U calculations depending on the elements present, and performs corrections to the total energy as appropriate.
 	
 3. Uses pymatgen's [`phasediagram`](http://pymatgen.org/pymatgen.phasediagram.html) package to calculate the [energy above hull](https://materialsproject.org/wiki/index.php/Glossary_of_Terms#Energetics) for each material and, if the material is unstable, its decomposition pathway. 
 

--- a/emmet/materials/electrodes.py
+++ b/emmet/materials/electrodes.py
@@ -1,6 +1,6 @@
 from pymatgen.core import Structure, Element
 from maggma.builders import Builder
-from pymatgen.entries.compatibility import MaterialsProjectCompatibility
+from pymatgen.entries.compatibility import MaterialsProject2020Compatibility
 from pymatgen.analysis.structure_matcher import (
     StructureMatcher, ElementComparator
 )
@@ -95,7 +95,7 @@ class ElectrodesBuilder(Builder):
         self.compatibility = (
             compatibility
             if compatibility
-            else MaterialsProjectCompatibility("Advanced")
+            else MaterialsProject2020Compatibility("Advanced")
         )
         self.completed_tasks = set()
 

--- a/mp_acceptance_tests/mp_pipeline.json
+++ b/mp_acceptance_tests/mp_pipeline.json
@@ -127,7 +127,7 @@
     "query": {},
     "compatibility": {
       "@module": "pymatgen.entries.compatibility",
-      "@class": "MaterialsProjectCompatibility",
+      "@class": "MaterialsProject2020Compatibility",
       "compat_type": "Advanced",
       "correct_peroxide": true,
       "check_potcar_hash": false


### PR DESCRIPTION
Follow up to #139 . Default MP build pipeline and electrodes builder to `MaterialsProject2020Compatibility`.

NOTE: `mpworks.py` still calls the legacy`MaterialsProjectCompatibility`. I left this as-is for historical reasons.