### PR TITLE
Add automatic oxidation state detection to ThermoBuilder

### DIFF
--- a/emmet/materials/thermo.py
+++ b/emmet/materials/thermo.py
@@ -319,6 +319,7 @@ class ThermoBuilder(Builder):
             entry.data["oxide_type"] = oxide_type(Structure.from_dict(d["structure"]))
             entry.data["_sbxn"] = d.get("_sbxn", [])
             entry.data["last_updated"] = d.get("last_updated", datetime.utcnow())
+            entry.data["oxidation_states"] = {}
             with Timeout():
                 try:
                     oxi_states = entry.composition.oxi_state_guesses(max_sites=-20)

--- a/emmet/materials/thermo.py
+++ b/emmet/materials/thermo.py
@@ -9,6 +9,7 @@ from pymatgen.analysis.phase_diagram import PhaseDiagram, PhaseDiagramError
 from pymatgen.analysis.structure_analyzer import oxide_type
 
 from maggma.builders import Builder
+from maggma.utils import Timeout
 from emmet.vasp.materials import ID_to_int
 
 __author__ = "Shyam Dwaraknath <shyamd@lbl.gov>"
@@ -318,6 +319,14 @@ class ThermoBuilder(Builder):
             entry.data["oxide_type"] = oxide_type(Structure.from_dict(d["structure"]))
             entry.data["_sbxn"] = d.get("_sbxn", [])
             entry.data["last_updated"] = d.get("last_updated", datetime.utcnow())
+            with Timeout():
+                try:
+                    oxi_states = entry.composition.oxi_state_guesses(max_sites=-20)
+                except ValueError:
+                    oxi_states = []
+
+                if oxi_states != []:
+                    entry.data["oxidation_states"] = oxi_states[0]
 
             # Add to cache
             elsyms = sorted(set([el.symbol for el in entry.composition.elements]))


### PR DESCRIPTION
* Attempts to populate the `ComputedEntry.data["oxidation_states"] key used by MP2020 corrections using `Composition.oxi_state_guesses()`
* `maggma.utils.Timeout` is used to prevent this from taking an excessively long time