### PR TITLE
Remove `bson` package requirement

### DIFF
--- a/emmet-core/requirements.txt
+++ b/emmet-core/requirements.txt
@@ -5,4 +5,3 @@ pybtex==0.24.0
 typing-extensions==3.10.0.0
 seekpath==2.0.1
 setuptools-scm==6.0.1
-bson==0.5.10

--- a/emmet-core/setup.py
+++ b/emmet-core/setup.py
@@ -18,7 +18,6 @@ setup(
         "pydantic[email]~=1.8",
         "pybtex~=0.24",
         "typing-extensions>=3.7,<4.0",
-        "bson~=0.5",
     ],
     license="modified BSD",
     zip_safe=False,


### PR DESCRIPTION
Hopefully this should get rid of the last of the stale `bson` package on pip and just use pymongo's `bson` module