### PR TITLE
Bug: Reference the last calculation to determine `run_type`

### DIFF
--- a/emmet-builders/emmet/builders/vasp/materials.py
+++ b/emmet-builders/emmet/builders/vasp/materials.py
@@ -181,7 +181,7 @@ class MaterialsBuilder(Builder):
             "output.energy_per_atom",
             "output.energy",
             "output.structure",
-            "input.parameters",
+            "calcs_reversed.0.input.parameters",
             "input.is_hubbard",
             "input.hubbards",
             "input.potcar_spec",

--- a/emmet-core/emmet/core/vasp/task.py
+++ b/emmet-core/emmet/core/vasp/task.py
@@ -117,7 +117,7 @@ class TaskDocument(BaseTaskDocument, StructureMetadata):
 
     @property
     def run_type(self) -> RunType:
-        return run_type(self.calcs_reversed[0].get("input",{}).get("parameters",{}))
+        return run_type(self.calcs_reversed[0].get("input", {}).get("parameters", {}))
 
     @property
     def task_type(self):

--- a/emmet-core/emmet/core/vasp/task.py
+++ b/emmet-core/emmet/core/vasp/task.py
@@ -117,7 +117,7 @@ class TaskDocument(BaseTaskDocument, StructureMetadata):
 
     @property
     def run_type(self) -> RunType:
-        return run_type(self.input.parameters)
+        return run_type(self.calcs_reversed[0].get("input",{}).get("parameters",{}))
 
     @property
     def task_type(self):


### PR DESCRIPTION
The current drone in atomate uses the `inputs` from the first calc as the `input` for the whole task document rather than the `input` for the last calc. This can cause the `run_type` to be wrong for SCAN calcs where a GGA static was used to initialize the SCF. 