### PR TITLE
minor changes to get material builder working on non-production databases.

### DIFF
--- a/emmet-builders/emmet/builders/vasp/materials.py
+++ b/emmet-builders/emmet/builders/vasp/materials.py
@@ -169,6 +169,7 @@ class MaterialsBuilder(Builder):
             "task_id",
             "formula_pretty",
             "output.energy_per_atom",
+            "output.energy",
             "output.structure",
             "input.parameters",
             "orig_inputs",

--- a/emmet-core/emmet/core/vasp/calc_types/enums.py
+++ b/emmet-core/emmet/core/vasp/calc_types/enums.py
@@ -83,6 +83,7 @@ class TaskType(ValueEnum):
     Static = "Static"
     Structure_Optimization = "Structure Optimization"
     Deformation = "Deformation"
+    Unrecognized = "Unrecognized"
 
 
 class CalcType(ValueEnum):

--- a/emmet-core/emmet/core/vasp/calc_types/utils.py
+++ b/emmet-core/emmet/core/vasp/calc_types/utils.py
@@ -108,6 +108,9 @@ def task_type(
     elif incar.get("ISIF", 3) == 2 and incar.get("IBRION", 0) > 0:
         calc_type.append("Deformation")
 
+    if len(calc_type) == 0:
+        return TaskType("Unrecognized")
+
     return TaskType(" ".join(calc_type))
 
 

--- a/emmet-core/emmet/core/vasp/task.py
+++ b/emmet-core/emmet/core/vasp/task.py
@@ -91,7 +91,10 @@ class RunStatistics(BaseModel):
     total_time: float = Field(
         None, description="The total CPU time for this calculation"
     )
-    cores: int = Field(None, description="The number of cores used by VASP")
+    cores: Union[int, str] = Field(
+        None,
+        description="The number of cores used by VASP (some clusters print `mpi-ranks` here)",
+    )
 
 
 class TaskDocument(StructureMetadata):


### PR DESCRIPTION
- added an Unrecognized task_type in case someone did a weird custom task that is not recognized by the current `task_type` function.
- and try except around materials doc creation and prints warning
- removed sandboxes in materials builder