### PR TITLE
serialize settings

### DIFF
--- a/emmet-builders/emmet/builders/vasp/materials.py
+++ b/emmet-builders/emmet/builders/vasp/materials.py
@@ -47,7 +47,7 @@ class MaterialsBuilder(Builder):
         materials: Store,
         task_validation: Optional[Store] = None,
         query: Optional[Dict] = None,
-        settings: Optional[EmmetBuildSettings] = None,
+        user_settings: Optional[EmmetBuildSettings] = None,
         **kwargs,
     ):
         """
@@ -62,7 +62,8 @@ class MaterialsBuilder(Builder):
         self.materials = materials
         self.task_validation = task_validation
         self.query = query if query else {}
-        self.settings = settings or SETTINGS
+        self.user_settings = user_settings
+        self.settings = user_settings or SETTINGS
         self.kwargs = kwargs
 
         sources = [tasks]

--- a/emmet-builders/emmet/builders/vasp/task_validator.py
+++ b/emmet-builders/emmet/builders/vasp/task_validator.py
@@ -20,7 +20,7 @@ class TaskValidator(MapBuilder):
         self,
         tasks: Store,
         task_validation: Store,
-        settings: Optional[EmmetBuildSettings] = None,
+        user_settings: Optional[EmmetBuildSettings] = None,
         **kwargs,
     ):
         """
@@ -32,7 +32,8 @@ class TaskValidator(MapBuilder):
         """
         self.tasks = tasks
         self.task_validation = task_validation
-        self.settings = settings or SETTINGS
+        self.user_settings = user_settings
+        self.settings = user_settings or SETTINGS
         self.kwargs = kwargs
 
         super().__init__(


### PR DESCRIPTION
The current implementations of settings for some builders are not serializable.
This fix makes the default version of the serializable, but some other kind of fix is probably needed.