### PR TITLE
ThermoBuilder changes to work with BVAnalyzer

### DIFF
--- a/emmet/materials/bond_valence.py
+++ b/emmet/materials/bond_valence.py
@@ -26,13 +26,12 @@ class BondValenceBuilder(MapBuilder):
         super().__init__(
             source=materials,
             target=bond_valence,
-            ufn=self.calc,
             projection=["structure"],
             timeout=14,
             **kwargs
         )
 
-    def calc(self, item):
+    def unary_function(self, item):
         s = Structure.from_dict(item["structure"])
 
         d = {

--- a/emmet/materials/bond_valence.py
+++ b/emmet/materials/bond_valence.py
@@ -15,7 +15,7 @@ MODULE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)))
 BOND_VALENCE_SCHEMA = os.path.join(MODULE_DIR, "schema", "bond_valence.json")
 
 
-class BondValenceBuilder(MapBuilder):
+class OxidationStateBuilder(MapBuilder):
     """
     Calculate plausible oxidation states from structures.
     """

--- a/emmet/materials/bond_valence.py
+++ b/emmet/materials/bond_valence.py
@@ -18,7 +18,7 @@ class BondValenceBuilder(MapBuilder):
     Calculate plausible oxidation states from structures.
     """
 
-    def __init__(self, materials, bond_valence, **kwargs):
+    def __init__(self, materials, bond_valence, timeout=14, **kwargs):
 
         self.materials = materials
         self.bond_valence = bond_valence
@@ -27,7 +27,6 @@ class BondValenceBuilder(MapBuilder):
             source=materials,
             target=bond_valence,
             projection=["structure"],
-            timeout=14,
             **kwargs
         )
 

--- a/emmet/materials/bond_valence.py
+++ b/emmet/materials/bond_valence.py
@@ -1,4 +1,6 @@
 import os.path
+import numpy as np
+from itertools import groupby
 from monty.serialization import loadfn
 
 from pymatgen.core.structure import Structure
@@ -50,9 +52,20 @@ class BondValenceBuilder(MapBuilder):
             d["successful"] = True
             s.add_oxidation_state_by_site(valences)
 
+            # construct a dict of average oxi_states for use
+            # by MP2020 corrections. The format should mirror
+            # the output of the first element from Composition.oxi_state_guesses()
+            # e.g. {'Li': 1.0, 'O': -2.0}
+            s_list=[(t.specie.element, t.specie.oxi_state) for t in s.sites]
+            s_list = sorted(s_list, key=lambda x: x[0])
+            oxi_state_dict = {}
+            for c,g in groupby(s_list, key=lambda x: x[0]):
+                oxi_state_dict[str(c)] = np.mean([e[1] for e in g])
+
             d["bond_valence"] = {
                 "possible_species": list(possible_species),
                 "possible_valences": valences,
+                "average_oxidation_states": oxi_state_dict,
                 "method": "BVAnalyzer",
                 "structure": s.as_dict(),
             }
@@ -76,6 +89,7 @@ class BondValenceBuilder(MapBuilder):
                 d["bond_valence"] = {
                     "possible_species": list(possible_species),
                     "possible_valences": valences,
+                    "average_oxidation_states": first_oxi_state_guess,
                     "method": "oxi_state_guesses",
                     "structure": s.as_dict(),
                 }

--- a/emmet/materials/tests/test_bond_valence.py
+++ b/emmet/materials/tests/test_bond_valence.py
@@ -2,7 +2,7 @@ import os
 import unittest
 from maggma.stores import JSONStore, MemoryStore
 from maggma.runner import Runner
-from emmet.materials.bond_valence import BondValenceBuilder
+from emmet.materials.bond_valence import OxidationStateBuilder
 
 __author__ = "Matthew Horton"
 __email__ = "mkhorton@lbl.gov"
@@ -11,7 +11,7 @@ module_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)))
 test_mats = os.path.join(module_dir, "..", "..", "..", "test_files", "thermo_test.json")
 
 
-class TestBondValence(unittest.TestCase):
+class TestOxidationState(unittest.TestCase):
     def setUp(self):
 
         self.materials = JSONStore(test_mats)
@@ -19,7 +19,7 @@ class TestBondValence(unittest.TestCase):
 
     def test_build(self):
 
-        builder = BondValenceBuilder(self.materials, self.bond_valence)
+        builder = OxidationStateBuilder(self.materials, self.bond_valence)
         runner = Runner([builder])
         runner.run()
 

--- a/emmet/materials/thermo.py
+++ b/emmet/materials/thermo.py
@@ -362,7 +362,7 @@ class ThermoBuilder(Builder):
             entry.data["oxide_type"] = oxide_type(Structure.from_dict(d["structure"]))
             entry.data["_sbxn"] = d.get("_sbxn", [])
             entry.data["last_updated"] = d.get("last_updated", datetime.utcnow())
-            entry.data["oxidation_states"] = oxi_state_data.get(d["task_id"], {})
+            entry.data["oxidation_states"] = oxi_states_data.get(d["task_id"], {})
 
             # Add to cache
             elsyms = sorted(set([el.symbol for el in entry.composition.elements]))

--- a/emmet/materials/thermo.py
+++ b/emmet/materials/thermo.py
@@ -324,14 +324,14 @@ class ThermoBuilder(Builder):
             entry.data["_sbxn"] = d.get("_sbxn", [])
             entry.data["last_updated"] = d.get("last_updated", datetime.utcnow())
             entry.data["oxidation_states"] = {}
-            with Timeout():
-                try:
-                    oxi_states = entry.composition.oxi_state_guesses(max_sites=-20)
-                except ValueError:
-                    oxi_states = []
+            # with Timeout():
+            #     try:
+            #         oxi_states = entry.composition.oxi_state_guesses(max_sites=-20)
+            #     except ValueError:
+            #         oxi_states = []
 
-                if oxi_states != []:
-                    entry.data["oxidation_states"] = oxi_states[0]
+            #     if oxi_states != []:
+            #         entry.data["oxidation_states"] = oxi_states[0]
 
             # Add to cache
             elsyms = sorted(set([el.symbol for el in entry.composition.elements]))

--- a/emmet/materials/thermo.py
+++ b/emmet/materials/thermo.py
@@ -48,7 +48,7 @@ class ThermoBuilder(Builder):
 
         self.materials = materials
         self.thermo = thermo
-        self.oxi_states = oxi_states
+        self.oxi_states = oxi_states if oxi_states else None
         self.query = query if query else {}
         self.compatibility = (
             compatibility if compatibility else MaterialsProject2020Compatibility()
@@ -333,10 +333,10 @@ class ThermoBuilder(Builder):
         if self.oxi_states:
             task_ids = [t["task_id"] for t in data]
             oxi_states_data = {
-                d["task_id"]: d["average_oxidation_states"]
+                d["task_id"]: d["bond_valence"]["average_oxidation_states"]
                 for d in self.oxi_states.query(
                     properties=["task_id", "bond_valence.average_oxidation_states"],
-                    criteria={"task_id": {"$in": task_ids}},
+                    criteria={"task_id": {"$in": task_ids}, "successful": True},
                 )
             }
 

--- a/emmet/materials/thermo.py
+++ b/emmet/materials/thermo.py
@@ -324,14 +324,14 @@ class ThermoBuilder(Builder):
             entry.data["_sbxn"] = d.get("_sbxn", [])
             entry.data["last_updated"] = d.get("last_updated", datetime.utcnow())
             entry.data["oxidation_states"] = {}
-            # with Timeout():
-            #     try:
-            #         oxi_states = entry.composition.oxi_state_guesses(max_sites=-20)
-            #     except ValueError:
-            #         oxi_states = []
+            with Timeout():
+                try:
+                    oxi_states = entry.composition.oxi_state_guesses(max_sites=-20)
+                except ValueError:
+                    oxi_states = []
 
-            #     if oxi_states != []:
-            #         entry.data["oxidation_states"] = oxi_states[0]
+                if oxi_states != []:
+                    entry.data["oxidation_states"] = oxi_states[0]
 
             # Add to cache
             elsyms = sorted(set([el.symbol for el in entry.composition.elements]))

--- a/emmet/materials/thermo.py
+++ b/emmet/materials/thermo.py
@@ -331,6 +331,7 @@ class ThermoBuilder(Builder):
         data = list(self.materials.query(properties=fields, criteria=new_q))
         oxi_states_data = {}
         if self.oxi_states:
+            self.oxi_states.connect()
             task_ids = [t["task_id"] for t in data]
             oxi_states_data = {
                 d["task_id"]: d["bond_valence"]["average_oxidation_states"]

--- a/mp_acceptance_tests/mp_pipeline.json
+++ b/mp_acceptance_tests/mp_pipeline.json
@@ -213,7 +213,7 @@
   },
   {
     "@module": "emmet.materials.bond_valence",
-    "@class": "BondValenceBuilder",
+    "@class": "OxidationStateBuilder",
     "materials": {
       "@module": "maggma.advanced_stores",
       "@class": "MongograntStore",


### PR DESCRIPTION
* Update `BondValenceBuilder` to work with latest maggma
* Add `avg_oxidation_states` to the docs generated by `BondValenceBuilder`. This key has the same format as the first element of `Composition.oxi_state_guesses` and is passed to the `Entry.data["oxidation_states"]` key by `ThermoBuilder`. This key, if present, is in turn read by the MP2020 correction scheme
* lint with `black`
