### PR TITLE
Add SCF gradient and Manual deprecation to VASP validation

### DIFF
--- a/emmet-builders/emmet/builders/__init__.py
+++ b/emmet-builders/emmet/builders/__init__.py
@@ -1,0 +1,3 @@
+from emmet.builders.settings import EmmetBuildSettings
+
+SETTINGS = EmmetBuildSettings()

--- a/emmet-builders/emmet/builders/settings.py
+++ b/emmet-builders/emmet/builders/settings.py
@@ -1,0 +1,17 @@
+"""
+Settings for defaults in the build pipelines for the Materials Project
+"""
+from typing import Union
+from pydantic.fields import Field
+from emmet.core.settings import EmmetSettings
+
+
+class EmmetBuildSettings(EmmetSettings):
+    """
+    Settings for the emmet-builder module
+    The default way to modify these is to modify ~/.emmet.json or set the environment variable
+    EMMET_CONFIG_FILE to point to the json with emmet settings
+    """
+
+    BUILD_TAGS: Union[str, list] = Field([], description="Tags for the build")
+    DEPRECATED_TAGS: Union[str, list] = Field([], description="Tags to deprecate")

--- a/emmet-builders/emmet/builders/vasp/task_validator.py
+++ b/emmet-builders/emmet/builders/vasp/task_validator.py
@@ -9,6 +9,7 @@ from emmet.core import SETTINGS
 from emmet.core.vasp.calc_types import run_type, task_type
 from emmet.core.vasp.task import TaskDocument
 from emmet.core.vasp.validation import DeprecationMessage, ValidationDoc
+from emmet.core.settings import EmmetSettings
 
 __author__ = "Shyam Dwaraknath"
 __email__ = "shyamd@lbl.gov"
@@ -19,7 +20,7 @@ class TaskValidator(MapBuilder):
         self,
         tasks: Store,
         task_validation: Store,
-        kpts_tolerance: float = SETTINGS.VASP_KPTS_TOLERANCE,
+        settings: EmmetSettings = SETTINGS,
         **kwargs,
     ):
         """
@@ -28,20 +29,22 @@ class TaskValidator(MapBuilder):
         Args:
             tasks: Store of task documents
             task_validation: Store of task_types for tasks
-            input_sets: dictionary of task_type and pymatgen input set to validate against
-            kpts_tolerance: the minimum kpt density as dictated by the InputSet to require
-            LDAU_fields: LDAU fields to check for consistency
         """
         self.tasks = tasks
         self.task_validation = task_validation
-        self.kpts_tolerance = kpts_tolerance
+        self.settings = settings
 
         self.kwargs = kwargs
 
         super().__init__(
             source=tasks,
             target=task_validation,
-            projection=["orig_inputs", "output.structure", "input.parameters"],
+            projection=[
+                "orig_inputs",
+                "output.structure",
+                "input.parameters",
+                "calcs_reversed.output.ionic_steps.e_fr_energy",
+            ],
             **kwargs,
         )
 
@@ -53,4 +56,10 @@ class TaskValidator(MapBuilder):
             item (dict): a (projection of a) task doc
         """
         task_doc = TaskDocument(**item)
-        return ValidationDoc.from_task_doc(task_doc=task_doc).dict()
+        return ValidationDoc.from_task_doc(
+            task_doc=task_doc,
+            kpts_tolerance=self.settings.VASP_KPTS_TOLERANCE,
+            input_sets=self.settings.VASP_DEFAULT_INPUT_SETS,
+            LDAU_fields=self.settings.VASP_CHECKED_LDAU_FIELDS,
+            max_allowed_scf_gradient=self.settings.VASP_MAX_SCF_GRADIENT,
+        ).dict()

--- a/emmet-core/emmet/core/settings.py
+++ b/emmet-core/emmet/core/settings.py
@@ -1,7 +1,5 @@
 """
-This file defines any arbitrary global variables used in Materials Project
-database building and in the website code, to ensure consistency between
-different modules and packages.
+Settings for defaults in the core definitions of Materials Project Documents
 """
 import importlib
 import json
@@ -17,6 +15,7 @@ DEFAULT_CONFIG_FILE_PATH = str(Path.home().joinpath(".emmet.json"))
 class EmmetSettings(BaseSettings):
     """
     Settings for the emmet- packages
+    Non-core packages should subclass this to get settings specific to their needs
     The default way to modify these is to modify ~/.emmet.json or set the environment variable
     EMMET_CONFIG_FILE to point to the json with emmet settings
     """

--- a/emmet-core/emmet/core/settings.py
+++ b/emmet-core/emmet/core/settings.py
@@ -67,6 +67,11 @@ class EmmetSettings(BaseSettings):
         ["LDAUU", "LDAUJ", "LDAUL"], description="LDAU fields to validate for tasks"
     )
 
+    VASP_MAX_SCF_GRADIENT: float = Field(
+        100,
+        description="Maximum upward gradient in the last SCF for any VASP calculation",
+    )
+
     class Config:
         env_prefix = "emmet_"
         extra = "ignore"

--- a/emmet-core/emmet/core/vasp/task.py
+++ b/emmet-core/emmet/core/vasp/task.py
@@ -40,15 +40,15 @@ class InputSummary(BaseModel):
 
     structure: Structure = Field(None, description="The input structure object")
     parameters: Dict = Field(
-        None,
+        {},
         description="Input parameters from VASPRUN for the last calculation in the series",
     )
     pseudo_potentials: Dict = Field(
-        None, description="Summary of the pseudopotentials used in this calculation"
+        {}, description="Summary of the pseudopotentials used in this calculation"
     )
 
     potcar_spec: List[Dict] = Field(
-        None, description="Potcar specification as a title and hash"
+        [], description="Potcar specification as a title and hash"
     )
 
 
@@ -66,10 +66,10 @@ class OutputSummary(BaseModel):
     )
     bandgap: float = Field(None, description="The DFT bandgap for the last calculation")
     forces: List[Vector3D] = Field(
-        None, description="Forces on atoms from the last calculation"
+        [], description="Forces on atoms from the last calculation"
     )
     stress: Matrix3D = Field(
-        None, description="Stress on the unitcell from the last calculation"
+        [], description="Stress on the unitcell from the last calculation"
     )
 
 
@@ -101,7 +101,7 @@ class TaskDocument(StructureMetadata):
 
     dir_name: str = Field(None, description="The directory for this VASP task")
     run_stats: Dict[str, RunStatistics] = Field(
-        None,
+        {},
         description="Summary of runtime statisitics for each calcualtion in this task",
     )
     completed_at: datetime = Field(
@@ -115,16 +115,20 @@ class TaskDocument(StructureMetadata):
         True, description="Whether this task document passed validation or not"
     )
 
-    input: InputSummary = Field(None)
-    output: OutputSummary = Field(None)
+    input: InputSummary = Field(InputSummary())
+    output: OutputSummary = Field(OutputSummary())
 
     state: Status = Field(None, description="State of this calculation")
 
     orig_inputs: Dict[str, Dict] = Field(
-        None, description="Summary of the original VASP inputs"
+        {}, description="Summary of the original VASP inputs"
     )
     task_id: Union[MPID, int] = Field(None, description="the Task ID For this document")
     tags: List[str] = Field([], description="Metadata tags for this task document")
+
+    calcs_reversed: List[Dict] = Field(
+        [], description="The 'raw' calculation docs used to assembled this task"
+    )
 
     @property
     def run_type(self) -> RunType:
@@ -139,7 +143,7 @@ class TaskDocument(StructureMetadata):
         return calc_type(self.orig_inputs, self.input.parameters)
 
     @property
-    def entry(self):
+    def entry(self) -> ComputedEntry:
         """ Turns a Task Doc into a ComputedEntry"""
         entry_dict = {
             "correction": 0.0,
@@ -161,7 +165,7 @@ class TaskDocument(StructureMetadata):
         return ComputedEntry.from_dict(entry_dict)
 
     @property
-    def structure_entry(self):
+    def structure_entry(self) -> ComputedStructureEntry:
         """ Turns a Task Doc into a ComputedStructureEntry"""
         entry_dict = self.entry.as_dict()
         entry_dict["structure"] = self.output.structure

--- a/emmet-core/emmet/core/vasp/validation.py
+++ b/emmet-core/emmet/core/vasp/validation.py
@@ -55,7 +55,7 @@ class ValidationDoc(BaseModel):
         kpts_tolerance: float = SETTINGS.VASP_KPTS_TOLERANCE,
         input_sets: Dict[str, PyObject] = SETTINGS.VASP_DEFAULT_INPUT_SETS,
         LDAU_fields: List[str] = SETTINGS.VASP_CHECKED_LDAU_FIELDS,
-        max_allowed_scf_gradient: float = SETTINGS.MAX_VASP_SCF_GRADIENT,
+        max_allowed_scf_gradient: float = SETTINGS.VASP_MAX_SCF_GRADIENT,
     ) -> "ValidationDoc":
         """
         Determines if a calculation is valid based on expected input parameters from a pymatgen inputset

--- a/emmet-core/emmet/core/vasp/validation.py
+++ b/emmet-core/emmet/core/vasp/validation.py
@@ -130,7 +130,7 @@ class ValidationDoc(BaseModel):
             ]
             max_gradient = np.max(np.gradient(energies)[skip:])
             data["max_gradient"] = max_gradient
-            if max_gradient > SETTINGS.VASP_MAX_SCF_GRADIENT:
+            if max_gradient > max_allowed_scf_gradient:
                 reasons.append(DeprecationMessage.MAX_SCF)
 
         doc = ValidationDoc(


### PR DESCRIPTION
Adds two additional validation methods:
- Max SCF gradient
- Manual deprecation by tags

This also starts to standardize on passing `EmmetSettings` objects in builders to reduce clutter while keeping kwargs in the Document models to ensure clarity. If you're running the builders you don't need to know every detail. If you're directly building documents, you want to know what you can change. 