### PR TITLE
Use deprecated tasks in Materials Builder

### DIFF
--- a/emmet-core/emmet/core/vasp/material.py
+++ b/emmet-core/emmet/core/vasp/material.py
@@ -65,7 +65,6 @@ class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
         task_types = {task.task_id: task.task_type for task in task_group}
         calc_types = {task.task_id: task.calc_type for task in task_group}
 
-        valid_tasks = [task for task in task_group if task.is_valid]
         structure_optimizations = [
             task
             for task in task_group
@@ -121,8 +120,8 @@ class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
 
         # Deprecated
         deprecated = all(task.task_id in deprecated_tasks for task in structure_calcs)
-        deprecated = deprecated or best_structure_calc.task_id in deprecated_tasks 
-        
+        deprecated = deprecated or best_structure_calc.task_id in deprecated_tasks
+
         # Origins
         origins = [
             PropertyOrigin(

--- a/emmet-core/emmet/core/vasp/material.py
+++ b/emmet-core/emmet/core/vasp/material.py
@@ -68,10 +68,10 @@ class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
         valid_tasks = [task for task in task_group if task.is_valid]
         structure_optimizations = [
             task
-            for task in valid_tasks
+            for task in task_group
             if task.task_type == TaskType.Structure_Optimization  # type: ignore
         ]
-        statics = [task for task in valid_tasks if task.task_type == TaskType.Static]  # type: ignore
+        statics = [task for task in task_group if task.task_type == TaskType.Static]  # type: ignore
         structure_calcs = (
             structure_optimizations + statics
             if use_statics
@@ -97,6 +97,7 @@ class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
             task_run_type = task.run_type
 
             return (
+                -1 * int(task.is_valid),
                 -1 * quality_scores.get(task_run_type.value, 0),
                 -1 * task_quality_scores.get(task.task_type.value, 0),
                 -1 * task.input.parameters.get("ISPIN", 1),
@@ -120,7 +121,8 @@ class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
 
         # Deprecated
         deprecated = all(task.task_id in deprecated_tasks for task in structure_calcs)
-
+        deprecated = deprecated or best_structure_calc.task_id in deprecated_tasks 
+        
         # Origins
         origins = [
             PropertyOrigin(


### PR DESCRIPTION
Deprecated tasks were being filtered out too early causing them to disappear. This should remedy that.