### PR TITLE
Fix Validation

### DIFF
--- a/emmet-builders/emmet/builders/materials/oxidation_states.py
+++ b/emmet-builders/emmet/builders/materials/oxidation_states.py
@@ -37,7 +37,10 @@ class OxidationStatesBuilder(MapBuilder):
 
     def unary_function(self, item):
         structure = Structure.from_dict(item["structure"])
-        oxi_doc = OxidationStateDoc.from_structure(structure)
+        mpid = item["material_id"]
+        oxi_doc = OxidationStateDoc.from_structure(
+            structure=structure, material_id=mpid
+        )
         doc = oxi_doc.dict()
 
         doc.update(

--- a/emmet-builders/emmet/builders/vasp/materials.py
+++ b/emmet-builders/emmet/builders/vasp/materials.py
@@ -179,6 +179,7 @@ class MaterialsBuilder(Builder):
             "output.energy",
             "output.structure",
             "calcs_reversed.input.parameters",
+            "calcs_reversed.input.incar",
             "input.is_hubbard",
             "input.hubbards",
             "input.potcar_spec",

--- a/emmet-builders/emmet/builders/vasp/materials.py
+++ b/emmet-builders/emmet/builders/vasp/materials.py
@@ -176,14 +176,18 @@ class MaterialsBuilder(Builder):
             "task_id",
             "formula_pretty",
             "output.energy_per_atom",
-            "output.energy",
             "output.structure",
+            "input.parameters",
+            # needed for run_type and task_type
             "calcs_reversed.input.parameters",
             "calcs_reversed.input.incar",
+            "orig_inputs",
+            # needed for entry from task_doc
+            "output.energy",
             "input.is_hubbard",
             "input.hubbards",
             "input.potcar_spec",
-            "orig_inputs",
+            # misc info for materials doc
             "input.structure",
             "tags",
         ]

--- a/emmet-builders/emmet/builders/vasp/task_validator.py
+++ b/emmet-builders/emmet/builders/vasp/task_validator.py
@@ -38,6 +38,7 @@ class TaskValidator(MapBuilder):
                 "output.structure",
                 "output.bandgap",
                 "calcs_reversed.input.parameters",
+                "calcs_reversed.input.incar",
                 "calcs_reversed.output.ionic_steps.electronic_steps.e_fr_energy",
                 "tags",
             ],

--- a/emmet-builders/emmet/builders/vasp/task_validator.py
+++ b/emmet-builders/emmet/builders/vasp/task_validator.py
@@ -35,12 +35,14 @@ class TaskValidator(MapBuilder):
             target=task_validation,
             projection=[
                 "orig_inputs",
+                "input.hubbards",
                 "output.structure",
                 "output.bandgap",
-                "calcs_reversed.input.parameters",
-                "calcs_reversed.input.incar",
                 "calcs_reversed.output.ionic_steps.electronic_steps.e_fr_energy",
                 "tags",
+                # Need these two for proper run_type determination
+                "calcs_reversed.input.parameters",
+                "calcs_reversed.input.incar",
             ],
             query=query,
             **kwargs,

--- a/emmet-core/emmet/core/settings.py
+++ b/emmet-core/emmet/core/settings.py
@@ -66,6 +66,8 @@ class EmmetSettings(BaseSettings):
         {
             "GGA Structure Optimization": "pymatgen.io.vasp.sets.MPRelaxSet",
             "GGA+U Structure Optimization": "pymatgen.io.vasp.sets.MPRelaxSet",
+            "GGA Static": "pymatgen.io.vasp.sets.MPStaticSet",
+            "GGA+U Static": "pymatgen.io.vasp.sets.MPStaticSet",
         },
         description="Default input sets for task validation",
     )

--- a/emmet-core/emmet/core/utils.py
+++ b/emmet-core/emmet/core/utils.py
@@ -139,6 +139,12 @@ class ValueEnum(Enum):
     def __str__(self):
         return str(self.value)
 
+    def __eq__(self, o: object) -> bool:
+        """Special Equals to enable converting strings back to the enum"""
+        if isinstance(o, str):
+            return super().__eq__(self.__class__(o))
+        return super().__eq__(o)
+
 
 class DocEnum(ValueEnum):
     """

--- a/emmet-core/emmet/core/utils.py
+++ b/emmet-core/emmet/core/utils.py
@@ -1,7 +1,7 @@
 import datetime
 from enum import Enum
 from itertools import groupby
-from typing import Iterator, List
+from typing import Any, Iterator, List
 
 import bson
 import numpy as np
@@ -143,7 +143,12 @@ class ValueEnum(Enum):
         """Special Equals to enable converting strings back to the enum"""
         if isinstance(o, str):
             return super().__eq__(self.__class__(o))
-        return super().__eq__(o)
+        elif isinstance(o, self.__class__):
+            return super().__eq__(o)
+        return False
+
+    def __hash__(self) -> Any:
+        return super().__hash__()
 
 
 class DocEnum(ValueEnum):

--- a/emmet-core/emmet/core/vasp/material.py
+++ b/emmet-core/emmet/core/vasp/material.py
@@ -94,13 +94,16 @@ class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
             """
 
             task_run_type = task.run_type
+            _SPECIAL_TAGS = ["LASPH", "ISPIN"]
+            special_tags = sum(
+                task.input.parameters.get(tag, False) for tag in _SPECIAL_TAGS
+            )
 
             return (
                 -1 * int(task.is_valid),
                 -1 * quality_scores.get(task_run_type.value, 0),
                 -1 * task_quality_scores.get(task.task_type.value, 0),
-                -1 * task.input.parameters.get("ISPIN", 1),
-                -1 * task.input.parameters.get("LASPH", False),
+                -1 * special_tags,
                 task.output.energy_per_atom,
             )
 

--- a/emmet-core/emmet/core/vasp/task.py
+++ b/emmet-core/emmet/core/vasp/task.py
@@ -1,7 +1,7 @@
 """ Core definition of a VASP Task Document """
 from typing import Any, ClassVar, Dict, List, Union
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field
 from pymatgen.analysis.structure_analyzer import oxide_type
 from pymatgen.core import Structure
 from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEntry

--- a/emmet-core/emmet/core/vasp/task.py
+++ b/emmet-core/emmet/core/vasp/task.py
@@ -177,7 +177,7 @@ class TaskDocument(BaseTaskDocument, StructureMetadata):
             },
             "data": {
                 "oxide_type": oxide_type(self.output.structure),
-                "aspherical": self.input.parameters.get("LASPH", True),
+                "aspherical": self.input.parameters.get("LASPH", False),
                 "last_updated": self.last_updated,
             },
             "structure": self.output.structure,

--- a/emmet-core/emmet/core/vasp/validation.py
+++ b/emmet-core/emmet/core/vasp/validation.py
@@ -108,11 +108,14 @@ class ValidationDoc(BaseModel):
                     )
                     # larger KSPACING means fewer k-points
                     if data["kspacing_delta"] > kspacing_tolerance:
-                        reasons.append(DeprecationMessage.KSPACING)
+                        warnings.append(
+                            f"KSPACING is greater than input set: {data['kspacing_delta']}"
+                            f" lower than {kspacing_tolerance} ",
+                        )
                     elif data["kspacing_delta"] < kspacing_tolerance:
                         warnings.append(
                             f"KSPACING is lower than input set: {data['kspacing_delta']}"
-                            " lower than {kspacing_tolerance} ",
+                            f" lower than {kspacing_tolerance} ",
                         )
 
             # warn, but don't invalidate if wrong ISMEAR

--- a/emmet-core/emmet/core/vasp/validation.py
+++ b/emmet-core/emmet/core/vasp/validation.py
@@ -155,11 +155,23 @@ class ValidationDoc(BaseModel):
                     d[0]: d[1:] for d in zip(*input_set_ldau_fields)
                 }
 
-                if any(
-                    input_set_ldau_params[el] != input_params
-                    for el, input_params in input_ldau_params.items()
-                ):
+                all_elements = list(
+                    set(input_set_ldau_params.keys()) | set(input_ldau_params.keys())
+                )
+                diff_ldau_params = {
+                    el: (input_set_ldau_params.get(el, 0), input_ldau_params.get(el, 0))
+                    for el in all_elements
+                    if input_set_ldau_params.get(el) != input_ldau_params.get(el)
+                }
+
+                if len(diff_ldau_params) > 0:
                     reasons.append(DeprecationMessage.LDAU)
+                    warnings.extend(
+                        [
+                            f"U-value for {el} should be {good} but was {bad}"
+                            for el, (bad, good) in diff_ldau_params.items()
+                        ]
+                    )
 
         # Check the max upwards SCF step
         skip = inputs.get("incar", {}).get("NLEMDL")

--- a/emmet-core/emmet/core/vasp/validation.py
+++ b/emmet-core/emmet/core/vasp/validation.py
@@ -88,7 +88,7 @@ class ValidationDoc(BaseModel):
                     structure, bandgap=bandgap
                 )
             except TypeError:
-                valid_input_set: VaspInputSet = input_sets[str(calc_type)](structure)
+                valid_input_set = input_sets[str(calc_type)](structure)
 
             # Checking K-Points
             # Calculations that use KSPACING will not have a .kpoints attr
@@ -139,9 +139,9 @@ class ValidationDoc(BaseModel):
 
             # NOTE: Reverting to old method of just using input.hubbards which is wrong in many instances
             input_hubbards = task_doc.input.hubbards
-            print(input_hubbards)
+
             # Checking U-values
-            if valid_input_set.incar.get("LDAU") or len(input_ldau_params) > 0:
+            if valid_input_set.incar.get("LDAU") or len(input_hubbards) > 0:
                 # Assemble required input_set LDAU params into dictionary
                 input_set_hubbards = dict(
                     zip(

--- a/emmet-core/emmet/core/vasp/validation.py
+++ b/emmet-core/emmet/core/vasp/validation.py
@@ -121,7 +121,7 @@ class ValidationDoc(BaseModel):
             if curr_ismear != valid_ismear:
                 warnings.append(
                     f"Inappropriate smearing settings. Set to {curr_ismear},"
-                    " but should be {valid_ismear}"
+                    f" but should be {valid_ismear}"
                 )
 
             # Checking ENCUT

--- a/emmet-core/emmet/core/vasp/validation.py
+++ b/emmet-core/emmet/core/vasp/validation.py
@@ -173,18 +173,18 @@ class ValidationDoc(BaseModel):
                         ]
                     )
 
-        # Check the max upwards SCF step
-        skip = abs(inputs.get("incar", {}).get("NLEMDL", -5)) - 1
-        energies = [
-            d["e_fr_energy"]
-            for d in task_doc.calcs_reversed[0]["output"]["ionic_steps"][-1][
-                "electronic_steps"
+            # Check the max upwards SCF step
+            skip = abs(inputs.get("incar", {}).get("NLEMDL", -5)) - 1
+            energies = [
+                d["e_fr_energy"]
+                for d in task_doc.calcs_reversed[0]["output"]["ionic_steps"][-1][
+                    "electronic_steps"
+                ]
             ]
-        ]
-        max_gradient = np.max(np.gradient(energies)[skip:])
-        data["max_gradient"] = max_gradient
-        if max_gradient > max_allowed_scf_gradient:
-            reasons.append(DeprecationMessage.MAX_SCF)
+            max_gradient = np.max(np.gradient(energies)[skip:])
+            data["max_gradient"] = max_gradient
+            if max_gradient > max_allowed_scf_gradient:
+                reasons.append(DeprecationMessage.MAX_SCF)
 
         doc = ValidationDoc(
             task_id=task_doc.task_id,

--- a/emmet-core/emmet/core/vasp/validation.py
+++ b/emmet-core/emmet/core/vasp/validation.py
@@ -156,7 +156,9 @@ class ValidationDoc(BaseModel):
                 diff_ldau_params = {
                     el: (input_set_hubbards.get(el, 0), input_hubbards.get(el, 0))
                     for el in all_elements
-                    if input_set_hubbards.get(el) != input_hubbards.get(el)
+                    if not np.allclose(
+                        input_set_hubbards.get(el, 0), input_hubbards.get(el, 0)
+                    )
                 }
 
                 if len(diff_ldau_params) > 0:

--- a/emmet-core/emmet/core/vasp/validation.py
+++ b/emmet-core/emmet/core/vasp/validation.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Union
 import numpy as np
 from pydantic import BaseModel, Field, PyObject
 from pymatgen.core.structure import Structure
+from pymatgen.io.vasp.sets import VaspInputSet
 
 from emmet.core import SETTINGS
 from emmet.core.mpid import MPID
@@ -83,9 +84,11 @@ class ValidationDoc(BaseModel):
 
             # Ensure inputsets that need the bandgap get it
             try:
-                valid_input_set = input_sets[str(calc_type)](structure, bandgap=bandgap)
+                valid_input_set: VaspInputSet = input_sets[str(calc_type)](
+                    structure, bandgap=bandgap
+                )
             except TypeError:
-                valid_input_set = input_sets[str(calc_type)](structure)
+                valid_input_set: VaspInputSet = input_sets[str(calc_type)](structure)
 
             # Checking K-Points
             # Calculations that use KSPACING will not have a .kpoints attr

--- a/emmet-core/emmet/core/vasp/validation.py
+++ b/emmet-core/emmet/core/vasp/validation.py
@@ -174,7 +174,7 @@ class ValidationDoc(BaseModel):
                     )
 
         # Check the max upwards SCF step
-        skip = inputs.get("incar", {}).get("NLEMDL")
+        skip = abs(inputs.get("incar", {}).get("NLEMDL", -5)) - 1
         energies = [
             d["e_fr_energy"]
             for d in task_doc.calcs_reversed[0]["output"]["ionic_steps"][-1][

--- a/emmet-core/emmet/core/vasp/validation.py
+++ b/emmet-core/emmet/core/vasp/validation.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Union
 
 import numpy as np
 from pydantic import BaseModel, Field, PyObject
-from pymatgen.core import Structure
+from pymatgen.core.structure import Structure
 
 from emmet.core import SETTINGS
 from emmet.core.mpid import MPID

--- a/emmet-core/emmet/core/vasp/validation.py
+++ b/emmet-core/emmet/core/vasp/validation.py
@@ -141,7 +141,7 @@ class ValidationDoc(BaseModel):
             input_hubbards = task_doc.input.hubbards
 
             # Checking U-values
-            if valid_input_set.incar.get("LDAU") or len(input_hubbards) > 0:
+            if valid_input_set.incar.get("LDAU", False) or len(input_hubbards) > 0:
                 # Assemble required input_set LDAU params into dictionary
                 input_set_hubbards = dict(
                     zip(

--- a/emmet-core/emmet/core/vasp/validation.py
+++ b/emmet-core/emmet/core/vasp/validation.py
@@ -134,16 +134,16 @@ class ValidationDoc(BaseModel):
             if data["encut_ratio"] < 1:
                 reasons.append(DeprecationMessage.ENCUT)
 
-            # Checking U-values
-            if valid_input_set.incar.get("LDAU"):
-                # Assemble actual input LDAU params into dictionary to account for possibility
-                # of differing order of elements.
-                structure_set_symbol_set = _get_unsorted_symbol_set(structure)
-                inputs_ldau_fields = [structure_set_symbol_set] + [
-                    inputs.get("incar", {}).get(k, []) for k in LDAU_fields
-                ]
-                input_ldau_params = {d[0]: d[1:] for d in zip(*inputs_ldau_fields)}
+            # Assemble actual input LDAU params into dictionary to account for possibility
+            # of differing order of elements.
+            structure_set_symbol_set = _get_unsorted_symbol_set(structure)
+            inputs_ldau_fields = [structure_set_symbol_set] + [
+                inputs.get("incar", {}).get(k, []) for k in LDAU_fields
+            ]
+            input_ldau_params = {d[0]: d[1:] for d in zip(*inputs_ldau_fields)}
 
+            # Checking U-values
+            if valid_input_set.incar.get("LDAU") or len(input_ldau_params) > 0:
                 # Assemble required input_set LDAU params into dictionary
                 input_set_symbol_set = _get_unsorted_symbol_set(
                     valid_input_set.poscar.structure

--- a/emmet-core/emmet/core/vasp/validation.py
+++ b/emmet-core/emmet/core/vasp/validation.py
@@ -181,10 +181,16 @@ class ValidationDoc(BaseModel):
                     "electronic_steps"
                 ]
             ]
-            max_gradient = np.max(np.gradient(energies)[skip:])
-            data["max_gradient"] = max_gradient
-            if max_gradient > max_allowed_scf_gradient:
-                reasons.append(DeprecationMessage.MAX_SCF)
+            if len(energies) > skip:
+                max_gradient = np.max(np.gradient(energies)[skip:])
+                data["max_gradient"] = max_gradient
+                if max_gradient > max_allowed_scf_gradient:
+                    reasons.append(DeprecationMessage.MAX_SCF)
+            else:
+                warnings.append(
+                    "Not enough electronic steps to compute valid gradient"
+                    " and compare with max SCF gradient tolerance"
+                )
 
         doc = ValidationDoc(
             task_id=task_doc.task_id,

--- a/tests/emmet-core/vasp/test_vasp.py
+++ b/tests/emmet-core/vasp/test_vasp.py
@@ -73,3 +73,15 @@ def task_ldau(test_dir):
 def test_ldau(task_ldau):
     assert task_ldau.run_type == RunType.GGA_U
     assert ValidationDoc.from_task_doc(task_ldau).valid is False
+
+
+def test_ldau_validation(test_dir):
+    with open(test_dir / "old_aflow_ggau_task.json") as f:
+        data = json.load(f)
+
+    task = TaskDocument(**data)
+    assert task.run_type == "GGA+U"
+
+    valid = ValidationDoc.from_task_doc(task)
+
+    assert valid.valid

--- a/tests/test_files/old_aflow_ggau_task.json
+++ b/tests/test_files/old_aflow_ggau_task.json
@@ -1,0 +1,10967 @@
+{
+    "_id" : "5bc79b662e927b78dbe5bfb6",
+    "dir_name" : "mc0805.nersc.gov:/global/projecta/projectdirs/matgen/garden/block_2013-06-23-09-28-21-424493/launcher_2013-06-23-20-21-15-188214",
+    "schema" : {
+        "code" : "atomate",
+        "version" : 0.2
+    },
+    "calcs_reversed" : [
+        {
+            "vasp_version" : "5.2.2",
+            "has_vasp_completed" : true,
+            "nsites" : 16,
+            "is_hubbard" : true,
+            "hubbards" : {
+                "Cl" : 0.0,
+                "O" : 0.0,
+                "Te" : 0.0,
+                "Co" : 3.32
+            },
+            "elements" : [
+                "Cl",
+                "Co",
+                "O",
+                "Te"
+            ],
+            "nelements" : 4,
+            "run_type" : "GGA+U",
+            "input" : {
+                "incar" : {
+                    "ISTART" : 1,
+                    "PREC" : "accurate",
+                    "ALGO" : "Fast",
+                    "ISPIN" : 2,
+                    "ICHARG" : 1,
+                    "NELM" : 100,
+                    "IBRION" : 1,
+                    "EDIFF" : 0.0001,
+                    "NSW" : 99,
+                    "ISIF" : 3,
+                    "ENCUT" : 520.0,
+                    "MAGMOM" : [
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        5.0,
+                        5.0,
+                        5.0,
+                        0.6,
+                        5.0
+                    ],
+                    "LREAL" : "Auto",
+                    "ISMEAR" : -5,
+                    "SIGMA" : 0.2,
+                    "LMAXMIX" : 4,
+                    "LWAVE" : false,
+                    "LORBIT" : false,
+                    "LPEAD" : false,
+                    "LCALCPOL" : false,
+                    "LCALCEPS" : false,
+                    "EFIELD_PEAD" : [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "LEFG" : false,
+                    "LDAU" : true,
+                    "LDAUTYPE" : [
+                        2
+                    ],
+                    "LDAUL" : [
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        2,
+                        0,
+                        2
+                    ],
+                    "LDAUU" : [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        3.32,
+                        0.0,
+                        3.32
+                    ],
+                    "LDAUJ" : [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                    ]
+                },
+                "kpoints" : {
+                    "comment" : "Kpoints from vasprun.xml",
+                    "nkpoints" : 0,
+                    "generation_style" : "Monkhorst",
+                    "kpoints" : [
+                        [
+                            6,
+                            4,
+                            4
+                        ]
+                    ],
+                    "usershift" : [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "kpts_weights" : null,
+                    "coord_type" : null,
+                    "labels" : null,
+                    "tet_number" : 0,
+                    "tet_weight" : 0,
+                    "tet_connections" : null,
+                    "genvec1" : [
+                        0.16666667,
+                        0.0,
+                        0.0
+                    ],
+                    "genvec2" : [
+                        0.0,
+                        0.25,
+                        0.0
+                    ],
+                    "genvec3" : [
+                        0.0,
+                        0.0,
+                        0.25
+                    ],
+                    "shift" : [
+                        0.5,
+                        0.5,
+                        0.5
+                    ],
+                    "@module" : "pymatgen.io.vasp.inputs",
+                    "@class" : "Kpoints",
+                    "actual_points" : [
+                        {
+                            "abc" : [
+                                0.08333333,
+                                0.125,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.25,
+                                0.125,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.41666667,
+                                0.125,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.41666667,
+                                0.125,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.25,
+                                0.125,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.08333333,
+                                0.125,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.08333333,
+                                0.375,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.25,
+                                0.375,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.41666667,
+                                0.375,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.41666667,
+                                0.375,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.25,
+                                0.375,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.08333333,
+                                0.375,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.08333333,
+                                -0.375,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.25,
+                                -0.375,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.41666667,
+                                -0.375,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.41666667,
+                                -0.375,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.25,
+                                -0.375,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.08333333,
+                                -0.375,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.08333333,
+                                -0.125,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.25,
+                                -0.125,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.41666667,
+                                -0.125,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.41666667,
+                                -0.125,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.25,
+                                -0.125,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.08333333,
+                                -0.125,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.08333333,
+                                0.125,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.25,
+                                0.125,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.41666667,
+                                0.125,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.41666667,
+                                0.125,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.25,
+                                0.125,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.08333333,
+                                0.125,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.08333333,
+                                0.375,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.25,
+                                0.375,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.41666667,
+                                0.375,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.41666667,
+                                0.375,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.25,
+                                0.375,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.08333333,
+                                0.375,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.08333333,
+                                -0.375,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.25,
+                                -0.375,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.41666667,
+                                -0.375,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.41666667,
+                                -0.375,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.25,
+                                -0.375,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.08333333,
+                                -0.375,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.08333333,
+                                -0.125,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.25,
+                                -0.125,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.41666667,
+                                -0.125,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.41666667,
+                                -0.125,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.25,
+                                -0.125,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.08333333,
+                                -0.125,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        }
+                    ]
+                },
+                "potcar" : [
+                    "Cl",
+                    "O",
+                    "Te",
+                    "O",
+                    "Cl",
+                    "O",
+                    "Te",
+                    "O",
+                    "Cl",
+                    "Co",
+                    "Cl",
+                    "Co"
+                ],
+                "potcar_spec" : [
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE Te 08Apr2002",
+                        "hash" : "72719856e22fb1d3032df6f96d98a0f2"
+                    },
+                    {
+                        "titel" : "PAW_PBE Te 08Apr2002",
+                        "hash" : "72719856e22fb1d3032df6f96d98a0f2"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE Te 08Apr2002",
+                        "hash" : "72719856e22fb1d3032df6f96d98a0f2"
+                    },
+                    {
+                        "titel" : "PAW_PBE Te 08Apr2002",
+                        "hash" : "72719856e22fb1d3032df6f96d98a0f2"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Co 06Sep2000",
+                        "hash" : "b169bca4e137294d2ab3df8cbdd09083"
+                    },
+                    {
+                        "titel" : "PAW_PBE Co 06Sep2000",
+                        "hash" : "b169bca4e137294d2ab3df8cbdd09083"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Co 06Sep2000",
+                        "hash" : "b169bca4e137294d2ab3df8cbdd09083"
+                    },
+                    {
+                        "titel" : "PAW_PBE Co 06Sep2000",
+                        "hash" : "b169bca4e137294d2ab3df8cbdd09083"
+                    }
+                ],
+                "potcar_type" : [
+                    "PAW_PBE",
+                    "PAW_PBE",
+                    "PAW_PBE",
+                    "PAW_PBE",
+                    "PAW_PBE",
+                    "PAW_PBE",
+                    "PAW_PBE",
+                    "PAW_PBE",
+                    "PAW_PBE",
+                    "PAW_PBE",
+                    "PAW_PBE",
+                    "PAW_PBE"
+                ],
+                "parameters" : {
+                    "SYSTEM" : "unknown system",
+                    "LCOMPAT" : false,
+                    "PREC" : "accura",
+                    "ENMAX" : 520.0,
+                    "ENAUG" : 605.392,
+                    "EDIFF" : 0.0001,
+                    "IALGO" : 68,
+                    "IWAVPR" : 11,
+                    "NBANDS" : 81,
+                    "NELECT" : 112.0,
+                    "ISMEAR" : -5,
+                    "SIGMA" : 0.2,
+                    "LREAL" : true,
+                    "ROPT" : [
+                        -0.00025,
+                        -0.00025,
+                        -0.00025,
+                        -0.00025,
+                        -0.00025,
+                        -0.00025,
+                        -0.00025,
+                        -0.00025,
+                        -0.00025,
+                        -0.00025,
+                        -0.00025,
+                        -0.00025
+                    ],
+                    "LMAXPAW" : -100,
+                    "LMAXMIX" : 4,
+                    "ISTART" : 0,
+                    "ICHARG" : 1,
+                    "INIWAV" : 1,
+                    "ISPIN" : 2,
+                    "LNONCOLLINEAR" : false,
+                    "MAGMOM" : [
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        5.0,
+                        5.0,
+                        5.0,
+                        0.6,
+                        5.0
+                    ],
+                    "NUPDOWN" : -1.0,
+                    "LSORBIT" : false,
+                    "SAXIS" : [
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "LSPIRAL" : false,
+                    "QSPIRAL" : [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "LZEROZ" : false,
+                    "LASPH" : false,
+                    "LMETAGGA" : false,
+                    "NELM" : 100,
+                    "NELMDL" : 0,
+                    "NELMIN" : 2,
+                    "ENINI" : 520.0,
+                    "LDIAG" : true,
+                    "WEIMIN" : 0.001,
+                    "EBREAK" : 3.1e-07,
+                    "DEPER" : 0.3,
+                    "NRMM" : 4,
+                    "TIME" : 0.4,
+                    "AMIX" : 0.4,
+                    "BMIX" : 1.0,
+                    "AMIN" : 0.1,
+                    "AMIX_MAG" : 1.6,
+                    "BMIX_MAG" : 1.0,
+                    "IMIX" : 4,
+                    "MAXMIX" : -45,
+                    "WC" : 100.0,
+                    "INIMIX" : 1,
+                    "MIXPRE" : 1,
+                    "MREMOVE" : 5,
+                    "LDIPOL" : false,
+                    "LMONO" : false,
+                    "IDIPOL" : 0,
+                    "EPSILON" : 1.0,
+                    "DIPOL" : [
+                        -100.0,
+                        -100.0,
+                        -100.0
+                    ],
+                    "EFIELD" : 0.0,
+                    "NGX" : 40,
+                    "NGY" : 50,
+                    "NGZ" : 64,
+                    "NGXF" : 80,
+                    "NGYF" : 100,
+                    "NGZF" : 128,
+                    "ADDGRID" : false,
+                    "NSW" : 99,
+                    "IBRION" : 1,
+                    "ISIF" : 3,
+                    "PSTRESS" : 0.0,
+                    "EDIFFG" : 0.001,
+                    "NFREE" : 0,
+                    "POTIM" : 0.5,
+                    "SMASS" : -3.0,
+                    "TEBEG" : 0.0001,
+                    "TEEND" : 0.0001,
+                    "NBLOCK" : 1,
+                    "KBLOCK" : 99,
+                    "NPACO" : 256,
+                    "APACO" : 16.0,
+                    "ISYM" : 2,
+                    "SYMPREC" : 1e-05,
+                    "LORBIT" : false,
+                    "RWIGS" : [
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0
+                    ],
+                    "NEDOS" : 301,
+                    "EMIN" : 10.0,
+                    "EMAX" : -10.0,
+                    "EFERMI" : 0.0,
+                    "NWRITE" : 2,
+                    "LWAVE" : false,
+                    "LCHARG" : true,
+                    "LPARD" : false,
+                    "LVTOT" : false,
+                    "LELF" : false,
+                    "LOPTICS" : false,
+                    "STM" : [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "NPAR" : 1,
+                    "NSIM" : 4,
+                    "NBLK" : 32,
+                    "LPLANE" : true,
+                    "LSCALAPACK" : false,
+                    "LSCAAWARE" : false,
+                    "LSCALU" : false,
+                    "LASYNC" : false,
+                    "IDIOT" : 3,
+                    "LMUSIC" : false,
+                    "POMASS" : [
+                        35.453,
+                        16.0,
+                        127.6,
+                        16.0,
+                        35.453,
+                        16.0,
+                        127.6,
+                        16.0,
+                        35.453,
+                        58.933,
+                        35.453,
+                        58.933
+                    ],
+                    "LCORR" : true,
+                    "LREAL_COMPAT" : false,
+                    "GGA_COMPAT" : true,
+                    "LBERRY" : false,
+                    "ICORELEVEL" : 0,
+                    "LDAU" : true,
+                    "LDAUTYPE" : [
+                        2
+                    ],
+                    "LDAUL" : [
+                        0
+                    ],
+                    "LDAUU" : [
+                        0.0
+                    ],
+                    "LDAUJ" : [
+                        0.0
+                    ],
+                    "LDAUPRINT" : 0,
+                    "I_CONSTRAINED_M" : 0,
+                    "GGA" : "--",
+                    "VOSKOWN" : 0,
+                    "LHFCALC" : false,
+                    "LHFONE" : false,
+                    "LRHFCALC" : false,
+                    "LTHOMAS" : false,
+                    "LMODELHF" : false,
+                    "ENCUTFOCK" : 0.0,
+                    "ENCUT4O" : -1.0,
+                    "EXXOEP" : 0,
+                    "FOURORBIT" : 0,
+                    "AEXX" : 0.0,
+                    "HFALPHA" : 0.0,
+                    "ALDAX" : 1.0,
+                    "AGGAX" : 1.0,
+                    "ALDAC" : 1.0,
+                    "AGGAC" : 1.0,
+                    "NKREDX" : 1,
+                    "NKREDY" : 1,
+                    "NKREDZ" : 1,
+                    "SHIFTRED" : false,
+                    "ODDONLY" : false,
+                    "EVENONLY" : false,
+                    "LMAXFOCK" : 0,
+                    "NMAXFOCKAE" : 0,
+                    "HFSCREEN" : 0.0,
+                    "HFSCREENC" : 0.0,
+                    "MODEL_GW" : 0,
+                    "MODEL_EPS0" : 10.53420016,
+                    "MODEL_ALPHA" : 1.0,
+                    "LEPSILON" : false,
+                    "LRPA" : false,
+                    "LNABLA" : false,
+                    "LVEL" : false,
+                    "KINTER" : 0,
+                    "CSHIFT" : 0.1,
+                    "OMEGAMAX" : -1.0,
+                    "ORBITALMAG" : false,
+                    "LMAGBLOCH" : false,
+                    "LCHIMAG" : false,
+                    "LGAUGE" : true,
+                    "MAGATOM" : 0,
+                    "MAGDIPOL" : [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "AVECCONST" : [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "LTCTE" : false,
+                    "LTETE" : false,
+                    "L2ORDER" : false,
+                    "LGWLF" : false,
+                    "ENCUTGW" : 346.66666667,
+                    "ENCUTGWSOFT" : -2.0,
+                    "ENCUTLF" : -1.0,
+                    "LMAXMP2" : -1,
+                    "SCISSOR" : 0.0,
+                    "NOMEGA" : 0,
+                    "NOMEGAR" : 0,
+                    "NBANDSGW" : -1,
+                    "NBANDSLF" : -1,
+                    "DIM" : 3,
+                    "ANTIRES" : 0,
+                    "LUSEW" : false,
+                    "OMEGATL" : -200.0,
+                    "OMEGAGRID" : 0,
+                    "SELFENERGY" : false,
+                    "LSPECTRAL" : false,
+                    "ODDONLYGW" : false,
+                    "EVENONLYGW" : false,
+                    "NKREDLFX" : 1,
+                    "NKREDLFY" : 1,
+                    "NKREDLFZ" : 1,
+                    "MAXMEM" : 1024,
+                    "TELESCOPE" : 0
+                },
+                "lattice_rec" : {
+                    "@module" : "pymatgen.core.lattice",
+                    "@class" : "Lattice",
+                    "matrix" : [
+                        [
+                            1.28754424056524,
+                            2.32481115645997e-05,
+                            -0.00469738419272573
+                        ],
+                        [
+                            1.75226515740408e-05,
+                            0.932183889244868,
+                            -7.91635225678835e-06
+                        ],
+                        [
+                            0.203937848142843,
+                            -9.10509407612667e-07,
+                            0.734055033533715
+                        ]
+                    ]
+                },
+                "structure" : {
+                    "@module" : "pymatgen.core.structure",
+                    "@class" : "Structure",
+                    "lattice" : {
+                        "matrix" : [
+                            [
+                                4.87196666,
+                                0.00023939,
+                                -1.35336648
+                            ],
+                            [
+                                0.0002305,
+                                6.73722788,
+                                -0.00039546
+                            ],
+                            [
+                                0.0325234,
+                                -0.00048148,
+                                8.54921124
+                            ]
+                        ],
+                        "a" : 5.05644737168763,
+                        "b" : 6.73722789554934,
+                        "c" : 8.54927311702655,
+                        "alpha" : 90.0065824481013,
+                        "beta" : 105.306607273376,
+                        "gamma" : 89.9944985329069,
+                        "volume" : 280.912004386033
+                    },
+                    "sites" : [
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Cl",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.16054504,
+                                0.74998936,
+                                0.49759572
+                            ],
+                            "xyz" : [
+                                0.798526459495694,
+                                5.05264807638522,
+                                4.03647805594133
+                            ],
+                            "label" : "Cl"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "O",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.76149909,
+                                0.96333395,
+                                0.16142756
+                            ],
+                            "xyz" : [
+                                3.71547039968072,
+                                6.49030491681609,
+                                0.349110007397404
+                            ],
+                            "label" : "O"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "O",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.23853208,
+                                0.46327695,
+                                0.83854001
+                            ],
+                            "xyz" : [
+                                1.18949929859866,
+                                3.12085574565198,
+                                6.84585114970239
+                            ],
+                            "label" : "O"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "O",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.23852166,
+                                0.0366917,
+                                0.83854862
+                            ],
+                            "xyz" : [
+                                1.18935048483241,
+                                0.246853699515226,
+                                6.84610755789285
+                            ],
+                            "label" : "O"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Te",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.40630505,
+                                0.25000793,
+                                0.75409072
+                            ],
+                            "xyz" : [
+                                2.00408787834035,
+                                1.68409458198314,
+                                5.89690235594297
+                            ],
+                            "label" : "Te"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "O",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.74902929,
+                                0.24999573,
+                                0.9267364
+                            ],
+                            "xyz" : [
+                                3.679443970891,
+                                1.68401130711681,
+                                6.90905525046155
+                            ],
+                            "label" : "O"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Cl",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.74549685,
+                                0.75000024,
+                                0.80111274
+                            ],
+                            "xyz" : [
+                                3.65826358347846,
+                                5.05271527166356,
+                                5.8396549984847
+                            ],
+                            "label" : "Cl"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "O",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.25095492,
+                                0.75000564,
+                                0.07329935
+                            ],
+                            "xyz" : [
+                                1.22520082378278,
+                                5.0529836918925,
+                                0.286721052955218
+                            ],
+                            "label" : "O"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Te",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.59366155,
+                                0.74999147,
+                                0.24596015
+                            ],
+                            "xyz" : [
+                                2.90047161230027,
+                                5.05288713319162,
+                                1.29902704511052
+                            ],
+                            "label" : "Te"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "O",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.76148788,
+                                0.53670171,
+                                0.16143891
+                            ],
+                            "xyz" : [
+                                3.71531781534373,
+                                3.61598628683288,
+                                0.349390928168849
+                            ],
+                            "label" : "O"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Cl",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.25450917,
+                                0.24999959,
+                                0.19888962
+                            ],
+                            "xyz" : [
+                                1.24648638247688,
+                                1.68426937331254,
+                                1.35580633045485
+                            ],
+                            "label" : "Cl"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Co",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.23110117,
+                                0.74998843,
+                                0.77457714
+                            ],
+                            "xyz" : [
+                                1.15128194981518,
+                                5.05252534018115,
+                                6.30896242414374
+                            ],
+                            "label" : "Co"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Co",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.76885137,
+                                0.25001225,
+                                0.22538046
+                            ],
+                            "xyz" : [
+                                3.75320600781171,
+                                1.68446504018711,
+                                0.886188619803908
+                            ],
+                            "label" : "Co"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Co",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                1.608e-05,
+                                0.50000858,
+                                1.057e-05
+                            ],
+                            "xyz" : [
+                                0.0001939369739208,
+                                3.36867174417536,
+                                -0.0001291303632384
+                            ],
+                            "label" : "Co"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Cl",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.83947218,
+                                0.25000364,
+                                0.50238286
+                            ],
+                            "xyz" : [
+                                4.10627729750546,
+                                1.68429056745522,
+                                3.15876481775135
+                            ],
+                            "label" : "Cl"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Co",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                1.66e-05,
+                                0.99999283,
+                                9.2e-06
+                            ],
+                            "xyz" : [
+                                0.000311672209151,
+                                6.73717957362036,
+                                -0.0003392703047118
+                            ],
+                            "label" : "Co"
+                        }
+                    ]
+                }
+            },
+            "output" : {
+                "ionic_steps" : [
+                    {
+                        "e_fr_energy" : -79.70597025,
+                        "e_wo_entrp" : -79.70597025,
+                        "e_0_energy" : 0.0,
+                        "forces" : [
+                            [
+                                0.00946619,
+                                -0.00011329,
+                                -0.00936174
+                            ],
+                            [
+                                0.01526707,
+                                -0.01859952,
+                                -0.00593067
+                            ],
+                            [
+                                -0.02568452,
+                                -0.00018406,
+                                0.02017709
+                            ],
+                            [
+                                -0.02160331,
+                                0.008271,
+                                0.01476913
+                            ],
+                            [
+                                -0.01212099,
+                                -0.00938336,
+                                0.01039623
+                            ],
+                            [
+                                -0.00904162,
+                                0.0010074,
+                                0.03964873
+                            ],
+                            [
+                                -0.02812936,
+                                -0.00058494,
+                                -0.03669305
+                            ],
+                            [
+                                0.0109616,
+                                -0.00100911,
+                                -0.03901985
+                            ],
+                            [
+                                0.02258175,
+                                0.00953558,
+                                -0.02740245
+                            ],
+                            [
+                                0.01957412,
+                                0.01005882,
+                                -0.01178317
+                            ],
+                            [
+                                0.02921928,
+                                0.00079021,
+                                0.03611757
+                            ],
+                            [
+                                -0.00081672,
+                                0.00086543,
+                                0.01911479
+                            ],
+                            [
+                                0.00146435,
+                                -0.00085108,
+                                -0.01878646
+                            ],
+                            [
+                                -0.00045952,
+                                -0.00064673,
+                                -0.0003821
+                            ],
+                            [
+                                -0.01013077,
+                                0.00025812,
+                                0.00937059
+                            ],
+                            [
+                                -0.00054754,
+                                0.00058555,
+                                -0.00023464
+                            ]
+                        ],
+                        "stress" : [
+                            [
+                                1.10857549,
+                                -0.09889586,
+                                -0.29784087
+                            ],
+                            [
+                                -0.09889976,
+                                0.85842056,
+                                0.12289575
+                            ],
+                            [
+                                -0.29782352,
+                                0.12289364,
+                                0.3723803
+                            ]
+                        ],
+                        "electronic_steps" : [
+                            {
+                                "alphaZ" : 265.67316889,
+                                "ewald" : -4771.61072577,
+                                "hartreedc" : -3293.04726772,
+                                "XCdc" : 264.34682808,
+                                "pawpsdc" : 5330.08618509,
+                                "pawaedc" : -5437.61689609,
+                                "eentropy" : 0.0,
+                                "bandstr" : 802.77278158,
+                                "atom" : 7933.79896004,
+                                "e_fr_energy" : 1094.40303412,
+                                "e_wo_entrp" : 1094.40303412,
+                                "e_0_energy" : 1094.40303412
+                            },
+                            {
+                                "e_fr_energy" : 106.9632554,
+                                "e_wo_entrp" : 106.9632554,
+                                "e_0_energy" : 106.9632554
+                            },
+                            {
+                                "e_fr_energy" : -69.55713518,
+                                "e_wo_entrp" : -69.55713518,
+                                "e_0_energy" : -69.55713518
+                            },
+                            {
+                                "e_fr_energy" : -79.41417968,
+                                "e_wo_entrp" : -79.41417968,
+                                "e_0_energy" : -79.41417968
+                            },
+                            {
+                                "e_fr_energy" : -79.69636823,
+                                "e_wo_entrp" : -79.69636823,
+                                "e_0_energy" : -79.69636823
+                            },
+                            {
+                                "e_fr_energy" : -79.70494904,
+                                "e_wo_entrp" : -79.70494904,
+                                "e_0_energy" : -79.70494904
+                            },
+                            {
+                                "e_fr_energy" : -79.70599223,
+                                "e_wo_entrp" : -79.70599223,
+                                "e_0_energy" : -79.70599223
+                            },
+                            {
+                                "alphaZ" : 265.67316889,
+                                "ewald" : -4771.61072577,
+                                "hartreedc" : -3292.92576025,
+                                "XCdc" : 264.3448249,
+                                "pawpsdc" : 5329.76709692,
+                                "pawaedc" : -5437.32409727,
+                                "eentropy" : 0.0,
+                                "bandstr" : -371.42943772,
+                                "atom" : 7933.79896004,
+                                "e_fr_energy" : -79.70597025,
+                                "e_wo_entrp" : -79.70597025,
+                                "e_0_energy" : -79.70597025
+                            }
+                        ],
+                        "structure" : {
+                            "@module" : "pymatgen.core.structure",
+                            "@class" : "Structure",
+                            "lattice" : {
+                                "matrix" : [
+                                    [
+                                        4.87196666,
+                                        0.00023939,
+                                        -1.35336648
+                                    ],
+                                    [
+                                        0.0002305,
+                                        6.73722788,
+                                        -0.00039546
+                                    ],
+                                    [
+                                        0.0325234,
+                                        -0.00048148,
+                                        8.54921124
+                                    ]
+                                ],
+                                "a" : 5.05644737168763,
+                                "b" : 6.73722789554934,
+                                "c" : 8.54927311702655,
+                                "alpha" : 90.0065824481013,
+                                "beta" : 105.306607273376,
+                                "gamma" : 89.9944985329069,
+                                "volume" : 280.912004386033
+                            },
+                            "sites" : [
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.16054504,
+                                        0.74998936,
+                                        0.49759572
+                                    ],
+                                    "xyz" : [
+                                        0.798526459495694,
+                                        5.05264807638522,
+                                        4.03647805594133
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76149909,
+                                        0.96333395,
+                                        0.16142756
+                                    ],
+                                    "xyz" : [
+                                        3.71547039968072,
+                                        6.49030491681609,
+                                        0.349110007397404
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23853208,
+                                        0.46327695,
+                                        0.83854001
+                                    ],
+                                    "xyz" : [
+                                        1.18949929859866,
+                                        3.12085574565198,
+                                        6.84585114970239
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23852166,
+                                        0.0366917,
+                                        0.83854862
+                                    ],
+                                    "xyz" : [
+                                        1.18935048483241,
+                                        0.246853699515226,
+                                        6.84610755789285
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Te",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.40630505,
+                                        0.25000793,
+                                        0.75409072
+                                    ],
+                                    "xyz" : [
+                                        2.00408787834035,
+                                        1.68409458198314,
+                                        5.89690235594297
+                                    ],
+                                    "label" : "Te"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.74902929,
+                                        0.24999573,
+                                        0.9267364
+                                    ],
+                                    "xyz" : [
+                                        3.679443970891,
+                                        1.68401130711681,
+                                        6.90905525046155
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.74549685,
+                                        0.75000024,
+                                        0.80111274
+                                    ],
+                                    "xyz" : [
+                                        3.65826358347846,
+                                        5.05271527166356,
+                                        5.8396549984847
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.25095492,
+                                        0.75000564,
+                                        0.07329935
+                                    ],
+                                    "xyz" : [
+                                        1.22520082378278,
+                                        5.0529836918925,
+                                        0.286721052955218
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Te",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.59366155,
+                                        0.74999147,
+                                        0.24596015
+                                    ],
+                                    "xyz" : [
+                                        2.90047161230027,
+                                        5.05288713319162,
+                                        1.29902704511052
+                                    ],
+                                    "label" : "Te"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76148788,
+                                        0.53670171,
+                                        0.16143891
+                                    ],
+                                    "xyz" : [
+                                        3.71531781534373,
+                                        3.61598628683288,
+                                        0.349390928168849
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.25450917,
+                                        0.24999959,
+                                        0.19888962
+                                    ],
+                                    "xyz" : [
+                                        1.24648638247688,
+                                        1.68426937331254,
+                                        1.35580633045485
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23110117,
+                                        0.74998843,
+                                        0.77457714
+                                    ],
+                                    "xyz" : [
+                                        1.15128194981518,
+                                        5.05252534018115,
+                                        6.30896242414374
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76885137,
+                                        0.25001225,
+                                        0.22538046
+                                    ],
+                                    "xyz" : [
+                                        3.75320600781171,
+                                        1.68446504018711,
+                                        0.886188619803908
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        1.608e-05,
+                                        0.50000858,
+                                        1.057e-05
+                                    ],
+                                    "xyz" : [
+                                        0.0001939369739208,
+                                        3.36867174417536,
+                                        -0.0001291303632384
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.83947218,
+                                        0.25000364,
+                                        0.50238286
+                                    ],
+                                    "xyz" : [
+                                        4.10627729750546,
+                                        1.68429056745522,
+                                        3.15876481775135
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        1.66e-05,
+                                        0.99999283,
+                                        9.2e-06
+                                    ],
+                                    "xyz" : [
+                                        0.000311672209151,
+                                        6.73717957362036,
+                                        -0.0003392703047118
+                                    ],
+                                    "label" : "Co"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "e_fr_energy" : -79.70665916,
+                        "e_wo_entrp" : -79.70665916,
+                        "e_0_energy" : 0.0,
+                        "forces" : [
+                            [
+                                0.00355023,
+                                7.23e-05,
+                                0.00446813
+                            ],
+                            [
+                                0.01960538,
+                                0.00083975,
+                                -0.01166286
+                            ],
+                            [
+                                -0.00490824,
+                                -0.02410983,
+                                -0.00784988
+                            ],
+                            [
+                                -0.01232333,
+                                0.01196937,
+                                0.00208189
+                            ],
+                            [
+                                -0.0168019,
+                                0.01477597,
+                                0.0568302
+                            ],
+                            [
+                                -0.02495287,
+                                -0.00095483,
+                                0.02447731
+                            ],
+                            [
+                                -0.0074403,
+                                0.00043293,
+                                -0.01250556
+                            ],
+                            [
+                                0.02238201,
+                                0.00103558,
+                                -0.02601513
+                            ],
+                            [
+                                0.00450905,
+                                -0.01553124,
+                                -0.03735933
+                            ],
+                            [
+                                0.01237108,
+                                0.01153112,
+                                -0.00197831
+                            ],
+                            [
+                                0.00645186,
+                                -0.00027832,
+                                0.01253499
+                            ],
+                            [
+                                -0.00078387,
+                                -0.00141367,
+                                0.00929284
+                            ],
+                            [
+                                7.634e-05,
+                                0.00146444,
+                                -0.00886916
+                            ],
+                            [
+                                0.00040288,
+                                0.00087402,
+                                0.00041075
+                            ],
+                            [
+                                -0.00255353,
+                                4.711e-05,
+                                -0.00428689
+                            ],
+                            [
+                                0.0004152,
+                                -0.00075468,
+                                0.00043102
+                            ]
+                        ],
+                        "stress" : [
+                            [
+                                -0.25181621,
+                                0.06955274,
+                                -0.68307484
+                            ],
+                            [
+                                0.06954893,
+                                -0.34276245,
+                                -0.07519312
+                            ],
+                            [
+                                -0.68308196,
+                                -0.07518809,
+                                -1.36685363
+                            ]
+                        ],
+                        "electronic_steps" : [
+                            {
+                                "alphaZ" : 265.34489536,
+                                "ewald" : -4769.86229319,
+                                "hartreedc" : -3291.51057818,
+                                "XCdc" : 264.18344131,
+                                "pawpsdc" : 5329.7342364,
+                                "pawaedc" : -5437.28517015,
+                                "eentropy" : 0.0,
+                                "bandstr" : -374.11070741,
+                                "atom" : 7933.79896004,
+                                "e_fr_energy" : -79.70721581,
+                                "e_wo_entrp" : -79.70721581,
+                                "e_0_energy" : -79.70721581
+                            },
+                            {
+                                "e_fr_energy" : -79.70675809,
+                                "e_wo_entrp" : -79.70675809,
+                                "e_0_energy" : -79.70675809
+                            },
+                            {
+                                "alphaZ" : 265.34489536,
+                                "ewald" : -4769.86229319,
+                                "hartreedc" : -3293.30795274,
+                                "XCdc" : 264.29437731,
+                                "pawpsdc" : 5329.46190542,
+                                "pawaedc" : -5437.06024173,
+                                "eentropy" : 0.0,
+                                "bandstr" : -372.37630964,
+                                "atom" : 7933.79896004,
+                                "e_fr_energy" : -79.70665916,
+                                "e_wo_entrp" : -79.70665916,
+                                "e_0_energy" : -79.70665916
+                            }
+                        ],
+                        "structure" : {
+                            "@module" : "pymatgen.core.structure",
+                            "@class" : "Structure",
+                            "lattice" : {
+                                "matrix" : [
+                                    [
+                                        4.87503495,
+                                        -0.00010314,
+                                        -1.3544
+                                    ],
+                                    [
+                                        -0.00012155,
+                                        6.74028524,
+                                        4.213e-05
+                                    ],
+                                    [
+                                        0.03119645,
+                                        7.203e-05,
+                                        8.55088908
+                                    ]
+                                ],
+                                "a" : 5.05968033914786,
+                                "b" : 6.74028524122764,
+                                "c" : 8.55094598755858,
+                                "alpha" : 89.9991630075578,
+                                "beta" : 105.317518063952,
+                                "gamma" : 90.0022593505773,
+                                "volume" : 281.25953630278
+                            },
+                            "sites" : [
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.16063903,
+                                        0.74998854,
+                                        0.49755777
+                                    ],
+                                    "xyz" : [
+                                        0.798551760570978,
+                                        5.05515595710777,
+                                        4.03702339694734
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76165034,
+                                        0.96320076,
+                                        0.16141803
+                                    ],
+                                    "xyz" : [
+                                        3.717990619629,
+                                        6.49218093610942,
+                                        0.348729029194131
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23827726,
+                                        0.46327565,
+                                        0.83861353
+                                    ],
+                                    "xyz" : [
+                                        1.18771542419295,
+                                        3.12264585516238,
+                                        6.84818807287639
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23830741,
+                                        0.03675093,
+                                        0.83859805
+                                    ],
+                                    "xyz" : [
+                                        1.18791376765536,
+                                        0.247747576226547,
+                                        6.84799690046697
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Te",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.40618477,
+                                        0.24994075,
+                                        0.75413034
+                                    ],
+                                    "xyz" : [
+                                        2.00366075905484,
+                                        1.68468437421074,
+                                        5.89835876671848
+                                    ],
+                                    "label" : "Te"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.74893836,
+                                        0.25000296,
+                                        0.92694574
+                                    ],
+                                    "xyz" : [
+                                        3.67998770896652,
+                                        1.68508078364351,
+                                        6.91185862375922
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.74521998,
+                                        0.74999604,
+                                        0.80086186
+                                    ],
+                                    "xyz" : [
+                                        3.65786633289204,
+                                        5.05516806256149,
+                                        5.83878658968365
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.25106481,
+                                        0.74999839,
+                                        0.07309656
+                                    ],
+                                    "xyz" : [
+                                        1.22613891434002,
+                                        5.05518244846148,
+                                        0.285029995457735
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Te",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.59388595,
+                                        0.75005973,
+                                        0.24584105
+                                    ],
+                                    "xyz" : [
+                                        2.90279296082804,
+                                        5.05557298177134,
+                                        1.29783201919716
+                                    ],
+                                    "label" : "Te"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76168194,
+                                        0.53677373,
+                                        0.16140314
+                                    ],
+                                    "xyz" : [
+                                        3.71819603842377,
+                                        3.61794111553163,
+                                        0.348540942044956
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.25479684,
+                                        0.25000525,
+                                        0.19913897
+                                    ],
+                                    "xyz" : [
+                                        1.24832554093208,
+                                        1.68509476073144,
+                                        1.35772893660063
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23109237,
+                                        0.74999463,
+                                        0.77468361
+                                    ],
+                                    "xyz" : [
+                                        1.15065959708624,
+                                        5.05520970026165,
+                                        6.31127371254974
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76886657,
+                                        0.25000615,
+                                        0.22527685
+                                    ],
+                                    "xyz" : [
+                                        3.75524885037627,
+                                        1.6850496885477,
+                                        0.884975006992897
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        1.155e-05,
+                                        0.50000395,
+                                        7.69e-06
+                                    ],
+                                    "xyz" : [
+                                        -4.2289257495e-06,
+                                        3.37016924348934,
+                                        7.11781834387e-05
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.83937162,
+                                        0.2500055,
+                                        0.50241981
+                                    ],
+                                    "xyz" : [
+                                        4.10760930985127,
+                                        1.68505799807885,
+                                        3.15930167750839
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        1.119e-05,
+                                        0.99999702,
+                                        7.02e-06
+                                    ],
+                                    "xyz" : [
+                                        -6.67789976115e-05,
+                                        6.7402651533015,
+                                        8.70013797942e-05
+                                    ],
+                                    "label" : "Co"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "efermi" : 2.15092374,
+                "bandgap" : 2.4452,
+                "cbm" : 4.5251,
+                "vbm" : 2.0799,
+                "is_gap_direct" : false,
+                "epsilon_static" : [],
+                "epsilon_static_wolfe" : [],
+                "epsilon_ionic" : [],
+                "structure" : {
+                    "@module" : "pymatgen.core.structure",
+                    "@class" : "Structure",
+                    "lattice" : {
+                        "matrix" : [
+                            [
+                                4.87503495,
+                                -0.00010314,
+                                -1.3544
+                            ],
+                            [
+                                -0.00012155,
+                                6.74028524,
+                                4.213e-05
+                            ],
+                            [
+                                0.03119645,
+                                7.203e-05,
+                                8.55088908
+                            ]
+                        ],
+                        "a" : 5.05968033914786,
+                        "b" : 6.74028524122764,
+                        "c" : 8.55094598755858,
+                        "alpha" : 89.9991630075578,
+                        "beta" : 105.317518063952,
+                        "gamma" : 90.0022593505773,
+                        "volume" : 281.25953630278
+                    },
+                    "sites" : [
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Cl",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.16063903,
+                                0.74998854,
+                                0.49755777
+                            ],
+                            "xyz" : [
+                                0.798551760570978,
+                                5.05515595710777,
+                                4.03702339694734
+                            ],
+                            "label" : "Cl"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "O",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.76165034,
+                                0.96320076,
+                                0.16141803
+                            ],
+                            "xyz" : [
+                                3.717990619629,
+                                6.49218093610942,
+                                0.348729029194131
+                            ],
+                            "label" : "O"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "O",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.23827726,
+                                0.46327565,
+                                0.83861353
+                            ],
+                            "xyz" : [
+                                1.18771542419295,
+                                3.12264585516238,
+                                6.84818807287639
+                            ],
+                            "label" : "O"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "O",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.23830741,
+                                0.03675093,
+                                0.83859805
+                            ],
+                            "xyz" : [
+                                1.18791376765536,
+                                0.247747576226547,
+                                6.84799690046697
+                            ],
+                            "label" : "O"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Te",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.40618477,
+                                0.24994075,
+                                0.75413034
+                            ],
+                            "xyz" : [
+                                2.00366075905484,
+                                1.68468437421074,
+                                5.89835876671848
+                            ],
+                            "label" : "Te"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "O",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.74893836,
+                                0.25000296,
+                                0.92694574
+                            ],
+                            "xyz" : [
+                                3.67998770896652,
+                                1.68508078364351,
+                                6.91185862375922
+                            ],
+                            "label" : "O"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Cl",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.74521998,
+                                0.74999604,
+                                0.80086186
+                            ],
+                            "xyz" : [
+                                3.65786633289204,
+                                5.05516806256149,
+                                5.83878658968365
+                            ],
+                            "label" : "Cl"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "O",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.25106481,
+                                0.74999839,
+                                0.07309656
+                            ],
+                            "xyz" : [
+                                1.22613891434002,
+                                5.05518244846148,
+                                0.285029995457735
+                            ],
+                            "label" : "O"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Te",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.59388595,
+                                0.75005973,
+                                0.24584105
+                            ],
+                            "xyz" : [
+                                2.90279296082804,
+                                5.05557298177134,
+                                1.29783201919716
+                            ],
+                            "label" : "Te"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "O",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.76168194,
+                                0.53677373,
+                                0.16140314
+                            ],
+                            "xyz" : [
+                                3.71819603842377,
+                                3.61794111553163,
+                                0.348540942044956
+                            ],
+                            "label" : "O"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Cl",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.25479684,
+                                0.25000525,
+                                0.19913897
+                            ],
+                            "xyz" : [
+                                1.24832554093208,
+                                1.68509476073144,
+                                1.35772893660063
+                            ],
+                            "label" : "Cl"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Co",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.23109237,
+                                0.74999463,
+                                0.77468361
+                            ],
+                            "xyz" : [
+                                1.15065959708624,
+                                5.05520970026165,
+                                6.31127371254974
+                            ],
+                            "label" : "Co"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Co",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.76886657,
+                                0.25000615,
+                                0.22527685
+                            ],
+                            "xyz" : [
+                                3.75524885037627,
+                                1.6850496885477,
+                                0.884975006992897
+                            ],
+                            "label" : "Co"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Co",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                1.155e-05,
+                                0.50000395,
+                                7.69e-06
+                            ],
+                            "xyz" : [
+                                -4.2289257495e-06,
+                                3.37016924348934,
+                                7.11781834387e-05
+                            ],
+                            "label" : "Co"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Cl",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.83937162,
+                                0.2500055,
+                                0.50241981
+                            ],
+                            "xyz" : [
+                                4.10760930985127,
+                                1.68505799807885,
+                                3.15930167750839
+                            ],
+                            "label" : "Cl"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Co",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                1.119e-05,
+                                0.99999702,
+                                7.02e-06
+                            ],
+                            "xyz" : [
+                                -6.67789976115e-05,
+                                6.7402651533015,
+                                8.70013797942e-05
+                            ],
+                            "label" : "Co"
+                        }
+                    ]
+                },
+                "energy" : -79.70665916,
+                "energy_per_atom" : -4.9816661975,
+                "is_metal" : false,
+                "outcar" : {
+                    "@module" : "pymatgen.io.vasp.outputs",
+                    "@class" : "Outcar",
+                    "efermi" : 2.1509,
+                    "magnetization" : [
+                        {
+                            "s" : 0.003,
+                            "p" : 0.062,
+                            "d" : 0.0,
+                            "tot" : 0.065
+                        },
+                        {
+                            "s" : 0.009,
+                            "p" : 0.072,
+                            "d" : 0.0,
+                            "tot" : 0.081
+                        },
+                        {
+                            "s" : 0.009,
+                            "p" : 0.072,
+                            "d" : 0.0,
+                            "tot" : 0.081
+                        },
+                        {
+                            "s" : 0.009,
+                            "p" : 0.072,
+                            "d" : 0.0,
+                            "tot" : 0.081
+                        },
+                        {
+                            "s" : 0.0,
+                            "p" : 0.026,
+                            "d" : 0.005,
+                            "tot" : 0.032
+                        },
+                        {
+                            "s" : 0.01,
+                            "p" : 0.073,
+                            "d" : 0.0,
+                            "tot" : 0.083
+                        },
+                        {
+                            "s" : 0.01,
+                            "p" : 0.094,
+                            "d" : 0.0,
+                            "tot" : 0.104
+                        },
+                        {
+                            "s" : 0.01,
+                            "p" : 0.073,
+                            "d" : 0.0,
+                            "tot" : 0.083
+                        },
+                        {
+                            "s" : 0.0,
+                            "p" : 0.026,
+                            "d" : 0.005,
+                            "tot" : 0.032
+                        },
+                        {
+                            "s" : 0.009,
+                            "p" : 0.072,
+                            "d" : 0.0,
+                            "tot" : 0.081
+                        },
+                        {
+                            "s" : 0.01,
+                            "p" : 0.094,
+                            "d" : 0.0,
+                            "tot" : 0.104
+                        },
+                        {
+                            "s" : 0.02,
+                            "p" : 0.018,
+                            "d" : 2.645,
+                            "tot" : 2.683
+                        },
+                        {
+                            "s" : 0.02,
+                            "p" : 0.018,
+                            "d" : 2.645,
+                            "tot" : 2.683
+                        },
+                        {
+                            "s" : 0.014,
+                            "p" : 0.01,
+                            "d" : 2.673,
+                            "tot" : 2.697
+                        },
+                        {
+                            "s" : 0.003,
+                            "p" : 0.062,
+                            "d" : 0.0,
+                            "tot" : 0.065
+                        },
+                        {
+                            "s" : 0.014,
+                            "p" : 0.01,
+                            "d" : 2.673,
+                            "tot" : 2.697
+                        }
+                    ],
+                    "charge" : [
+                        {
+                            "s" : 1.597,
+                            "p" : 3.533,
+                            "d" : 0.0,
+                            "tot" : 5.13
+                        },
+                        {
+                            "s" : 1.568,
+                            "p" : 3.467,
+                            "d" : 0.0,
+                            "tot" : 5.036
+                        },
+                        {
+                            "s" : 1.568,
+                            "p" : 3.467,
+                            "d" : 0.0,
+                            "tot" : 5.035
+                        },
+                        {
+                            "s" : 1.568,
+                            "p" : 3.467,
+                            "d" : 0.0,
+                            "tot" : 5.035
+                        },
+                        {
+                            "s" : 1.429,
+                            "p" : 1.538,
+                            "d" : 0.23,
+                            "tot" : 3.197
+                        },
+                        {
+                            "s" : 1.57,
+                            "p" : 3.438,
+                            "d" : 0.0,
+                            "tot" : 5.007
+                        },
+                        {
+                            "s" : 1.597,
+                            "p" : 3.548,
+                            "d" : 0.0,
+                            "tot" : 5.145
+                        },
+                        {
+                            "s" : 1.57,
+                            "p" : 3.438,
+                            "d" : 0.0,
+                            "tot" : 5.008
+                        },
+                        {
+                            "s" : 1.428,
+                            "p" : 1.539,
+                            "d" : 0.231,
+                            "tot" : 3.198
+                        },
+                        {
+                            "s" : 1.568,
+                            "p" : 3.467,
+                            "d" : 0.0,
+                            "tot" : 5.035
+                        },
+                        {
+                            "s" : 1.597,
+                            "p" : 3.548,
+                            "d" : 0.0,
+                            "tot" : 5.145
+                        },
+                        {
+                            "s" : 0.303,
+                            "p" : 0.345,
+                            "d" : 7.092,
+                            "tot" : 7.74
+                        },
+                        {
+                            "s" : 0.303,
+                            "p" : 0.344,
+                            "d" : 7.092,
+                            "tot" : 7.74
+                        },
+                        {
+                            "s" : 0.288,
+                            "p" : 0.34,
+                            "d" : 7.085,
+                            "tot" : 7.713
+                        },
+                        {
+                            "s" : 1.597,
+                            "p" : 3.532,
+                            "d" : 0.0,
+                            "tot" : 5.13
+                        },
+                        {
+                            "s" : 0.288,
+                            "p" : 0.34,
+                            "d" : 7.085,
+                            "tot" : 7.713
+                        }
+                    ],
+                    "total_magnetization" : 12.0000006,
+                    "nelect" : 111.9999991,
+                    "is_stopped" : false
+                }
+            },
+            "formula_pretty" : "Co2TeCl2O3",
+            "composition_reduced" : {
+                "Co" : 2.0,
+                "Te" : 1.0,
+                "Cl" : 2.0,
+                "O" : 3.0
+            },
+            "composition_unit_cell" : {
+                "Cl" : 4.0,
+                "O" : 6.0,
+                "Te" : 2.0,
+                "Co" : 4.0
+            },
+            "formula_anonymous" : "AB2C2D3",
+            "formula_reduced_abc" : "Cl2 Co2 O3 Te1",
+            "dir_name" : "/global/projecta/projectdirs/matgen/garden/block_2013-06-23-09-28-21-424493/launcher_2013-06-23-20-21-15-188214",
+            "completed_at" : "2013-06-23 16:27:42",
+            "task" : {
+                "type" : "relax2",
+                "name" : "relax2"
+            },
+            "output_file_paths" : {}
+        },
+        {
+            "vasp_version" : "5.2.2",
+            "has_vasp_completed" : true,
+            "nsites" : 16,
+            "elements" : [
+                "Cl",
+                "Co",
+                "O",
+                "Te"
+            ],
+            "nelements" : 4,
+            "run_type" : "GGA+U",
+            "input" : {
+                "incar" : {
+                    "PREC" : "accurate",
+                    "ALGO" : "Fast",
+                    "ISPIN" : 2,
+                    "ICHARG" : 1,
+                    "NELM" : 100,
+                    "IBRION" : 1,
+                    "EDIFF" : 0.0001,
+                    "NSW" : 99,
+                    "ISIF" : 3,
+                    "ENCUT" : 520.0,
+                    "MAGMOM" : [
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        5.0,
+                        5.0,
+                        5.0,
+                        0.6,
+                        5.0
+                    ],
+                    "LREAL" : "Auto",
+                    "ISMEAR" : -5,
+                    "SIGMA" : 0.2,
+                    "LMAXMIX" : 4,
+                    "LWAVE" : false,
+                    "LORBIT" : false,
+                    "LPEAD" : false,
+                    "LCALCPOL" : false,
+                    "LCALCEPS" : false,
+                    "EFIELD_PEAD" : [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "LEFG" : false,
+                    "LDAU" : true,
+                    "LDAUTYPE" : [
+                        2
+                    ],
+                    "LDAUL" : [
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        2,
+                        0,
+                        2
+                    ],
+                    "LDAUU" : [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        3.32,
+                        0.0,
+                        3.32
+                    ],
+                    "LDAUJ" : [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                    ]
+                },
+                "kpoints" : {
+                    "comment" : "Kpoints from vasprun.xml",
+                    "nkpoints" : 0,
+                    "generation_style" : "Monkhorst",
+                    "kpoints" : [
+                        [
+                            6,
+                            4,
+                            4
+                        ]
+                    ],
+                    "usershift" : [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "kpts_weights" : null,
+                    "coord_type" : null,
+                    "labels" : null,
+                    "tet_number" : 0,
+                    "tet_weight" : 0,
+                    "tet_connections" : null,
+                    "genvec1" : [
+                        0.16666667,
+                        0.0,
+                        0.0
+                    ],
+                    "genvec2" : [
+                        0.0,
+                        0.25,
+                        0.0
+                    ],
+                    "genvec3" : [
+                        0.0,
+                        0.0,
+                        0.25
+                    ],
+                    "shift" : [
+                        0.5,
+                        0.5,
+                        0.5
+                    ],
+                    "@module" : "pymatgen.io.vasp.inputs",
+                    "@class" : "Kpoints",
+                    "actual_points" : [
+                        {
+                            "abc" : [
+                                0.08333333,
+                                0.125,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.25,
+                                0.125,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.41666667,
+                                0.125,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.41666667,
+                                0.125,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.25,
+                                0.125,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.08333333,
+                                0.125,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.08333333,
+                                0.375,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.25,
+                                0.375,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.41666667,
+                                0.375,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.41666667,
+                                0.375,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.25,
+                                0.375,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.08333333,
+                                0.375,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.08333333,
+                                -0.375,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.25,
+                                -0.375,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.41666667,
+                                -0.375,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.41666667,
+                                -0.375,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.25,
+                                -0.375,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.08333333,
+                                -0.375,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.08333333,
+                                -0.125,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.25,
+                                -0.125,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.41666667,
+                                -0.125,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.41666667,
+                                -0.125,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.25,
+                                -0.125,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.08333333,
+                                -0.125,
+                                0.125
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.08333333,
+                                0.125,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.25,
+                                0.125,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.41666667,
+                                0.125,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.41666667,
+                                0.125,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.25,
+                                0.125,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.08333333,
+                                0.125,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.08333333,
+                                0.375,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.25,
+                                0.375,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.41666667,
+                                0.375,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.41666667,
+                                0.375,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.25,
+                                0.375,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.08333333,
+                                0.375,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.08333333,
+                                -0.375,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.25,
+                                -0.375,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.41666667,
+                                -0.375,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.41666667,
+                                -0.375,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.25,
+                                -0.375,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.08333333,
+                                -0.375,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.08333333,
+                                -0.125,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.25,
+                                -0.125,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                0.41666667,
+                                -0.125,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.41666667,
+                                -0.125,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.25,
+                                -0.125,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        },
+                        {
+                            "abc" : [
+                                -0.08333333,
+                                -0.125,
+                                0.375
+                            ],
+                            "weight" : 0.02083333
+                        }
+                    ]
+                },
+                "potcar" : [
+                    "Cl",
+                    "O",
+                    "Te",
+                    "O",
+                    "Cl",
+                    "O",
+                    "Te",
+                    "O",
+                    "Cl",
+                    "Co",
+                    "Cl",
+                    "Co"
+                ],
+                "potcar_spec" : [
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE Te 08Apr2002",
+                        "hash" : "72719856e22fb1d3032df6f96d98a0f2"
+                    },
+                    {
+                        "titel" : "PAW_PBE Te 08Apr2002",
+                        "hash" : "72719856e22fb1d3032df6f96d98a0f2"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE Te 08Apr2002",
+                        "hash" : "72719856e22fb1d3032df6f96d98a0f2"
+                    },
+                    {
+                        "titel" : "PAW_PBE Te 08Apr2002",
+                        "hash" : "72719856e22fb1d3032df6f96d98a0f2"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE O 08Apr2002",
+                        "hash" : "7a25bc5b9a5393f46600a4939d357982"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Co 06Sep2000",
+                        "hash" : "b169bca4e137294d2ab3df8cbdd09083"
+                    },
+                    {
+                        "titel" : "PAW_PBE Co 06Sep2000",
+                        "hash" : "b169bca4e137294d2ab3df8cbdd09083"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Cl 17Jan2003",
+                        "hash" : "779b9901046c78fe51c5d80224642aeb"
+                    },
+                    {
+                        "titel" : "PAW_PBE Co 06Sep2000",
+                        "hash" : "b169bca4e137294d2ab3df8cbdd09083"
+                    },
+                    {
+                        "titel" : "PAW_PBE Co 06Sep2000",
+                        "hash" : "b169bca4e137294d2ab3df8cbdd09083"
+                    }
+                ],
+                "potcar_type" : [
+                    "PAW_PBE",
+                    "PAW_PBE",
+                    "PAW_PBE",
+                    "PAW_PBE",
+                    "PAW_PBE",
+                    "PAW_PBE",
+                    "PAW_PBE",
+                    "PAW_PBE",
+                    "PAW_PBE",
+                    "PAW_PBE",
+                    "PAW_PBE",
+                    "PAW_PBE"
+                ],
+                "parameters" : {
+                    "SYSTEM" : "unknown system",
+                    "LCOMPAT" : false,
+                    "PREC" : "accura",
+                    "ENMAX" : 520.0,
+                    "ENAUG" : 605.392,
+                    "EDIFF" : 0.0001,
+                    "IALGO" : 68,
+                    "IWAVPR" : 11,
+                    "NBANDS" : 81,
+                    "NELECT" : 112.0,
+                    "ISMEAR" : -5,
+                    "SIGMA" : 0.2,
+                    "LREAL" : true,
+                    "ROPT" : [
+                        -0.00025,
+                        -0.00025,
+                        -0.00025,
+                        -0.00025,
+                        -0.00025,
+                        -0.00025,
+                        -0.00025,
+                        -0.00025,
+                        -0.00025,
+                        -0.00025,
+                        -0.00025,
+                        -0.00025
+                    ],
+                    "LMAXPAW" : -100,
+                    "LMAXMIX" : 4,
+                    "ISTART" : 0,
+                    "ICHARG" : 1,
+                    "INIWAV" : 1,
+                    "ISPIN" : 2,
+                    "LNONCOLLINEAR" : false,
+                    "MAGMOM" : [
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        0.6,
+                        5.0,
+                        5.0,
+                        5.0,
+                        0.6,
+                        5.0
+                    ],
+                    "NUPDOWN" : -1.0,
+                    "LSORBIT" : false,
+                    "SAXIS" : [
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "LSPIRAL" : false,
+                    "QSPIRAL" : [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "LZEROZ" : false,
+                    "LASPH" : false,
+                    "LMETAGGA" : false,
+                    "NELM" : 100,
+                    "NELMDL" : -5,
+                    "NELMIN" : 2,
+                    "ENINI" : 520.0,
+                    "LDIAG" : true,
+                    "WEIMIN" : 0.001,
+                    "EBREAK" : 3.1e-07,
+                    "DEPER" : 0.3,
+                    "NRMM" : 4,
+                    "TIME" : 0.4,
+                    "AMIX" : 0.4,
+                    "BMIX" : 1.0,
+                    "AMIN" : 0.1,
+                    "AMIX_MAG" : 1.6,
+                    "BMIX_MAG" : 1.0,
+                    "IMIX" : 4,
+                    "MAXMIX" : -45,
+                    "WC" : 100.0,
+                    "INIMIX" : 1,
+                    "MIXPRE" : 1,
+                    "MREMOVE" : 5,
+                    "LDIPOL" : false,
+                    "LMONO" : false,
+                    "IDIPOL" : 0,
+                    "EPSILON" : 1.0,
+                    "DIPOL" : [
+                        -100.0,
+                        -100.0,
+                        -100.0
+                    ],
+                    "EFIELD" : 0.0,
+                    "NGX" : 40,
+                    "NGY" : 50,
+                    "NGZ" : 64,
+                    "NGXF" : 80,
+                    "NGYF" : 100,
+                    "NGZF" : 128,
+                    "ADDGRID" : false,
+                    "NSW" : 99,
+                    "IBRION" : 1,
+                    "ISIF" : 3,
+                    "PSTRESS" : 0.0,
+                    "EDIFFG" : 0.001,
+                    "NFREE" : 0,
+                    "POTIM" : 0.5,
+                    "SMASS" : -3.0,
+                    "TEBEG" : 0.0001,
+                    "TEEND" : 0.0001,
+                    "NBLOCK" : 1,
+                    "KBLOCK" : 99,
+                    "NPACO" : 256,
+                    "APACO" : 16.0,
+                    "ISYM" : 2,
+                    "SYMPREC" : 1e-05,
+                    "LORBIT" : false,
+                    "RWIGS" : [
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0
+                    ],
+                    "NEDOS" : 301,
+                    "EMIN" : 10.0,
+                    "EMAX" : -10.0,
+                    "EFERMI" : 0.0,
+                    "NWRITE" : 2,
+                    "LWAVE" : false,
+                    "LCHARG" : true,
+                    "LPARD" : false,
+                    "LVTOT" : false,
+                    "LELF" : false,
+                    "LOPTICS" : false,
+                    "STM" : [
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "NPAR" : 1,
+                    "NSIM" : 4,
+                    "NBLK" : 32,
+                    "LPLANE" : true,
+                    "LSCALAPACK" : false,
+                    "LSCAAWARE" : false,
+                    "LSCALU" : false,
+                    "LASYNC" : false,
+                    "IDIOT" : 3,
+                    "LMUSIC" : false,
+                    "POMASS" : [
+                        35.453,
+                        16.0,
+                        127.6,
+                        16.0,
+                        35.453,
+                        16.0,
+                        127.6,
+                        16.0,
+                        35.453,
+                        58.933,
+                        35.453,
+                        58.933
+                    ],
+                    "LCORR" : true,
+                    "LREAL_COMPAT" : false,
+                    "GGA_COMPAT" : true,
+                    "LBERRY" : false,
+                    "ICORELEVEL" : 0,
+                    "LDAU" : true,
+                    "LDAUTYPE" : [
+                        2
+                    ],
+                    "LDAUL" : [
+                        0
+                    ],
+                    "LDAUU" : [
+                        0.0
+                    ],
+                    "LDAUJ" : [
+                        0.0
+                    ],
+                    "LDAUPRINT" : 0,
+                    "I_CONSTRAINED_M" : 0,
+                    "GGA" : "--",
+                    "VOSKOWN" : 0,
+                    "LHFCALC" : false,
+                    "LHFONE" : false,
+                    "LRHFCALC" : false,
+                    "LTHOMAS" : false,
+                    "LMODELHF" : false,
+                    "ENCUTFOCK" : 0.0,
+                    "ENCUT4O" : -1.0,
+                    "EXXOEP" : 0,
+                    "FOURORBIT" : 0,
+                    "AEXX" : 0.0,
+                    "HFALPHA" : 0.0,
+                    "ALDAX" : 1.0,
+                    "AGGAX" : 1.0,
+                    "ALDAC" : 1.0,
+                    "AGGAC" : 1.0,
+                    "NKREDX" : 1,
+                    "NKREDY" : 1,
+                    "NKREDZ" : 1,
+                    "SHIFTRED" : false,
+                    "ODDONLY" : false,
+                    "EVENONLY" : false,
+                    "LMAXFOCK" : 0,
+                    "NMAXFOCKAE" : 0,
+                    "HFSCREEN" : 0.0,
+                    "HFSCREENC" : 0.0,
+                    "MODEL_GW" : 0,
+                    "MODEL_EPS0" : 10.31900526,
+                    "MODEL_ALPHA" : 1.0,
+                    "LEPSILON" : false,
+                    "LRPA" : false,
+                    "LNABLA" : false,
+                    "LVEL" : false,
+                    "KINTER" : 0,
+                    "CSHIFT" : 0.1,
+                    "OMEGAMAX" : -1.0,
+                    "ORBITALMAG" : false,
+                    "LMAGBLOCH" : false,
+                    "LCHIMAG" : false,
+                    "LGAUGE" : true,
+                    "MAGATOM" : 0,
+                    "MAGDIPOL" : [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "AVECCONST" : [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "LTCTE" : false,
+                    "LTETE" : false,
+                    "L2ORDER" : false,
+                    "LGWLF" : false,
+                    "ENCUTGW" : 346.66666667,
+                    "ENCUTGWSOFT" : -2.0,
+                    "ENCUTLF" : -1.0,
+                    "LMAXMP2" : -1,
+                    "SCISSOR" : 0.0,
+                    "NOMEGA" : 0,
+                    "NOMEGAR" : 0,
+                    "NBANDSGW" : -1,
+                    "NBANDSLF" : -1,
+                    "DIM" : 3,
+                    "ANTIRES" : 0,
+                    "LUSEW" : false,
+                    "OMEGATL" : -200.0,
+                    "OMEGAGRID" : 0,
+                    "SELFENERGY" : false,
+                    "LSPECTRAL" : false,
+                    "ODDONLYGW" : false,
+                    "EVENONLYGW" : false,
+                    "NKREDLFX" : 1,
+                    "NKREDLFY" : 1,
+                    "NKREDLFZ" : 1,
+                    "MAXMEM" : 1024,
+                    "TELESCOPE" : 0
+                },
+                "lattice_rec" : {
+                    "@module" : "pymatgen.core.lattice",
+                    "@class" : "Lattice",
+                    "matrix" : [
+                        [
+                            1.28829954556587,
+                            -4.43641227733992e-05,
+                            -0.00490102555948716
+                        ],
+                        [
+                            -3.12015773925877e-05,
+                            0.932606918914148,
+                            5.26418576014685e-05
+                        ],
+                        [
+                            0.203941785959322,
+                            3.61165266373353e-05,
+                            0.734167429963691
+                        ]
+                    ]
+                },
+                "structure" : {
+                    "@module" : "pymatgen.core.structure",
+                    "@class" : "Structure",
+                    "lattice" : {
+                        "matrix" : [
+                            [
+                                4.85343059,
+                                6.041e-05,
+                                -1.29721956
+                            ],
+                            [
+                                6.911e-05,
+                                6.66863986,
+                                -8.241e-05
+                            ],
+                            [
+                                0.10998805,
+                                -8.619e-05,
+                                8.47259034
+                            ]
+                        ],
+                        "a" : 5.02380006394002,
+                        "b" : 6.66863986086731,
+                        "c" : 8.4733042225588,
+                        "alpha" : 90.0012830945821,
+                        "beta" : 104.220410448655,
+                        "gamma" : 89.9985545579525,
+                        "volume" : 275.17347329123
+                    },
+                    "sites" : [
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Cl",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.16069209,
+                                0.7499791,
+                                0.50056639
+                            ],
+                            "xyz" : [
+                                0.835016057364274,
+                                5.00130708401893,
+                                4.03257923237976
+                            ],
+                            "label" : "Cl"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "O",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.76410709,
+                                0.96455099,
+                                0.16327596
+                            ],
+                            "xyz" : [
+                                3.72656578921308,
+                                6.43227526587078,
+                                0.39207616972046
+                            ],
+                            "label" : "O"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "O",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.23585032,
+                                0.46457567,
+                                0.83671644
+                            ],
+                            "xyz" : [
+                                1.23674407421238,
+                                3.09802996207607,
+                                6.78316769284597
+                            ],
+                            "label" : "O"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "O",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.23586763,
+                                0.03542795,
+                                0.83672884
+                            ],
+                            "xyz" : [
+                                1.23679979254879,
+                                0.236198370632896,
+                                6.7832856641592
+                            ],
+                            "label" : "O"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Te",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.41254978,
+                                0.24997739,
+                                0.75140053
+                            ],
+                            "xyz" : [
+                                2.08494407715086,
+                                1.66696934597329,
+                                5.83112062722247
+                            ],
+                            "label" : "Te"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "O",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.75476504,
+                                0.24998253,
+                                0.92230702
+                            ],
+                            "xyz" : [
+                                3.76465976032233,
+                                1.66700956557566,
+                                6.83521297401371
+                            ],
+                            "label" : "O"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Cl",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.74125699,
+                                0.75000821,
+                                0.80351893
+                            ],
+                            "xyz" : [
+                                3.6860686636335,
+                                5.00151016857144,
+                                5.84625184973383
+                            ],
+                            "label" : "Cl"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "O",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.24522244,
+                                0.75001634,
+                                0.07775203
+                            ],
+                            "xyz" : [
+                                1.19877371944294,
+                                5.00159697301545,
+                                0.340591943727884
+                            ],
+                            "label" : "O"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Te",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.58752069,
+                                0.75003314,
+                                0.24860474
+                            ],
+                            "xyz" : [
+                                2.87888627446757,
+                                5.0017149586073,
+                                1.34412097739845
+                            ],
+                            "label" : "Te"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "O",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.76411473,
+                                0.53544709,
+                                0.16329301
+                            ],
+                            "xyz" : [
+                                3.72657508934851,
+                                3.57073589324131,
+                                0.392246079080718
+                            ],
+                            "label" : "O"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Cl",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.25875702,
+                                0.24998979,
+                                0.19648892
+                            ],
+                            "xyz" : [
+                                1.27748794619703,
+                                1.66709057431859,
+                                1.32908485621913
+                            ],
+                            "label" : "Cl"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Co",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.23316513,
+                                0.75000373,
+                                0.77512103
+                            ],
+                            "xyz" : [
+                                1.2169566578248,
+                                5.00145204685061,
+                                6.26475477595552
+                            ],
+                            "label" : "Co"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Co",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.76679262,
+                                0.24999602,
+                                0.22482379
+                            ],
+                            "xyz" : [
+                                3.7463199655749,
+                                1.66716036819307,
+                                0.910120884056533
+                            ],
+                            "label" : "Co"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Co",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                1.411e-05,
+                                0.50000433,
+                                1.353e-05
+                            ],
+                            "xyz" : [
+                                0.0001045253431877,
+                                3.33434880489683,
+                                5.51250224733e-05
+                            ],
+                            "label" : "Co"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Cl",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.83930639,
+                                0.25001415,
+                                0.49937727
+                            ],
+                            "xyz" : [
+                                4.128458118228,
+                                1.66726198742614,
+                                3.14223376421048
+                            ],
+                            "label" : "Cl"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Co",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                1.794e-05,
+                                0.99999356,
+                                1.156e-05
+                            ],
+                            "xyz" : [
+                                0.0001574515615742,
+                                6.6685969140467,
+                                -7.73844385560001e-06
+                            ],
+                            "label" : "Co"
+                        }
+                    ]
+                }
+            },
+            "output" : {
+                "ionic_steps" : [
+                    {
+                        "e_fr_energy" : -79.62002633,
+                        "e_wo_entrp" : -79.62002633,
+                        "e_0_energy" : 0.0,
+                        "forces" : [
+                            [
+                                -0.04315506,
+                                0.00035431,
+                                -0.2874263
+                            ],
+                            [
+                                -0.21239471,
+                                -0.30871734,
+                                0.11157034
+                            ],
+                            [
+                                0.2176578,
+                                -0.31623822,
+                                -0.11780493
+                            ],
+                            [
+                                0.21628199,
+                                0.31434342,
+                                -0.11704698
+                            ],
+                            [
+                                -0.20414623,
+                                0.00194471,
+                                0.24690134
+                            ],
+                            [
+                                -0.27282087,
+                                0.00088335,
+                                0.04163503
+                            ],
+                            [
+                                0.0419438,
+                                -0.00025288,
+                                -0.12917517
+                            ],
+                            [
+                                0.27264313,
+                                -0.00064435,
+                                -0.04262544
+                            ],
+                            [
+                                0.19622077,
+                                -0.00376705,
+                                -0.2373801
+                            ],
+                            [
+                                -0.21388363,
+                                0.31137711,
+                                0.11263194
+                            ],
+                            [
+                                -0.04267438,
+                                0.00037017,
+                                0.12905829
+                            ],
+                            [
+                                -0.03765601,
+                                -0.0006842,
+                                0.06194264
+                            ],
+                            [
+                                0.03719411,
+                                0.00105286,
+                                -0.06176363
+                            ],
+                            [
+                                0.00034701,
+                                0.00056794,
+                                0.00024055
+                            ],
+                            [
+                                0.04403465,
+                                -0.0002352,
+                                0.28908378
+                            ],
+                            [
+                                0.00040763,
+                                -0.00035462,
+                                0.00015864
+                            ]
+                        ],
+                        "stress" : [
+                            [
+                                6.95102257,
+                                0.02425011,
+                                -3.58641172
+                            ],
+                            [
+                                0.02425697,
+                                16.9251919,
+                                -0.02529413
+                            ],
+                            [
+                                -3.58642498,
+                                -0.02529036,
+                                16.7309935
+                            ]
+                        ],
+                        "electronic_steps" : [
+                            {
+                                "alphaZ" : 271.21357809,
+                                "ewald" : -4808.35925884,
+                                "hartreedc" : -3281.48881068,
+                                "XCdc" : 263.86403288,
+                                "pawpsdc" : 5345.84278029,
+                                "pawaedc" : -5455.51211834,
+                                "eentropy" : 0.0,
+                                "bandstr" : 837.78407636,
+                                "atom" : 7933.79896004,
+                                "e_fr_energy" : 1107.14323981,
+                                "e_wo_entrp" : 1107.14323981,
+                                "e_0_energy" : 1107.14323981
+                            },
+                            {
+                                "e_fr_energy" : 107.8029642,
+                                "e_wo_entrp" : 107.8029642,
+                                "e_0_energy" : 107.8029642
+                            },
+                            {
+                                "e_fr_energy" : -69.07227821,
+                                "e_wo_entrp" : -69.07227821,
+                                "e_0_energy" : -69.07227821
+                            },
+                            {
+                                "e_fr_energy" : -79.04805464,
+                                "e_wo_entrp" : -79.04805464,
+                                "e_0_energy" : -79.04805464
+                            },
+                            {
+                                "e_fr_energy" : -79.33508878,
+                                "e_wo_entrp" : -79.33508878,
+                                "e_0_energy" : -79.33508878
+                            },
+                            {
+                                "e_fr_energy" : -79.50981735,
+                                "e_wo_entrp" : -79.50981735,
+                                "e_0_energy" : -79.50981735
+                            },
+                            {
+                                "e_fr_energy" : -79.54751142,
+                                "e_wo_entrp" : -79.54751142,
+                                "e_0_energy" : -79.54751142
+                            },
+                            {
+                                "e_fr_energy" : -79.55941015,
+                                "e_wo_entrp" : -79.55941015,
+                                "e_0_energy" : -79.55941015
+                            },
+                            {
+                                "e_fr_energy" : -79.5712618,
+                                "e_wo_entrp" : -79.5712618,
+                                "e_0_energy" : -79.5712618
+                            },
+                            {
+                                "e_fr_energy" : -79.57523624,
+                                "e_wo_entrp" : -79.57523624,
+                                "e_0_energy" : -79.57523624
+                            },
+                            {
+                                "e_fr_energy" : -79.58191955,
+                                "e_wo_entrp" : -79.58191955,
+                                "e_0_energy" : -79.58191955
+                            },
+                            {
+                                "e_fr_energy" : -79.58932415,
+                                "e_wo_entrp" : -79.58932415,
+                                "e_0_energy" : -79.58932415
+                            },
+                            {
+                                "e_fr_energy" : -79.60324514,
+                                "e_wo_entrp" : -79.60324514,
+                                "e_0_energy" : -79.60324514
+                            },
+                            {
+                                "e_fr_energy" : -79.60727567,
+                                "e_wo_entrp" : -79.60727567,
+                                "e_0_energy" : -79.60727567
+                            },
+                            {
+                                "e_fr_energy" : -79.61161721,
+                                "e_wo_entrp" : -79.61161721,
+                                "e_0_energy" : -79.61161721
+                            },
+                            {
+                                "e_fr_energy" : -79.61490422,
+                                "e_wo_entrp" : -79.61490422,
+                                "e_0_energy" : -79.61490422
+                            },
+                            {
+                                "e_fr_energy" : -79.61768352,
+                                "e_wo_entrp" : -79.61768352,
+                                "e_0_energy" : -79.61768352
+                            },
+                            {
+                                "e_fr_energy" : -79.61844036,
+                                "e_wo_entrp" : -79.61844036,
+                                "e_0_energy" : -79.61844036
+                            },
+                            {
+                                "e_fr_energy" : -79.61898493,
+                                "e_wo_entrp" : -79.61898493,
+                                "e_0_energy" : -79.61898493
+                            },
+                            {
+                                "e_fr_energy" : -79.61933486,
+                                "e_wo_entrp" : -79.61933486,
+                                "e_0_energy" : -79.61933486
+                            },
+                            {
+                                "e_fr_energy" : -79.61967221,
+                                "e_wo_entrp" : -79.61967221,
+                                "e_0_energy" : -79.61967221
+                            },
+                            {
+                                "e_fr_energy" : -79.61985635,
+                                "e_wo_entrp" : -79.61985635,
+                                "e_0_energy" : -79.61985635
+                            },
+                            {
+                                "e_fr_energy" : -79.61996185,
+                                "e_wo_entrp" : -79.61996185,
+                                "e_0_energy" : -79.61996185
+                            },
+                            {
+                                "alphaZ" : 271.21357809,
+                                "ewald" : -4808.35925884,
+                                "hartreedc" : -3279.92743426,
+                                "XCdc" : 264.85688085,
+                                "pawpsdc" : 5356.13079812,
+                                "pawaedc" : -5464.15819651,
+                                "eentropy" : 0.0,
+                                "bandstr" : -353.17535382,
+                                "atom" : 7933.79896004,
+                                "e_fr_energy" : -79.62002633,
+                                "e_wo_entrp" : -79.62002633,
+                                "e_0_energy" : -79.62002633
+                            }
+                        ],
+                        "structure" : {
+                            "@module" : "pymatgen.core.structure",
+                            "@class" : "Structure",
+                            "lattice" : {
+                                "matrix" : [
+                                    [
+                                        4.85343059,
+                                        6.041e-05,
+                                        -1.29721956
+                                    ],
+                                    [
+                                        6.911e-05,
+                                        6.66863986,
+                                        -8.241e-05
+                                    ],
+                                    [
+                                        0.10998805,
+                                        -8.619e-05,
+                                        8.47259034
+                                    ]
+                                ],
+                                "a" : 5.02380006394002,
+                                "b" : 6.66863986086731,
+                                "c" : 8.4733042225588,
+                                "alpha" : 90.0012830945821,
+                                "beta" : 104.220410448655,
+                                "gamma" : 89.9985545579525,
+                                "volume" : 275.17347329123
+                            },
+                            "sites" : [
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.16069209,
+                                        0.7499791,
+                                        0.50056639
+                                    ],
+                                    "xyz" : [
+                                        0.835016057364274,
+                                        5.00130708401893,
+                                        4.03257923237976
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76410709,
+                                        0.96455099,
+                                        0.16327596
+                                    ],
+                                    "xyz" : [
+                                        3.72656578921308,
+                                        6.43227526587078,
+                                        0.39207616972046
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23585032,
+                                        0.46457567,
+                                        0.83671644
+                                    ],
+                                    "xyz" : [
+                                        1.23674407421238,
+                                        3.09802996207607,
+                                        6.78316769284597
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23586763,
+                                        0.03542795,
+                                        0.83672884
+                                    ],
+                                    "xyz" : [
+                                        1.23679979254879,
+                                        0.236198370632896,
+                                        6.7832856641592
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Te",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.41254978,
+                                        0.24997739,
+                                        0.75140053
+                                    ],
+                                    "xyz" : [
+                                        2.08494407715086,
+                                        1.66696934597329,
+                                        5.83112062722247
+                                    ],
+                                    "label" : "Te"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.75476504,
+                                        0.24998253,
+                                        0.92230702
+                                    ],
+                                    "xyz" : [
+                                        3.76465976032233,
+                                        1.66700956557566,
+                                        6.83521297401371
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.74125699,
+                                        0.75000821,
+                                        0.80351893
+                                    ],
+                                    "xyz" : [
+                                        3.6860686636335,
+                                        5.00151016857144,
+                                        5.84625184973383
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.24522244,
+                                        0.75001634,
+                                        0.07775203
+                                    ],
+                                    "xyz" : [
+                                        1.19877371944294,
+                                        5.00159697301545,
+                                        0.340591943727884
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Te",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.58752069,
+                                        0.75003314,
+                                        0.24860474
+                                    ],
+                                    "xyz" : [
+                                        2.87888627446757,
+                                        5.0017149586073,
+                                        1.34412097739845
+                                    ],
+                                    "label" : "Te"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76411473,
+                                        0.53544709,
+                                        0.16329301
+                                    ],
+                                    "xyz" : [
+                                        3.72657508934851,
+                                        3.57073589324131,
+                                        0.392246079080718
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.25875702,
+                                        0.24998979,
+                                        0.19648892
+                                    ],
+                                    "xyz" : [
+                                        1.27748794619703,
+                                        1.66709057431859,
+                                        1.32908485621913
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23316513,
+                                        0.75000373,
+                                        0.77512103
+                                    ],
+                                    "xyz" : [
+                                        1.2169566578248,
+                                        5.00145204685061,
+                                        6.26475477595552
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76679262,
+                                        0.24999602,
+                                        0.22482379
+                                    ],
+                                    "xyz" : [
+                                        3.7463199655749,
+                                        1.66716036819307,
+                                        0.910120884056533
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        1.411e-05,
+                                        0.50000433,
+                                        1.353e-05
+                                    ],
+                                    "xyz" : [
+                                        0.0001045253431877,
+                                        3.33434880489683,
+                                        5.51250224733e-05
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.83930639,
+                                        0.25001415,
+                                        0.49937727
+                                    ],
+                                    "xyz" : [
+                                        4.128458118228,
+                                        1.66726198742614,
+                                        3.14223376421048
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        1.794e-05,
+                                        0.99999356,
+                                        1.156e-05
+                                    ],
+                                    "xyz" : [
+                                        0.0001574515615742,
+                                        6.6685969140467,
+                                        -7.73844385560001e-06
+                                    ],
+                                    "label" : "Co"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "e_fr_energy" : -79.67416304,
+                        "e_wo_entrp" : -79.67416304,
+                        "e_0_energy" : 0.0,
+                        "forces" : [
+                            [
+                                0.00648512,
+                                -4.462e-05,
+                                -0.00314886
+                            ],
+                            [
+                                0.00453115,
+                                0.10691686,
+                                -0.11407836
+                            ],
+                            [
+                                -0.01061841,
+                                0.11726104,
+                                0.12258921
+                            ],
+                            [
+                                -0.00953802,
+                                -0.11512931,
+                                0.12042213
+                            ],
+                            [
+                                -0.03071565,
+                                -0.00222281,
+                                -0.04023571
+                            ],
+                            [
+                                -0.02409982,
+                                0.00100478,
+                                0.2006915
+                            ],
+                            [
+                                0.13492428,
+                                -0.00058858,
+                                -0.04419044
+                            ],
+                            [
+                                0.02521633,
+                                -0.00108627,
+                                -0.20069214
+                            ],
+                            [
+                                0.03876102,
+                                0.00443989,
+                                0.02896765
+                            ],
+                            [
+                                0.00656711,
+                                -0.11075302,
+                                -0.11750468
+                            ],
+                            [
+                                -0.1344931,
+                                0.00061276,
+                                0.04374877
+                            ],
+                            [
+                                -0.04142719,
+                                -4.284e-05,
+                                -0.06490821
+                            ],
+                            [
+                                0.04147275,
+                                -0.00032162,
+                                0.06486384
+                            ],
+                            [
+                                -0.00019875,
+                                -0.00037306,
+                                -0.00034301
+                            ],
+                            [
+                                -0.0064927,
+                                -0.00011681,
+                                0.00396751
+                            ],
+                            [
+                                -0.00037411,
+                                0.00044359,
+                                -0.00014923
+                            ]
+                        ],
+                        "stress" : [
+                            [
+                                -1.22708945,
+                                -0.03577723,
+                                -3.55987104
+                            ],
+                            [
+                                -0.03577522,
+                                1.28384878,
+                                0.04145048
+                            ],
+                            [
+                                -3.5598628,
+                                0.04144923,
+                                0.13164555
+                            ]
+                        ],
+                        "electronic_steps" : [
+                            {
+                                "alphaZ" : 265.59255881,
+                                "ewald" : -4783.40661256,
+                                "hartreedc" : -3246.8985217,
+                                "XCdc" : 262.16509213,
+                                "pawpsdc" : 5356.10906106,
+                                "pawaedc" : -5464.13909279,
+                                "eentropy" : 0.0,
+                                "bandstr" : -403.17815504,
+                                "atom" : 7933.79896004,
+                                "e_fr_energy" : -79.95671004,
+                                "e_wo_entrp" : -79.95671004,
+                                "e_0_energy" : -79.95671004
+                            },
+                            {
+                                "e_fr_energy" : -79.71234733,
+                                "e_wo_entrp" : -79.71234733,
+                                "e_0_energy" : -79.71234733
+                            },
+                            {
+                                "e_fr_energy" : -79.67863973,
+                                "e_wo_entrp" : -79.67863973,
+                                "e_0_energy" : -79.67863973
+                            },
+                            {
+                                "e_fr_energy" : -79.67494131,
+                                "e_wo_entrp" : -79.67494131,
+                                "e_0_energy" : -79.67494131
+                            },
+                            {
+                                "e_fr_energy" : -79.67435008,
+                                "e_wo_entrp" : -79.67435008,
+                                "e_0_energy" : -79.67435008
+                            },
+                            {
+                                "e_fr_energy" : -79.67410738,
+                                "e_wo_entrp" : -79.67410738,
+                                "e_0_energy" : -79.67410738
+                            },
+                            {
+                                "alphaZ" : 265.59255881,
+                                "ewald" : -4783.40661256,
+                                "hartreedc" : -3279.80365223,
+                                "XCdc" : 264.30004373,
+                                "pawpsdc" : 5331.07886014,
+                                "pawaedc" : -5438.60461366,
+                                "eentropy" : 0.0,
+                                "bandstr" : -372.62970732,
+                                "atom" : 7933.79896004,
+                                "e_fr_energy" : -79.67416304,
+                                "e_wo_entrp" : -79.67416304,
+                                "e_0_energy" : -79.67416304
+                            }
+                        ],
+                        "structure" : {
+                            "@module" : "pymatgen.core.structure",
+                            "@class" : "Structure",
+                            "lattice" : {
+                                "matrix" : [
+                                    [
+                                        4.87331032,
+                                        0.00013888,
+                                        -1.31747291
+                                    ],
+                                    [
+                                        0.00015328,
+                                        6.727089,
+                                        -0.0001706
+                                    ],
+                                    [
+                                        0.0946483,
+                                        -0.00019653,
+                                        8.54579436
+                                    ]
+                                ],
+                                "a" : 5.04825597240176,
+                                "b" : 6.7270890039095,
+                                "c" : 8.54631848123651,
+                                "alpha" : 90.0027560484592,
+                                "beta" : 104.493424596841,
+                                "gamma" : 89.9967842891682,
+                                "volume" : 280.997264034194
+                            },
+                            "sites" : [
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.16030158,
+                                        0.74998164,
+                                        0.49887
+                                    ],
+                                    "xyz" : [
+                                        0.828531498733085,
+                                        5.04511746040829,
+                                        4.05191949642522
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76198889,
+                                        0.96231767,
+                                        0.1635869
+                                    ],
+                                    "xyz" : [
+                                        3.72903904740207,
+                                        6.47367028764622,
+                                        0.393916115699412
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23802152,
+                                        0.4622879,
+                                        0.83637806
+                                    ],
+                                    "xyz" : [
+                                        1.2391853508237,
+                                        3.10972052997167,
+                                        6.83384913706298
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23802504,
+                                        0.03770197,
+                                        0.83639272
+                                    ],
+                                    "xyz" : [
+                                        1.23913881188875,
+                                        0.253493188321624,
+                                        6.83404221526331
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Te",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.41049585,
+                                        0.24999149,
+                                        0.75249191
+                                    ],
+                                    "xyz" : [
+                                        2.07173406086301,
+                                        1.68162412490119,
+                                        5.88978130983301
+                                    ],
+                                    "label" : "Te"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.75205725,
+                                        0.24998894,
+                                        0.92212951
+                                    ],
+                                    "xyz" : [
+                                        3.75232466646188,
+                                        1.68162106799394,
+                                        6.8894714639903
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.74168907,
+                                        0.75000637,
+                                        0.80284957
+                                    ],
+                                    "xyz" : [
+                                        3.69058430699483,
+                                        5.04530482330898,
+                                        5.88370411877961
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.2479286,
+                                        0.75001165,
+                                        0.07792366
+                                    ],
+                                    "xyz" : [
+                                        1.21572330873764,
+                                        5.04541423857392,
+                                        0.339152408036842
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Te",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.58949489,
+                                        0.75000586,
+                                        0.24755537
+                                    ],
+                                    "xyz" : [
+                                        2.89633718684886,
+                                        5.045389387735,
+                                        1.33878578557557
+                                    ],
+                                    "label" : "Te"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76198158,
+                                        0.5376997,
+                                        0.16360775
+                                    ],
+                                    "xyz" : [
+                                        3.72894031147825,
+                                        3.61722740734402,
+                                        0.394176366064472
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.25831771,
+                                        0.24999248,
+                                        0.19715651
+                                    ],
+                                    "xyz" : [
+                                        1.27756120933453,
+                                        1.68171879028537,
+                                        1.34448975737996
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23278416,
+                                        0.74999879,
+                                        0.77541541
+                                    ],
+                                    "xyz" : [
+                                        1.20793615942537,
+                                        5.04518854689592,
+                                        6.31972586296441
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76716899,
+                                        0.25000363,
+                                        0.22452973
+                                    ],
+                                    "xyz" : [
+                                        3.75994223395134,
+                                        1.68185908693456,
+                                        0.908017887949984
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        1.751e-05,
+                                        0.50000844,
+                                        1.542e-05
+                                    ],
+                                    "xyz" : [
+                                        0.0001634324341724,
+                                        3.36360127603246,
+                                        2.34057585131e-05
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.8397054,
+                                        0.25001247,
+                                        0.50108439
+                                    ],
+                                    "xyz" : [
+                                        4.13961009916117,
+                                        1.68187427697062,
+                                        3.17583238493794
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        2.196e-05,
+                                        0.99999099,
+                                        1.308e-05
+                                    ],
+                                    "xyz" : [
+                                        0.0002615345133384,
+                                        6.7270283894073,
+                                        -8.77511777688e-05
+                                    ],
+                                    "label" : "Co"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "e_fr_energy" : -79.68227778,
+                        "e_wo_entrp" : -79.68227778,
+                        "e_0_energy" : 0.0,
+                        "forces" : [
+                            [
+                                -0.00456832,
+                                0.00029432,
+                                -0.03803005
+                            ],
+                            [
+                                -0.06976719,
+                                -0.04241796,
+                                0.01116367
+                            ],
+                            [
+                                0.07652974,
+                                -0.05397549,
+                                -0.01987664
+                            ],
+                            [
+                                0.07470403,
+                                0.05076917,
+                                -0.01793897
+                            ],
+                            [
+                                -0.15299433,
+                                0.00277747,
+                                0.24819119
+                            ],
+                            [
+                                -0.08277096,
+                                -0.000167,
+                                0.11069304
+                            ],
+                            [
+                                0.08667091,
+                                0.00011478,
+                                -0.05251929
+                            ],
+                            [
+                                0.08145027,
+                                0.00028169,
+                                -0.11185556
+                            ],
+                            [
+                                0.14546473,
+                                -0.00538121,
+                                -0.23597384
+                            ],
+                            [
+                                -0.07246812,
+                                0.04755731,
+                                0.01432551
+                            ],
+                            [
+                                -0.08729012,
+                                -8.003e-05,
+                                0.05241377
+                            ],
+                            [
+                                -0.02961264,
+                                -0.00053011,
+                                -0.01021237
+                            ],
+                            [
+                                0.02907,
+                                0.00081592,
+                                0.01047468
+                            ],
+                            [
+                                0.00021057,
+                                0.00060335,
+                                0.00018613
+                            ],
+                            [
+                                0.00515782,
+                                -0.00019386,
+                                0.0389091
+                            ],
+                            [
+                                0.00021361,
+                                -0.00046836,
+                                4.965e-05
+                            ]
+                        ],
+                        "stress" : [
+                            [
+                                -3.07779505,
+                                0.03791138,
+                                -1.32818293
+                            ],
+                            [
+                                0.03790942,
+                                -2.86491439,
+                                -0.0501616
+                            ],
+                            [
+                                -1.32820209,
+                                -0.05015391,
+                                -1.53193921
+                            ]
+                        ],
+                        "electronic_steps" : [
+                            {
+                                "alphaZ" : 265.56824532,
+                                "ewald" : -4781.55847949,
+                                "hartreedc" : -3282.94035091,
+                                "XCdc" : 264.28142865,
+                                "pawpsdc" : 5330.46613643,
+                                "pawaedc" : -5437.98077719,
+                                "eentropy" : 0.0,
+                                "bandstr" : -371.31233048,
+                                "atom" : 7933.79896004,
+                                "e_fr_energy" : -79.67716764,
+                                "e_wo_entrp" : -79.67716764,
+                                "e_0_energy" : -79.67716764
+                            },
+                            {
+                                "e_fr_energy" : -79.68342676,
+                                "e_wo_entrp" : -79.68342676,
+                                "e_0_energy" : -79.68342676
+                            },
+                            {
+                                "e_fr_energy" : -79.68263073,
+                                "e_wo_entrp" : -79.68263073,
+                                "e_0_energy" : -79.68263073
+                            },
+                            {
+                                "e_fr_energy" : -79.68222095,
+                                "e_wo_entrp" : -79.68222095,
+                                "e_0_energy" : -79.68222095
+                            },
+                            {
+                                "alphaZ" : 265.56824532,
+                                "ewald" : -4781.55847949,
+                                "hartreedc" : -3282.88641277,
+                                "XCdc" : 264.23937498,
+                                "pawpsdc" : 5328.80441215,
+                                "pawaedc" : -5436.32977926,
+                                "eentropy" : 0.0,
+                                "bandstr" : -371.31859876,
+                                "atom" : 7933.79896004,
+                                "e_fr_energy" : -79.68227778,
+                                "e_wo_entrp" : -79.68227778,
+                                "e_0_energy" : -79.68227778
+                            }
+                        ],
+                        "structure" : {
+                            "@module" : "pymatgen.core.structure",
+                            "@class" : "Structure",
+                            "lattice" : {
+                                "matrix" : [
+                                    [
+                                        4.87265857,
+                                        2.329e-05,
+                                        -1.32632573
+                                    ],
+                                    [
+                                        3.19e-05,
+                                        6.73145258,
+                                        -3.001e-05
+                                    ],
+                                    [
+                                        0.07921909,
+                                        -1.94e-05,
+                                        8.54619253
+                                    ]
+                                ],
+                                "a" : 5.04994470092464,
+                                "b" : 6.73145258014248,
+                                "c" : 8.54655968354663,
+                                "alpha" : 90.0003829637163,
+                                "beta" : 104.695776223085,
+                                "gamma" : 89.9994066785021,
+                                "volume" : 281.022989943888
+                            },
+                            "sites" : [
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.16036306,
+                                        0.74998133,
+                                        0.4988625
+                                    ],
+                                    "xyz" : [
+                                        0.820937796309976,
+                                        5.0484578157035,
+                                        4.05065881143788
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76204351,
+                                        0.96305023,
+                                        0.16298004
+                                    ],
+                                    "xyz" : [
+                                        3.72611969147368,
+                                        6.48274154158366,
+                                        0.382111984557187
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23790856,
+                                        0.46309137,
+                                        0.83702186
+                                    ],
+                                    "xyz" : [
+                                        1.22557006643437,
+                                        3.11726690002851,
+                                        6.83779182549144
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23792254,
+                                        0.03691315,
+                                        0.83702641
+                                    ],
+                                    "xyz" : [
+                                        1.22562495156282,
+                                        0.24846842170703,
+                                        6.83782495824213
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Te",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.4102104,
+                                        0.24997626,
+                                        0.75223089
+                                    ],
+                                    "xyz" : [
+                                        2.05841424188151,
+                                        1.6826983008367,
+                                        5.8846299029321
+                                    ],
+                                    "label" : "Te"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.75180903,
+                                        0.24999586,
+                                        0.92317369
+                                    ],
+                                    "xyz" : [
+                                        3.73644966753456,
+                                        1.68283487684904,
+                                        6.89246893045944
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.74296602,
+                                        0.75000231,
+                                        0.80280808
+                                    ],
+                                    "xyz" : [
+                                        3.68384139518773,
+                                        5.04860671385731,
+                                        5.87551495990863
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.24818735,
+                                        0.75000417,
+                                        0.0768811
+                                    ],
+                                    "xyz" : [
+                                        1.21544659385631,
+                                        5.0486217939473,
+                                        0.327840906727526
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Te",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.58985738,
+                                        0.75003628,
+                                        0.2477675
+                                    ],
+                                    "xyz" : [
+                                        2.89382545977365,
+                                        5.04884258318848,
+                                        1.33510322896363
+                                    ],
+                                    "label" : "Te"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76205581,
+                                        0.53694082,
+                                        0.16298541
+                                    ],
+                                    "xyz" : [
+                                        3.72616645769043,
+                                        3.61440625445918,
+                                        0.382154351347988
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.25704488,
+                                        0.24999671,
+                                        0.19719625
+                                    ],
+                                    "xyz" : [
+                                        1.26812161977808,
+                                        1.68284315948902,
+                                        1.34434437818398
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23240028,
+                                        0.74999849,
+                                        0.77500613
+                                    ],
+                                    "xyz" : [
+                                        1.19382642132725,
+                                        5.0485696479902,
+                                        6.31509062043232
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.7675533,
+                                        0.25000143,
+                                        0.22493883
+                                    ],
+                                    "xyz" : [
+                                        3.75785258964066,
+                                        1.68288628348024,
+                                        0.904337355173617
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        1.567e-05,
+                                        0.50000588,
+                                        1.329e-05
+                                    ],
+                                    "xyz" : [
+                                        9.335756907e-05,
+                                        3.3657658710483,
+                                        7.77901980758e-05
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.83964376,
+                                        0.25001167,
+                                        0.50109629
+                                    ],
+                                    "xyz" : [
+                                        4.13100173037947,
+                                        1.68295153508675,
+                                        3.16881674463655
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        1.845e-05,
+                                        0.99999403,
+                                        1.173e-05
+                                    ],
+                                    "xyz" : [
+                                        0.0001227296000992,
+                                        6.73141239343024,
+                                        4.57663078181e-05
+                                    ],
+                                    "label" : "Co"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "e_fr_energy" : -79.68662608,
+                        "e_wo_entrp" : -79.68662608,
+                        "e_0_energy" : 0.0,
+                        "forces" : [
+                            [
+                                0.0053242,
+                                0.00018544,
+                                -0.03754055
+                            ],
+                            [
+                                0.00187128,
+                                0.04629296,
+                                -0.07523858
+                            ],
+                            [
+                                -0.00244692,
+                                0.047013,
+                                0.0764372
+                            ],
+                            [
+                                -0.00234956,
+                                -0.04698279,
+                                0.0758999
+                            ],
+                            [
+                                -0.03705814,
+                                -0.00037182,
+                                -0.01246545
+                            ],
+                            [
+                                -0.02744429,
+                                0.00019267,
+                                0.13915147
+                            ],
+                            [
+                                0.0579935,
+                                -4.825e-05,
+                                -0.05302216
+                            ],
+                            [
+                                0.02816044,
+                                -0.00019125,
+                                -0.13909478
+                            ],
+                            [
+                                0.03704326,
+                                0.00096442,
+                                0.01078627
+                            ],
+                            [
+                                0.00225401,
+                                -0.04672037,
+                                -0.07609565
+                            ],
+                            [
+                                -0.05799282,
+                                8.54e-06,
+                                0.05297593
+                            ],
+                            [
+                                -0.02914619,
+                                -0.00019797,
+                                -0.01874851
+                            ],
+                            [
+                                0.02918502,
+                                8.728e-05,
+                                0.01911915
+                            ],
+                            [
+                                -1.947e-05,
+                                3.235e-05,
+                                -0.00010503
+                            ],
+                            [
+                                -0.00529712,
+                                -0.00022176,
+                                0.03798497
+                            ],
+                            [
+                                -7.72e-05,
+                                -4.247e-05,
+                                -4.419e-05
+                            ]
+                        ],
+                        "stress" : [
+                            [
+                                0.06940516,
+                                0.002463,
+                                -2.4463083
+                            ],
+                            [
+                                0.0024625,
+                                1.91939873,
+                                -0.0014516
+                            ],
+                            [
+                                -2.44629106,
+                                -0.00143919,
+                                1.63922224
+                            ]
+                        ],
+                        "electronic_steps" : [
+                            {
+                                "alphaZ" : 266.12462709,
+                                "ewald" : -4781.67849016,
+                                "hartreedc" : -3287.7580904,
+                                "XCdc" : 264.56336065,
+                                "pawpsdc" : 5328.74835523,
+                                "pawaedc" : -5436.27137767,
+                                "eentropy" : 0.0,
+                                "bandstr" : -367.21538025,
+                                "atom" : 7933.79896004,
+                                "e_fr_energy" : -79.68803546,
+                                "e_wo_entrp" : -79.68803546,
+                                "e_0_energy" : -79.68803546
+                            },
+                            {
+                                "e_fr_energy" : -79.68685031,
+                                "e_wo_entrp" : -79.68685031,
+                                "e_0_energy" : -79.68685031
+                            },
+                            {
+                                "e_fr_energy" : -79.68666678,
+                                "e_wo_entrp" : -79.68666678,
+                                "e_0_energy" : -79.68666678
+                            },
+                            {
+                                "alphaZ" : 266.12462709,
+                                "ewald" : -4781.67849016,
+                                "hartreedc" : -3284.4203262,
+                                "XCdc" : 264.38747052,
+                                "pawpsdc" : 5331.17852793,
+                                "pawaedc" : -5438.66780965,
+                                "eentropy" : 0.0,
+                                "bandstr" : -370.40958566,
+                                "atom" : 7933.79896004,
+                                "e_fr_energy" : -79.68662608,
+                                "e_wo_entrp" : -79.68662608,
+                                "e_0_energy" : -79.68662608
+                            }
+                        ],
+                        "structure" : {
+                            "@module" : "pymatgen.core.structure",
+                            "@class" : "Structure",
+                            "lattice" : {
+                                "matrix" : [
+                                    [
+                                        4.86896615,
+                                        9.524e-05,
+                                        -1.3274378
+                                    ],
+                                    [
+                                        0.00010503,
+                                        6.72599454,
+                                        -0.00012651
+                                    ],
+                                    [
+                                        0.07620218,
+                                        -0.00014103,
+                                        8.54249533
+                                    ]
+                                ],
+                                "a" : 5.04667439922424,
+                                "b" : 6.72599454200982,
+                                "c" : 8.5428352000491,
+                                "alpha" : 90.0020155306534,
+                                "beta" : 104.738971987398,
+                                "gamma" : 89.9977720592412,
+                                "volume" : 280.435460817849
+                            },
+                            "sites" : [
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.16034014,
+                                        0.74998245,
+                                        0.49874565
+                                    ],
+                                    "xyz" : [
+                                        0.818774990598501,
+                                        5.04432279649174,
+                                        4.04759594300977
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76167777,
+                                        0.96287871,
+                                        0.16296563
+                                    ],
+                                    "xyz" : [
+                                        3.72110274675947,
+                                        6.47636650529026,
+                                        0.3809314561222
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.2383109,
+                                        0.462875,
+                                        0.83701527
+                                    ],
+                                    "xyz" : [
+                                        1.22415870930457,
+                                        3.11319937516909,
+                                        6.83379757998542
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23831509,
+                                        0.03711714,
+                                        0.83702425
+                                    ],
+                                    "xyz" : [
+                                        1.22413507722028,
+                                        0.24955433257961,
+                                        6.83392259225597
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Te",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.40940348,
+                                        0.24998701,
+                                        0.7528498
+                                    ],
+                                    "xyz" : [
+                                        2.05076673792043,
+                                        1.68134408151107,
+                                        5.88772662003125
+                                    ],
+                                    "label" : "Te"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.751375,
+                                        0.24999513,
+                                        0.92342093
+                                    ],
+                                    "xyz" : [
+                                        3.72881238586838,
+                                        1.68140721030783,
+                                        6.89088377829036
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.74340252,
+                                        0.7500028,
+                                        0.80272255
+                                    ],
+                                    "xyz" : [
+                                        3.68084968674394,
+                                        5.04447233147949,
+                                        5.87033814614321
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.24861439,
+                                        0.75000535,
+                                        0.0766293
+                                    ],
+                                    "xyz" : [
+                                        1.21641314208668,
+                                        5.04454476007511,
+                                        0.324490415304398
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Te",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.59062326,
+                                        0.75001543,
+                                        0.24717958
+                                    ],
+                                    "xyz" : [
+                                        2.89463905731075,
+                                        5.04462107831887,
+                                        1.32741988248608
+                                    ],
+                                    "label" : "Te"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76167552,
+                                        0.53713221,
+                                        0.16297845
+                                    ],
+                                    "xyz" : [
+                                        3.72104805234269,
+                                        3.61279786884385,
+                                        0.381097818837095
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.25660508,
+                                        0.24999634,
+                                        0.19728099
+                                    ],
+                                    "xyz" : [
+                                        1.26446094706419,
+                                        1.68147063438978,
+                                        1.34461302587178
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23225174,
+                                        0.74999649,
+                                        0.77495772
+                                    ],
+                                    "xyz" : [
+                                        1.18995810014178,
+                                        5.04438512412763,
+                                        6.31167808319973
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76769899,
+                                        0.25000456,
+                                        0.22498759
+                                    ],
+                                    "xyz" : [
+                                        3.75507119850907,
+                                        1.68157069118709,
+                                        0.902851150458247
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        1.679e-05,
+                                        0.50000821,
+                                        1.405e-05
+                                    ],
+                                    "xyz" : [
+                                        0.0001353364445838,
+                                        3.36305249003278,
+                                        3.44783400774e-05
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.83966972,
+                                        0.25001095,
+                                        0.50121617
+                                    ],
+                                    "xyz" : [
+                                        4.12654346731531,
+                                        1.68158156826789,
+                                        3.16699583681679
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        1.961e-05,
+                                        0.99999221,
+                                        1.207e-05
+                                    ],
+                                    "xyz" : [
+                                        0.0002014293683304,
+                                        6.72594214466796,
+                                        -4.9432151112e-05
+                                    ],
+                                    "label" : "Co"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "e_fr_energy" : -79.69348361,
+                        "e_wo_entrp" : -79.69348361,
+                        "e_0_energy" : 0.0,
+                        "forces" : [
+                            [
+                                0.0039749,
+                                -4.338e-05,
+                                -0.03505036
+                            ],
+                            [
+                                0.01285508,
+                                0.02428651,
+                                -0.06265743
+                            ],
+                            [
+                                -0.01941503,
+                                0.0355016,
+                                0.07177183
+                            ],
+                            [
+                                -0.01765841,
+                                -0.03221989,
+                                0.06921166
+                            ],
+                            [
+                                -0.01662109,
+                                -0.00362581,
+                                -0.01907612
+                            ],
+                            [
+                                -0.02596681,
+                                0.00061768,
+                                0.1105114
+                            ],
+                            [
+                                0.02738414,
+                                -0.00039527,
+                                -0.05871135
+                            ],
+                            [
+                                0.02679989,
+                                -0.00060431,
+                                -0.11006495
+                            ],
+                            [
+                                0.0249161,
+                                0.00503755,
+                                0.00654013
+                            ],
+                            [
+                                0.01537186,
+                                -0.02886202,
+                                -0.0661657
+                            ],
+                            [
+                                -0.02685556,
+                                0.0004618,
+                                0.05860747
+                            ],
+                            [
+                                -0.01628391,
+                                0.00026949,
+                                -0.00795029
+                            ],
+                            [
+                                0.01662608,
+                                -0.00042184,
+                                0.00820744
+                            ],
+                            [
+                                -0.00038514,
+                                -0.00057245,
+                                -0.00030497
+                            ],
+                            [
+                                -0.0042783,
+                                -1.342e-05,
+                                0.03529349
+                            ],
+                            [
+                                -0.00046382,
+                                0.00058374,
+                                -0.00016226
+                            ]
+                        ],
+                        "stress" : [
+                            [
+                                0.48479651,
+                                -0.05171325,
+                                -1.54078249
+                            ],
+                            [
+                                -0.05171108,
+                                1.52101847,
+                                0.0569636
+                            ],
+                            [
+                                -1.54078422,
+                                0.05695185,
+                                0.82941783
+                            ]
+                        ],
+                        "electronic_steps" : [
+                            {
+                                "alphaZ" : 266.00303505,
+                                "ewald" : -4777.27319426,
+                                "hartreedc" : -3287.93871852,
+                                "XCdc" : 264.35110602,
+                                "pawpsdc" : 5332.02206702,
+                                "pawaedc" : -5439.55284916,
+                                "eentropy" : 0.0,
+                                "bandstr" : -371.10104082,
+                                "atom" : 7933.79896004,
+                                "e_fr_energy" : -79.69063463,
+                                "e_wo_entrp" : -79.69063463,
+                                "e_0_energy" : -79.69063463
+                            },
+                            {
+                                "e_fr_energy" : -79.69460602,
+                                "e_wo_entrp" : -79.69460602,
+                                "e_0_energy" : -79.69460602
+                            },
+                            {
+                                "e_fr_energy" : -79.69380831,
+                                "e_wo_entrp" : -79.69380831,
+                                "e_0_energy" : -79.69380831
+                            },
+                            {
+                                "e_fr_energy" : -79.69344203,
+                                "e_wo_entrp" : -79.69344203,
+                                "e_0_energy" : -79.69344203
+                            },
+                            {
+                                "alphaZ" : 266.00303505,
+                                "ewald" : -4777.27319426,
+                                "hartreedc" : -3288.35560304,
+                                "XCdc" : 264.38373372,
+                                "pawpsdc" : 5332.26575011,
+                                "pawaedc" : -5439.83598745,
+                                "eentropy" : 0.0,
+                                "bandstr" : -370.68017778,
+                                "atom" : 7933.79896004,
+                                "e_fr_energy" : -79.69348361,
+                                "e_wo_entrp" : -79.69348361,
+                                "e_0_energy" : -79.69348361
+                            }
+                        ],
+                        "structure" : {
+                            "@module" : "pymatgen.core.structure",
+                            "@class" : "Structure",
+                            "lattice" : {
+                                "matrix" : [
+                                    [
+                                        4.86802001,
+                                        0.00016858,
+                                        -1.33713825
+                                    ],
+                                    [
+                                        0.00018125,
+                                        6.72930489,
+                                        -0.00021919
+                                    ],
+                                    [
+                                        0.06066134,
+                                        -0.00025751,
+                                        8.54797234
+                                    ]
+                                ],
+                                "a" : 5.04832225058907,
+                                "b" : 6.72930489601071,
+                                "c" : 8.54818758509001,
+                                "alpha" : 90.0035812735367,
+                                "beta" : 104.952503442138,
+                                "gamma" : 89.9961042806317,
+                                "volume" : 280.563649882976
+                            },
+                            "sites" : [
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.16038597,
+                                        0.74998501,
+                                        0.49840142
+                                    ],
+                                    "xyz" : [
+                                        0.811131744061425,
+                                        5.04677648973686,
+                                        4.04569894791203
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76138849,
+                                        0.96311406,
+                                        0.16246027
+                                    ],
+                                    "xyz" : [
+                                        3.71648402680202,
+                                        6.48117467331327,
+                                        0.370413116249378
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23862602,
+                                        0.46307637,
+                                        0.83750877
+                                    ],
+                                    "xyz" : [
+                                        1.21252457710867,
+                                        3.11600664177554,
+                                        6.83982431997062
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23862276,
+                                        0.03690505,
+                                        0.83751834
+                                    ],
+                                    "xyz" : [
+                                        1.21243204434072,
+                                        0.248169891107842,
+                                        6.84000389562824
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Te",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.4082697,
+                                        0.24999344,
+                                        0.75324099
+                                    ],
+                                    "xyz" : [
+                                        2.03320298818402,
+                                        1.68215693727861,
+                                        5.89271531962608
+                                    ],
+                                    "label" : "Te"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.7506627,
+                                        0.24999606,
+                                        0.9245049
+                                    ],
+                                    "xyz" : [
+                                        3.71036806221707,
+                                        1.6821881864999,
+                                        6.8988477077398
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.744452,
+                                        0.75000287,
+                                        0.80239856
+                                    ],
+                                    "xyz" : [
+                                        3.67281774236838,
+                                        5.04691685467001,
+                                        5.86328105891775
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.24932887,
+                                        0.75000483,
+                                        0.07554304
+                                    ],
+                                    "xyz" : [
+                                        1.2184564086402,
+                                        5.04703374881529,
+                                        0.312188253934548
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Te",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.59172009,
+                                        0.75000505,
+                                        0.24680483
+                                    ],
+                                    "xyz" : [
+                                        2.89561268856059,
+                                        5.04704884795069,
+                                        1.31830490097905
+                                    ],
+                                    "label" : "Te"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76137789,
+                                        0.53691089,
+                                        0.16247475
+                                    ],
+                                    "xyz" : [
+                                        3.71635605484156,
+                                        3.61312359178308,
+                                        0.370644484027143
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.25555269,
+                                        0.24999605,
+                                        0.19760401
+                                    ],
+                                    "xyz" : [
+                                        1.25606784434936,
+                                        1.68229183780955,
+                                        1.34734953842949
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23178666,
+                                        0.74999306,
+                                        0.77474256
+                                    ],
+                                    "xyz" : [
+                                        1.17547495701782,
+                                        5.04677153676258,
+                                        6.31238277359622
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.768162,
+                                        0.25000806,
+                                        0.22520561
+                                    ],
+                                    "xyz" : [
+                                        3.75313457496061,
+                                        1.68245196475074,
+                                        0.897857733429656
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        1.758e-05,
+                                        0.50001055,
+                                        1.4e-05
+                                    ],
+                                    "xyz" : [
+                                        0.0001770559627233,
+                                        3.36472343852509,
+                                        -1.34325901295e-05
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.83962681,
+                                        0.25000844,
+                                        0.50156601
+                                    ],
+                                    "xyz" : [
+                                        4.11779109230727,
+                                        1.68239540385767,
+                                        3.16462045743772
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        1.978e-05,
+                                        0.99999022,
+                                        1.195e-05
+                                    ],
+                                    "xyz" : [
+                                        0.0002782625661858,
+                                        6.72923907765544,
+                                        -0.0001434881814438
+                                    ],
+                                    "label" : "Co"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "e_fr_energy" : -79.69981565,
+                        "e_wo_entrp" : -79.69981565,
+                        "e_0_energy" : 0.0,
+                        "forces" : [
+                            [
+                                0.00578534,
+                                0.00030172,
+                                -0.02413764
+                            ],
+                            [
+                                0.02922603,
+                                0.00755451,
+                                -0.03363743
+                            ],
+                            [
+                                -0.01367329,
+                                -0.01832738,
+                                0.01324959
+                            ],
+                            [
+                                -0.01891966,
+                                0.00849523,
+                                0.02031912
+                            ],
+                            [
+                                -0.02186636,
+                                0.01245013,
+                                0.04435777
+                            ],
+                            [
+                                -0.02593819,
+                                -0.00144186,
+                                0.05139006
+                            ],
+                            [
+                                -0.02716655,
+                                0.00043437,
+                                -0.05544768
+                            ],
+                            [
+                                0.02367695,
+                                0.00139021,
+                                -0.05332729
+                            ],
+                            [
+                                0.00245613,
+                                -0.0137637,
+                                -0.01822324
+                            ],
+                            [
+                                0.02325495,
+                                0.00367181,
+                                -0.02556008
+                            ],
+                            [
+                                0.02642131,
+                                -0.00047729,
+                                0.05559603
+                            ],
+                            [
+                                -0.00203216,
+                                -0.00124783,
+                                0.01316405
+                            ],
+                            [
+                                0.00181642,
+                                0.00132632,
+                                -0.01251534
+                            ],
+                            [
+                                0.00080644,
+                                0.00084822,
+                                0.00014972
+                            ],
+                            [
+                                -0.00466735,
+                                -0.00032957,
+                                0.02454805
+                            ],
+                            [
+                                0.00081999,
+                                -0.0008849,
+                                7.433e-05
+                            ]
+                        ],
+                        "stress" : [
+                            [
+                                0.30191498,
+                                0.11114078,
+                                -0.72329209
+                            ],
+                            [
+                                0.11115747,
+                                0.02201854,
+                                -0.14658437
+                            ],
+                            [
+                                -0.72328383,
+                                -0.14659918,
+                                -0.71027394
+                            ]
+                        ],
+                        "electronic_steps" : [
+                            {
+                                "alphaZ" : 265.77733486,
+                                "ewald" : -4771.44414602,
+                                "hartreedc" : -3292.78204342,
+                                "XCdc" : 264.29973534,
+                                "pawpsdc" : 5332.19213044,
+                                "pawaedc" : -5439.74776683,
+                                "eentropy" : 0.0,
+                                "bandstr" : -371.7839484,
+                                "atom" : 7933.79896004,
+                                "e_fr_energy" : -79.68974397,
+                                "e_wo_entrp" : -79.68974397,
+                                "e_0_energy" : -79.68974397
+                            },
+                            {
+                                "e_fr_energy" : -79.70213817,
+                                "e_wo_entrp" : -79.70213817,
+                                "e_0_energy" : -79.70213817
+                            },
+                            {
+                                "e_fr_energy" : -79.70054926,
+                                "e_wo_entrp" : -79.70054926,
+                                "e_0_energy" : -79.70054926
+                            },
+                            {
+                                "e_fr_energy" : -79.69973467,
+                                "e_wo_entrp" : -79.69973467,
+                                "e_0_energy" : -79.69973467
+                            },
+                            {
+                                "alphaZ" : 265.77733486,
+                                "ewald" : -4771.44414602,
+                                "hartreedc" : -3293.7009106,
+                                "XCdc" : 264.36180619,
+                                "pawpsdc" : 5330.81395955,
+                                "pawaedc" : -5438.36812535,
+                                "eentropy" : 0.0,
+                                "bandstr" : -370.93869432,
+                                "atom" : 7933.79896004,
+                                "e_fr_energy" : -79.69981565,
+                                "e_wo_entrp" : -79.69981565,
+                                "e_0_energy" : -79.69981565
+                            }
+                        ],
+                        "structure" : {
+                            "@module" : "pymatgen.core.structure",
+                            "@class" : "Structure",
+                            "lattice" : {
+                                "matrix" : [
+                                    [
+                                        4.86851828,
+                                        -9.587e-05,
+                                        -1.34996429
+                                    ],
+                                    [
+                                        -0.00010329,
+                                        6.7350955,
+                                        7.394e-05
+                                    ],
+                                    [
+                                        0.0394474,
+                                        0.00011284,
+                                        8.5527233
+                                    ]
+                                ],
+                                "a" : 5.05221474564972,
+                                "b" : 6.7350955011979,
+                                "c" : 8.55281427113102,
+                                "alpha" : 89.9986191268441,
+                                "beta" : 105.233604208541,
+                                "gamma" : 90.0021020527129,
+                                "volume" : 280.801906974531
+                            },
+                            "sites" : [
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.16045672,
+                                        0.74998619,
+                                        0.49778826
+                                    ],
+                                    "xyz" : [
+                                        0.800745461002801,
+                                        5.05126940077266,
+                                        4.04088986165682
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76118231,
+                                        0.96332219,
+                                        0.16164166
+                                    ],
+                                    "xyz" : [
+                                        3.71210683231731,
+                                        6.488012212016,
+                                        0.354978683095697
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23874259,
+                                        0.46339408,
+                                        0.83838695
+                                    ],
+                                    "xyz" : [
+                                        1.19534698502645,
+                                        3.12107509826597,
+                                        6.8482318940371
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23876337,
+                                        0.03662028,
+                                        0.8383772
+                                    ],
+                                    "xyz" : [
+                                        1.19549184968996,
+                                        0.246712795275706,
+                                        6.84808889707221
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Te",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.40675709,
+                                        0.24995259,
+                                        0.75376048
+                                    ],
+                                    "xyz" : [
+                                        2.01001240174034,
+                                        1.68350062265269,
+                                        5.89761575520537
+                                    ],
+                                    "label" : "Te"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.74945499,
+                                        0.25000469,
+                                        0.92623508
+                                    ],
+                                    "xyz" : [
+                                        3.68524706156258,
+                                        1.68383812871443,
+                                        6.91011336187784
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.74573824,
+                                        0.74999751,
+                                        0.80162146
+                                    ],
+                                    "xyz" : [
+                                        3.66218466867342,
+                                        5.05132381565268,
+                                        5.84938199985046
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.25054616,
+                                        0.749997,
+                                        0.07381512
+                                    ],
+                                    "xyz" : [
+                                        1.22262290731836,
+                                        5.05128572915128,
+                                        0.29314738249785
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Te",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.59335112,
+                                        0.75005453,
+                                        0.24620345
+                                    ],
+                                    "xyz" : [
+                                        2.8983753870196,
+                                        5.05165978678304,
+                                        1.30476261895583
+                                    ],
+                                    "label" : "Te"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76120592,
+                                        0.5366598,
+                                        0.16163185
+                                    ],
+                                    "xyz" : [
+                                        3.71226546101317,
+                                        3.6144002657373,
+                                        0.35483136080612
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.25427302,
+                                        0.25000251,
+                                        0.19838052
+                                    ],
+                                    "xyz" : [
+                                        1.2457326189462,
+                                        1.68378878819315,
+                                        1.35345268394525
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.231183,
+                                        0.74999409,
+                                        0.77450014
+                                    ],
+                                    "xyz" : [
+                                        1.15599321145832,
+                                        5.05134705166718,
+                                        6.31205205333921
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76876903,
+                                        0.25000606,
+                                        0.22545324
+                                    ],
+                                    "xyz" : [
+                                        3.75163379666651,
+                                        1.68376642793543,
+                                        0.89044692649863
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        1.107e-05,
+                                        0.50000511,
+                                        1.001e-05
+                                    ],
+                                    "xyz" : [
+                                        2.64383802170001e-06,
+                                        3.36758216640625,
+                                        0.0001076390333761
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.83955381,
+                                        0.25000689,
+                                        0.50218569
+                                    ],
+                                    "xyz" : [
+                                        4.10716716760469,
+                                        1.68379645841749,
+                                        3.16170607426558
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        1.155e-05,
+                                        0.99999647,
+                                        8.9e-06
+                                    ],
+                                    "xyz" : [
+                                        -4.67071673923e-05,
+                                        6.73507172500986,
+                                        0.0001344668888123
+                                    ],
+                                    "label" : "Co"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "e_fr_energy" : -79.70080645,
+                        "e_wo_entrp" : -79.70080645,
+                        "e_0_energy" : 0.0,
+                        "forces" : [
+                            [
+                                0.00581764,
+                                0.00023136,
+                                -0.00037031
+                            ],
+                            [
+                                0.00967328,
+                                -0.02236063,
+                                0.00138987
+                            ],
+                            [
+                                -0.029243,
+                                0.00947774,
+                                0.02454768
+                            ],
+                            [
+                                -0.02117636,
+                                0.00406818,
+                                0.01364315
+                            ],
+                            [
+                                -0.01198831,
+                                -0.01806235,
+                                0.0070782
+                            ],
+                            [
+                                -0.0052424,
+                                0.00089308,
+                                0.04383163
+                            ],
+                            [
+                                -0.02053027,
+                                -0.0001904,
+                                -0.0207153
+                            ],
+                            [
+                                0.00765631,
+                                -0.00089171,
+                                -0.04345609
+                            ],
+                            [
+                                0.03350813,
+                                0.01934577,
+                                -0.03516023
+                            ],
+                            [
+                                0.01900608,
+                                0.00747761,
+                                -0.01103619
+                            ],
+                            [
+                                0.02141135,
+                                0.00022296,
+                                0.02092986
+                            ],
+                            [
+                                -0.00108155,
+                                0.0018845,
+                                0.01021005
+                            ],
+                            [
+                                0.00197552,
+                                -0.00193713,
+                                -0.0104096
+                            ],
+                            [
+                                -0.00109879,
+                                -0.00133813,
+                                -0.00054819
+                            ],
+                            [
+                                -0.00758692,
+                                -0.00017386,
+                                0.00052638
+                            ],
+                            [
+                                -0.00110073,
+                                0.00135302,
+                                -0.00046091
+                            ]
+                        ],
+                        "stress" : [
+                            [
+                                2.31959481,
+                                -0.08317232,
+                                -1.00207335
+                            ],
+                            [
+                                -0.08317846,
+                                1.68696389,
+                                0.08927484
+                            ],
+                            [
+                                -1.00208194,
+                                0.08925591,
+                                -0.00797629
+                            ]
+                        ],
+                        "electronic_steps" : [
+                            {
+                                "alphaZ" : 265.82885756,
+                                "ewald" : -4772.57399077,
+                                "hartreedc" : -3293.24581154,
+                                "XCdc" : 264.38467102,
+                                "pawpsdc" : 5330.67062835,
+                                "pawaedc" : -5438.20209708,
+                                "eentropy" : 0.0,
+                                "bandstr" : -370.36150979,
+                                "atom" : 7933.79896004,
+                                "e_fr_energy" : -79.70029221,
+                                "e_wo_entrp" : -79.70029221,
+                                "e_0_energy" : -79.70029221
+                            },
+                            {
+                                "e_fr_energy" : -79.70085565,
+                                "e_wo_entrp" : -79.70085565,
+                                "e_0_energy" : -79.70085565
+                            },
+                            {
+                                "alphaZ" : 265.82885756,
+                                "ewald" : -4772.57399077,
+                                "hartreedc" : -3292.79909186,
+                                "XCdc" : 264.36442282,
+                                "pawpsdc" : 5330.33554591,
+                                "pawaedc" : -5437.84817908,
+                                "eentropy" : 0.0,
+                                "bandstr" : -370.80733107,
+                                "atom" : 7933.79896004,
+                                "e_fr_energy" : -79.70080645,
+                                "e_wo_entrp" : -79.70080645,
+                                "e_0_energy" : -79.70080645
+                            }
+                        ],
+                        "structure" : {
+                            "@module" : "pymatgen.core.structure",
+                            "@class" : "Structure",
+                            "lattice" : {
+                                "matrix" : [
+                                    [
+                                        4.8698177,
+                                        0.00029096,
+                                        -1.35119954
+                                    ],
+                                    [
+                                        0.00028866,
+                                        6.73516812,
+                                        -0.00044244
+                                    ],
+                                    [
+                                        0.03640113,
+                                        -0.00054069,
+                                        8.54952478
+                                    ]
+                                ],
+                                "a" : 5.05379705892384,
+                                "b" : 6.73516814071795,
+                                "c" : 8.54960228890473,
+                                "alpha" : 90.0073768016248,
+                                "beta" : 105.263478772037,
+                                "gamma" : 89.9933288060409,
+                                "volume" : 280.747481981159
+                            },
+                            "sites" : [
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.160514,
+                                        0.74998831,
+                                        0.49766809
+                                    ],
+                                    "xyz" : [
+                                        0.800006090764306,
+                                        5.05107497487854,
+                                        4.03760739987883
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76147366,
+                                        0.96337522,
+                                        0.16150559
+                                    ],
+                                    "xyz" : [
+                                        3.7143949814201,
+                                        6.48862830326064,
+                                        0.351466948967067
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23860447,
+                                        0.46326364,
+                                        0.83843336
+                                    ],
+                                    "xyz" : [
+                                        1.19261391872114,
+                                        3.11977459110633,
+                                        6.84559957122784
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23857358,
+                                        0.03668104,
+                                        0.83845494
+                                    ],
+                                    "xyz" : [
+                                        1.19234113825545,
+                                        0.246669042383773,
+                                        6.84601454573192
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Te",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.40655802,
+                                        0.25004084,
+                                        0.75396549
+                                    ],
+                                    "xyz" : [
+                                        2.00738081447883,
+                                        1.68377772478673,
+                                        5.89659500234328
+                                    ],
+                                    "label" : "Te"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.74921078,
+                                        0.24999444,
+                                        0.92646683
+                                    ],
+                                    "xyz" : [
+                                        3.68231652038937,
+                                        1.68347164148349,
+                                        6.90840725209397
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.74546272,
+                                        0.75000061,
+                                        0.80127707
+                                    ],
+                                    "xyz" : [
+                                        3.65965143451332,
+                                        5.05116385578659,
+                                        5.84293745098976
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.25076833,
+                                        0.75000689,
+                                        0.07356912
+                                    ],
+                                    "xyz" : [
+                                        1.22409054812341,
+                                        5.05145568077415,
+                                        0.289811129291814
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Te",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.59335885,
+                                        0.74995699,
+                                        0.2461142
+                                    ],
+                                    "xyz" : [
+                                        2.89872474775542,
+                                        5.05112598262336,
+                                        1.30208143546429
+                                    ],
+                                    "label" : "Te"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76143843,
+                                        0.53668633,
+                                        0.1615316
+                                    ],
+                                    "xyz" : [
+                                        3.71410119652094,
+                                        3.61480686986059,
+                                        0.351925709098881
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.25454122,
+                                        0.24999909,
+                                        0.19872459
+                                    ],
+                                    "xyz" : [
+                                        1.2468753029077,
+                                        1.68375251391182,
+                                        1.35495421762792
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23116801,
+                                        0.74998528,
+                                        0.77457237
+                                    ],
+                                    "xyz" : [
+                                        1.15415786705748,
+                                        5.05092540543473,
+                                        6.30953973895633
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76878188,
+                                        0.25001543,
+                                        0.22538424
+                                    ],
+                                    "xyz" : [
+                                        3.75210401713749,
+                                        1.68399777541517,
+                                        0.888039805458283
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        1.898e-05,
+                                        0.50001113,
+                                        1.211e-05
+                                    ],
+                                    "xyz" : [
+                                        0.0002372031704161,
+                                        3.36765902139584,
+                                        -0.0001433359465406
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.83950744,
+                                        0.25000457,
+                                        0.5023098
+                                    ],
+                                    "xyz" : [
+                                        4.10660500124294,
+                                        1.68379547891729,
+                                        3.16005740356032
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        1.961e-05,
+                                        0.99999019,
+                                        1.059e-05
+                                    ],
+                                    "xyz" : [
+                                        0.0003845397813091,
+                                        6.73510204798056,
+                                        -0.0003783932152228
+                                    ],
+                                    "label" : "Co"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "e_fr_energy" : -79.70158229,
+                        "e_wo_entrp" : -79.70158229,
+                        "e_0_energy" : 0.0,
+                        "forces" : [
+                            [
+                                0.00440768,
+                                -0.00053393,
+                                0.00049883
+                            ],
+                            [
+                                0.01373559,
+                                -0.01663589,
+                                -0.0023476
+                            ],
+                            [
+                                -0.0244377,
+                                0.00248968,
+                                0.01714763
+                            ],
+                            [
+                                -0.02050907,
+                                0.00597018,
+                                0.01169937
+                            ],
+                            [
+                                -0.01086369,
+                                -0.00947576,
+                                0.01126956
+                            ],
+                            [
+                                -0.01132573,
+                                0.00156625,
+                                0.03575857
+                            ],
+                            [
+                                -0.03145728,
+                                -0.00103636,
+                                -0.02189126
+                            ],
+                            [
+                                0.01345822,
+                                -0.00151866,
+                                -0.0349171
+                            ],
+                            [
+                                0.02145776,
+                                0.00969401,
+                                -0.02882298
+                            ],
+                            [
+                                0.01794775,
+                                0.00761246,
+                                -0.00834796
+                            ],
+                            [
+                                0.03234597,
+                                0.00116165,
+                                0.02119386
+                            ],
+                            [
+                                0.0036889,
+                                0.00062498,
+                                0.01840181
+                            ],
+                            [
+                                -0.00332004,
+                                -0.00059912,
+                                -0.01820206
+                            ],
+                            [
+                                -0.00030643,
+                                -0.00034113,
+                                -0.00027653
+                            ],
+                            [
+                                -0.00447858,
+                                0.00064934,
+                                -0.0009571
+                            ],
+                            [
+                                -0.00034335,
+                                0.00037229,
+                                -0.00020704
+                            ]
+                        ],
+                        "stress" : [
+                            [
+                                1.19862962,
+                                -0.10301856,
+                                -1.03039992
+                            ],
+                            [
+                                -0.1030247,
+                                0.91354581,
+                                0.12791474
+                            ],
+                            [
+                                -1.03040198,
+                                0.12791904,
+                                -0.33669551
+                            ]
+                        ],
+                        "electronic_steps" : [
+                            {
+                                "alphaZ" : 265.67316889,
+                                "ewald" : -4771.61072577,
+                                "hartreedc" : -3292.29124929,
+                                "XCdc" : 264.29328523,
+                                "pawpsdc" : 5330.46367517,
+                                "pawaedc" : -5437.99727954,
+                                "eentropy" : 0.0,
+                                "bandstr" : -372.03145838,
+                                "atom" : 7933.79896004,
+                                "e_fr_energy" : -79.70162365,
+                                "e_wo_entrp" : -79.70162365,
+                                "e_0_energy" : -79.70162365
+                            },
+                            {
+                                "e_fr_energy" : -79.70166216,
+                                "e_wo_entrp" : -79.70166216,
+                                "e_0_energy" : -79.70166216
+                            },
+                            {
+                                "alphaZ" : 265.67316889,
+                                "ewald" : -4771.61072577,
+                                "hartreedc" : -3293.01175417,
+                                "XCdc" : 264.344081,
+                                "pawpsdc" : 5330.4306603,
+                                "pawaedc" : -5437.98946937,
+                                "eentropy" : 0.0,
+                                "bandstr" : -371.33650322,
+                                "atom" : 7933.79896004,
+                                "e_fr_energy" : -79.70158229,
+                                "e_wo_entrp" : -79.70158229,
+                                "e_0_energy" : -79.70158229
+                            }
+                        ],
+                        "structure" : {
+                            "@module" : "pymatgen.core.structure",
+                            "@class" : "Structure",
+                            "lattice" : {
+                                "matrix" : [
+                                    [
+                                        4.87196666,
+                                        0.00023939,
+                                        -1.35336648
+                                    ],
+                                    [
+                                        0.0002305,
+                                        6.73722788,
+                                        -0.00039546
+                                    ],
+                                    [
+                                        0.0325234,
+                                        -0.00048148,
+                                        8.54921124
+                                    ]
+                                ],
+                                "a" : 5.05644737168763,
+                                "b" : 6.73722789554934,
+                                "c" : 8.54927311702655,
+                                "alpha" : 90.0065824481013,
+                                "beta" : 105.306607273376,
+                                "gamma" : 89.9944985329069,
+                                "volume" : 280.912004386033
+                            },
+                            "sites" : [
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.16054504,
+                                        0.74998936,
+                                        0.49759572
+                                    ],
+                                    "xyz" : [
+                                        0.798526459495694,
+                                        5.05264807638522,
+                                        4.03647805594133
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76149909,
+                                        0.96333395,
+                                        0.16142756
+                                    ],
+                                    "xyz" : [
+                                        3.71547039968072,
+                                        6.49030491681609,
+                                        0.349110007397404
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23853208,
+                                        0.46327695,
+                                        0.83854001
+                                    ],
+                                    "xyz" : [
+                                        1.18949929859866,
+                                        3.12085574565198,
+                                        6.84585114970239
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23852166,
+                                        0.0366917,
+                                        0.83854862
+                                    ],
+                                    "xyz" : [
+                                        1.18935048483241,
+                                        0.246853699515226,
+                                        6.84610755789285
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Te",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.40630505,
+                                        0.25000793,
+                                        0.75409072
+                                    ],
+                                    "xyz" : [
+                                        2.00408787834035,
+                                        1.68409458198314,
+                                        5.89690235594297
+                                    ],
+                                    "label" : "Te"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.74902929,
+                                        0.24999573,
+                                        0.9267364
+                                    ],
+                                    "xyz" : [
+                                        3.679443970891,
+                                        1.68401130711681,
+                                        6.90905525046155
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.74549685,
+                                        0.75000024,
+                                        0.80111274
+                                    ],
+                                    "xyz" : [
+                                        3.65826358347846,
+                                        5.05271527166356,
+                                        5.8396549984847
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.25095492,
+                                        0.75000564,
+                                        0.07329935
+                                    ],
+                                    "xyz" : [
+                                        1.22520082378278,
+                                        5.0529836918925,
+                                        0.286721052955218
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Te",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.59366155,
+                                        0.74999147,
+                                        0.24596015
+                                    ],
+                                    "xyz" : [
+                                        2.90047161230027,
+                                        5.05288713319162,
+                                        1.29902704511052
+                                    ],
+                                    "label" : "Te"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "O",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76148788,
+                                        0.53670171,
+                                        0.16143891
+                                    ],
+                                    "xyz" : [
+                                        3.71531781534373,
+                                        3.61598628683288,
+                                        0.349390928168849
+                                    ],
+                                    "label" : "O"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.25450917,
+                                        0.24999959,
+                                        0.19888962
+                                    ],
+                                    "xyz" : [
+                                        1.24648638247688,
+                                        1.68426937331254,
+                                        1.35580633045485
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.23110117,
+                                        0.74998843,
+                                        0.77457714
+                                    ],
+                                    "xyz" : [
+                                        1.15128194981518,
+                                        5.05252534018115,
+                                        6.30896242414374
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.76885137,
+                                        0.25001225,
+                                        0.22538046
+                                    ],
+                                    "xyz" : [
+                                        3.75320600781171,
+                                        1.68446504018711,
+                                        0.886188619803908
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        1.608e-05,
+                                        0.50000858,
+                                        1.057e-05
+                                    ],
+                                    "xyz" : [
+                                        0.0001939369739208,
+                                        3.36867174417536,
+                                        -0.0001291303632384
+                                    ],
+                                    "label" : "Co"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Cl",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        0.83947218,
+                                        0.25000364,
+                                        0.50238286
+                                    ],
+                                    "xyz" : [
+                                        4.10627729750546,
+                                        1.68429056745522,
+                                        3.15876481775135
+                                    ],
+                                    "label" : "Cl"
+                                },
+                                {
+                                    "species" : [
+                                        {
+                                            "element" : "Co",
+                                            "occu" : 1
+                                        }
+                                    ],
+                                    "abc" : [
+                                        1.66e-05,
+                                        0.99999283,
+                                        9.2e-06
+                                    ],
+                                    "xyz" : [
+                                        0.000311672209151,
+                                        6.73717957362036,
+                                        -0.0003392703047118
+                                    ],
+                                    "label" : "Co"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "efermi" : 2.09530561,
+                "bandgap" : 2.443,
+                "cbm" : 4.5374,
+                "vbm" : 2.0944,
+                "is_gap_direct" : false,
+                "epsilon_static" : [],
+                "epsilon_static_wolfe" : [],
+                "epsilon_ionic" : [],
+                "structure" : {
+                    "@module" : "pymatgen.core.structure",
+                    "@class" : "Structure",
+                    "lattice" : {
+                        "matrix" : [
+                            [
+                                4.87196666,
+                                0.00023939,
+                                -1.35336648
+                            ],
+                            [
+                                0.0002305,
+                                6.73722788,
+                                -0.00039546
+                            ],
+                            [
+                                0.0325234,
+                                -0.00048148,
+                                8.54921124
+                            ]
+                        ],
+                        "a" : 5.05644737168763,
+                        "b" : 6.73722789554934,
+                        "c" : 8.54927311702655,
+                        "alpha" : 90.0065824481013,
+                        "beta" : 105.306607273376,
+                        "gamma" : 89.9944985329069,
+                        "volume" : 280.912004386033
+                    },
+                    "sites" : [
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Cl",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.16054504,
+                                0.74998936,
+                                0.49759572
+                            ],
+                            "xyz" : [
+                                0.798526459495694,
+                                5.05264807638522,
+                                4.03647805594133
+                            ],
+                            "label" : "Cl"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "O",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.76149909,
+                                0.96333395,
+                                0.16142756
+                            ],
+                            "xyz" : [
+                                3.71547039968072,
+                                6.49030491681609,
+                                0.349110007397404
+                            ],
+                            "label" : "O"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "O",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.23853208,
+                                0.46327695,
+                                0.83854001
+                            ],
+                            "xyz" : [
+                                1.18949929859866,
+                                3.12085574565198,
+                                6.84585114970239
+                            ],
+                            "label" : "O"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "O",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.23852166,
+                                0.0366917,
+                                0.83854862
+                            ],
+                            "xyz" : [
+                                1.18935048483241,
+                                0.246853699515226,
+                                6.84610755789285
+                            ],
+                            "label" : "O"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Te",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.40630505,
+                                0.25000793,
+                                0.75409072
+                            ],
+                            "xyz" : [
+                                2.00408787834035,
+                                1.68409458198314,
+                                5.89690235594297
+                            ],
+                            "label" : "Te"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "O",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.74902929,
+                                0.24999573,
+                                0.9267364
+                            ],
+                            "xyz" : [
+                                3.679443970891,
+                                1.68401130711681,
+                                6.90905525046155
+                            ],
+                            "label" : "O"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Cl",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.74549685,
+                                0.75000024,
+                                0.80111274
+                            ],
+                            "xyz" : [
+                                3.65826358347846,
+                                5.05271527166356,
+                                5.8396549984847
+                            ],
+                            "label" : "Cl"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "O",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.25095492,
+                                0.75000564,
+                                0.07329935
+                            ],
+                            "xyz" : [
+                                1.22520082378278,
+                                5.0529836918925,
+                                0.286721052955218
+                            ],
+                            "label" : "O"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Te",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.59366155,
+                                0.74999147,
+                                0.24596015
+                            ],
+                            "xyz" : [
+                                2.90047161230027,
+                                5.05288713319162,
+                                1.29902704511052
+                            ],
+                            "label" : "Te"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "O",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.76148788,
+                                0.53670171,
+                                0.16143891
+                            ],
+                            "xyz" : [
+                                3.71531781534373,
+                                3.61598628683288,
+                                0.349390928168849
+                            ],
+                            "label" : "O"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Cl",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.25450917,
+                                0.24999959,
+                                0.19888962
+                            ],
+                            "xyz" : [
+                                1.24648638247688,
+                                1.68426937331254,
+                                1.35580633045485
+                            ],
+                            "label" : "Cl"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Co",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.23110117,
+                                0.74998843,
+                                0.77457714
+                            ],
+                            "xyz" : [
+                                1.15128194981518,
+                                5.05252534018115,
+                                6.30896242414374
+                            ],
+                            "label" : "Co"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Co",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.76885137,
+                                0.25001225,
+                                0.22538046
+                            ],
+                            "xyz" : [
+                                3.75320600781171,
+                                1.68446504018711,
+                                0.886188619803908
+                            ],
+                            "label" : "Co"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Co",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                1.608e-05,
+                                0.50000858,
+                                1.057e-05
+                            ],
+                            "xyz" : [
+                                0.0001939369739208,
+                                3.36867174417536,
+                                -0.0001291303632384
+                            ],
+                            "label" : "Co"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Cl",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                0.83947218,
+                                0.25000364,
+                                0.50238286
+                            ],
+                            "xyz" : [
+                                4.10627729750546,
+                                1.68429056745522,
+                                3.15876481775135
+                            ],
+                            "label" : "Cl"
+                        },
+                        {
+                            "species" : [
+                                {
+                                    "element" : "Co",
+                                    "occu" : 1
+                                }
+                            ],
+                            "abc" : [
+                                1.66e-05,
+                                0.99999283,
+                                9.2e-06
+                            ],
+                            "xyz" : [
+                                0.000311672209151,
+                                6.73717957362036,
+                                -0.0003392703047118
+                            ],
+                            "label" : "Co"
+                        }
+                    ]
+                },
+                "energy" : -79.70158229,
+                "energy_per_atom" : -4.981348893125,
+                "is_metal" : false,
+                "outcar" : {
+                    "@module" : "pymatgen.io.vasp.outputs",
+                    "@class" : "Outcar",
+                    "efermi" : 2.0953,
+                    "magnetization" : [
+                        {
+                            "s" : 0.003,
+                            "p" : 0.062,
+                            "d" : 0.0,
+                            "tot" : 0.065
+                        },
+                        {
+                            "s" : 0.009,
+                            "p" : 0.072,
+                            "d" : 0.0,
+                            "tot" : 0.081
+                        },
+                        {
+                            "s" : 0.009,
+                            "p" : 0.072,
+                            "d" : 0.0,
+                            "tot" : 0.081
+                        },
+                        {
+                            "s" : 0.009,
+                            "p" : 0.072,
+                            "d" : 0.0,
+                            "tot" : 0.081
+                        },
+                        {
+                            "s" : 0.0,
+                            "p" : 0.026,
+                            "d" : 0.005,
+                            "tot" : 0.032
+                        },
+                        {
+                            "s" : 0.01,
+                            "p" : 0.073,
+                            "d" : 0.0,
+                            "tot" : 0.083
+                        },
+                        {
+                            "s" : 0.01,
+                            "p" : 0.094,
+                            "d" : 0.0,
+                            "tot" : 0.104
+                        },
+                        {
+                            "s" : 0.01,
+                            "p" : 0.073,
+                            "d" : 0.0,
+                            "tot" : 0.083
+                        },
+                        {
+                            "s" : 0.0,
+                            "p" : 0.026,
+                            "d" : 0.005,
+                            "tot" : 0.032
+                        },
+                        {
+                            "s" : 0.009,
+                            "p" : 0.072,
+                            "d" : 0.0,
+                            "tot" : 0.081
+                        },
+                        {
+                            "s" : 0.01,
+                            "p" : 0.094,
+                            "d" : 0.0,
+                            "tot" : 0.104
+                        },
+                        {
+                            "s" : 0.02,
+                            "p" : 0.019,
+                            "d" : 2.644,
+                            "tot" : 2.683
+                        },
+                        {
+                            "s" : 0.02,
+                            "p" : 0.019,
+                            "d" : 2.644,
+                            "tot" : 2.683
+                        },
+                        {
+                            "s" : 0.014,
+                            "p" : 0.01,
+                            "d" : 2.673,
+                            "tot" : 2.697
+                        },
+                        {
+                            "s" : 0.003,
+                            "p" : 0.062,
+                            "d" : 0.0,
+                            "tot" : 0.065
+                        },
+                        {
+                            "s" : 0.014,
+                            "p" : 0.01,
+                            "d" : 2.673,
+                            "tot" : 2.697
+                        }
+                    ],
+                    "charge" : [
+                        {
+                            "s" : 1.597,
+                            "p" : 3.533,
+                            "d" : 0.0,
+                            "tot" : 5.13
+                        },
+                        {
+                            "s" : 1.569,
+                            "p" : 3.467,
+                            "d" : 0.0,
+                            "tot" : 5.036
+                        },
+                        {
+                            "s" : 1.569,
+                            "p" : 3.468,
+                            "d" : 0.0,
+                            "tot" : 5.037
+                        },
+                        {
+                            "s" : 1.569,
+                            "p" : 3.468,
+                            "d" : 0.0,
+                            "tot" : 5.036
+                        },
+                        {
+                            "s" : 1.428,
+                            "p" : 1.539,
+                            "d" : 0.231,
+                            "tot" : 3.199
+                        },
+                        {
+                            "s" : 1.57,
+                            "p" : 3.439,
+                            "d" : 0.0,
+                            "tot" : 5.009
+                        },
+                        {
+                            "s" : 1.597,
+                            "p" : 3.548,
+                            "d" : 0.0,
+                            "tot" : 5.145
+                        },
+                        {
+                            "s" : 1.57,
+                            "p" : 3.439,
+                            "d" : 0.0,
+                            "tot" : 5.009
+                        },
+                        {
+                            "s" : 1.428,
+                            "p" : 1.539,
+                            "d" : 0.231,
+                            "tot" : 3.198
+                        },
+                        {
+                            "s" : 1.569,
+                            "p" : 3.468,
+                            "d" : 0.0,
+                            "tot" : 5.036
+                        },
+                        {
+                            "s" : 1.597,
+                            "p" : 3.548,
+                            "d" : 0.0,
+                            "tot" : 5.145
+                        },
+                        {
+                            "s" : 0.304,
+                            "p" : 0.346,
+                            "d" : 7.093,
+                            "tot" : 7.742
+                        },
+                        {
+                            "s" : 0.304,
+                            "p" : 0.346,
+                            "d" : 7.093,
+                            "tot" : 7.743
+                        },
+                        {
+                            "s" : 0.289,
+                            "p" : 0.34,
+                            "d" : 7.086,
+                            "tot" : 7.715
+                        },
+                        {
+                            "s" : 1.597,
+                            "p" : 3.533,
+                            "d" : 0.0,
+                            "tot" : 5.13
+                        },
+                        {
+                            "s" : 0.289,
+                            "p" : 0.341,
+                            "d" : 7.086,
+                            "tot" : 7.715
+                        }
+                    ],
+                    "total_magnetization" : 12.0000006,
+                    "nelect" : 111.9999991,
+                    "is_stopped" : false
+                }
+            },
+            "formula_pretty" : "Co2TeCl2O3",
+            "composition_reduced" : {
+                "Co" : 2.0,
+                "Te" : 1.0,
+                "Cl" : 2.0,
+                "O" : 3.0
+            },
+            "composition_unit_cell" : {
+                "Cl" : 4.0,
+                "O" : 6.0,
+                "Te" : 2.0,
+                "Co" : 4.0
+            },
+            "formula_anonymous" : "AB2C2D3",
+            "formula_reduced_abc" : "Cl2 Co2 O3 Te1",
+            "dir_name" : "/global/projecta/projectdirs/matgen/garden/block_2013-06-23-09-28-21-424493/launcher_2013-06-23-20-21-15-188214",
+            "completed_at" : "2013-06-23 16:19:53",
+            "density" : 4.30776599273674,
+            "task" : {
+                "type" : "relax1",
+                "name" : "relax1"
+            },
+            "output_file_paths" : {}
+        }
+    ],
+    "run_stats" : {
+        "relax1" : {
+            "Average memory used (kb)" : 0.0,
+            "Maximum memory used (kb)" : 141244.0,
+            "Elapsed time (sec)" : 1933.675,
+            "System time (sec)" : 59.99,
+            "User time (sec)" : 1866.201,
+            "Total CPU time used (sec)" : 1926.191,
+            "cores" : "32"
+        },
+        "relax2" : {
+            "Average memory used (kb)" : 0.0,
+            "Maximum memory used (kb)" : 141728.0,
+            "Elapsed time (sec)" : 467.896,
+            "System time (sec)" : 15.323,
+            "User time (sec)" : 449.107,
+            "Total CPU time used (sec)" : 464.429,
+            "cores" : "32"
+        },
+        "overall" : {
+            "Total CPU time used (sec)" : 2390.62,
+            "User time (sec)" : 2315.308,
+            "System time (sec)" : 75.313,
+            "Elapsed time (sec)" : 2401.571
+        }
+    },
+    "chemsys" : "Cl-Co-O-Te",
+    "formula_anonymous" : "AB2C2D3",
+    "formula_reduced_abc" : "Cl2 Co2 O3 Te1",
+    "completed_at" : "2013-06-23 16:27:42",
+    "nsites" : 16,
+    "composition_unit_cell" : {
+        "Cl" : 4.0,
+        "O" : 6.0,
+        "Te" : 2.0,
+        "Co" : 4.0
+    },
+    "composition_reduced" : {
+        "Co" : 2.0,
+        "Te" : 1.0,
+        "Cl" : 2.0,
+        "O" : 3.0
+    },
+    "formula_pretty" : "Co2TeCl2O3",
+    "elements" : [
+        "Cl",
+        "Co",
+        "O",
+        "Te"
+    ],
+    "nelements" : 4,
+    "input" : {
+        "structure" : {
+            "@module" : "pymatgen.core.structure",
+            "@class" : "Structure",
+            "lattice" : {
+                "matrix" : [
+                    [
+                        4.85343059,
+                        6.041e-05,
+                        -1.29721956
+                    ],
+                    [
+                        6.911e-05,
+                        6.66863986,
+                        -8.241e-05
+                    ],
+                    [
+                        0.10998805,
+                        -8.619e-05,
+                        8.47259034
+                    ]
+                ],
+                "a" : 5.02380006394002,
+                "b" : 6.66863986086731,
+                "c" : 8.4733042225588,
+                "alpha" : 90.0012830945821,
+                "beta" : 104.220410448655,
+                "gamma" : 89.9985545579525,
+                "volume" : 275.17347329123
+            },
+            "sites" : [
+                {
+                    "species" : [
+                        {
+                            "element" : "Cl",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.16069209,
+                        0.7499791,
+                        0.50056639
+                    ],
+                    "xyz" : [
+                        0.835016057364274,
+                        5.00130708401893,
+                        4.03257923237976
+                    ],
+                    "label" : "Cl"
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "O",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.76410709,
+                        0.96455099,
+                        0.16327596
+                    ],
+                    "xyz" : [
+                        3.72656578921308,
+                        6.43227526587078,
+                        0.39207616972046
+                    ],
+                    "label" : "O"
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "O",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.23585032,
+                        0.46457567,
+                        0.83671644
+                    ],
+                    "xyz" : [
+                        1.23674407421238,
+                        3.09802996207607,
+                        6.78316769284597
+                    ],
+                    "label" : "O"
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "O",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.23586763,
+                        0.03542795,
+                        0.83672884
+                    ],
+                    "xyz" : [
+                        1.23679979254879,
+                        0.236198370632896,
+                        6.7832856641592
+                    ],
+                    "label" : "O"
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "Te",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.41254978,
+                        0.24997739,
+                        0.75140053
+                    ],
+                    "xyz" : [
+                        2.08494407715086,
+                        1.66696934597329,
+                        5.83112062722247
+                    ],
+                    "label" : "Te"
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "O",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.75476504,
+                        0.24998253,
+                        0.92230702
+                    ],
+                    "xyz" : [
+                        3.76465976032233,
+                        1.66700956557566,
+                        6.83521297401371
+                    ],
+                    "label" : "O"
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "Cl",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.74125699,
+                        0.75000821,
+                        0.80351893
+                    ],
+                    "xyz" : [
+                        3.6860686636335,
+                        5.00151016857144,
+                        5.84625184973383
+                    ],
+                    "label" : "Cl"
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "O",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.24522244,
+                        0.75001634,
+                        0.07775203
+                    ],
+                    "xyz" : [
+                        1.19877371944294,
+                        5.00159697301545,
+                        0.340591943727884
+                    ],
+                    "label" : "O"
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "Te",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.58752069,
+                        0.75003314,
+                        0.24860474
+                    ],
+                    "xyz" : [
+                        2.87888627446757,
+                        5.0017149586073,
+                        1.34412097739845
+                    ],
+                    "label" : "Te"
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "O",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.76411473,
+                        0.53544709,
+                        0.16329301
+                    ],
+                    "xyz" : [
+                        3.72657508934851,
+                        3.57073589324131,
+                        0.392246079080718
+                    ],
+                    "label" : "O"
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "Cl",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.25875702,
+                        0.24998979,
+                        0.19648892
+                    ],
+                    "xyz" : [
+                        1.27748794619703,
+                        1.66709057431859,
+                        1.32908485621913
+                    ],
+                    "label" : "Cl"
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "Co",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.23316513,
+                        0.75000373,
+                        0.77512103
+                    ],
+                    "xyz" : [
+                        1.2169566578248,
+                        5.00145204685061,
+                        6.26475477595552
+                    ],
+                    "label" : "Co"
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "Co",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.76679262,
+                        0.24999602,
+                        0.22482379
+                    ],
+                    "xyz" : [
+                        3.7463199655749,
+                        1.66716036819307,
+                        0.910120884056533
+                    ],
+                    "label" : "Co"
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "Co",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        1.411e-05,
+                        0.50000433,
+                        1.353e-05
+                    ],
+                    "xyz" : [
+                        0.0001045253431877,
+                        3.33434880489683,
+                        5.51250224733e-05
+                    ],
+                    "label" : "Co"
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "Cl",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.83930639,
+                        0.25001415,
+                        0.49937727
+                    ],
+                    "xyz" : [
+                        4.128458118228,
+                        1.66726198742614,
+                        3.14223376421048
+                    ],
+                    "label" : "Cl"
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "Co",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        1.794e-05,
+                        0.99999356,
+                        1.156e-05
+                    ],
+                    "xyz" : [
+                        0.0001574515615742,
+                        6.6685969140467,
+                        -7.73844385560001e-06
+                    ],
+                    "label" : "Co"
+                }
+            ]
+        },
+        "is_hubbard" : true,
+        "hubbards" : {
+            "Cl" : 0.0,
+            "O" : 0.0,
+            "Te" : 0.0,
+            "Co" : 3.32
+        },
+        "is_lasph" : false,
+        "potcar_spec" : [
+            {
+                "titel" : "PAW_PBE Cl 17Jan2003",
+                "hash" : "779b9901046c78fe51c5d80224642aeb"
+            },
+            {
+                "titel" : "PAW_PBE Cl 17Jan2003",
+                "hash" : "779b9901046c78fe51c5d80224642aeb"
+            },
+            {
+                "titel" : "PAW_PBE Cl 17Jan2003",
+                "hash" : "779b9901046c78fe51c5d80224642aeb"
+            },
+            {
+                "titel" : "PAW_PBE Cl 17Jan2003",
+                "hash" : "779b9901046c78fe51c5d80224642aeb"
+            },
+            {
+                "titel" : "PAW_PBE O 08Apr2002",
+                "hash" : "7a25bc5b9a5393f46600a4939d357982"
+            },
+            {
+                "titel" : "PAW_PBE O 08Apr2002",
+                "hash" : "7a25bc5b9a5393f46600a4939d357982"
+            },
+            {
+                "titel" : "PAW_PBE O 08Apr2002",
+                "hash" : "7a25bc5b9a5393f46600a4939d357982"
+            },
+            {
+                "titel" : "PAW_PBE O 08Apr2002",
+                "hash" : "7a25bc5b9a5393f46600a4939d357982"
+            },
+            {
+                "titel" : "PAW_PBE Te 08Apr2002",
+                "hash" : "72719856e22fb1d3032df6f96d98a0f2"
+            },
+            {
+                "titel" : "PAW_PBE Te 08Apr2002",
+                "hash" : "72719856e22fb1d3032df6f96d98a0f2"
+            },
+            {
+                "titel" : "PAW_PBE O 08Apr2002",
+                "hash" : "7a25bc5b9a5393f46600a4939d357982"
+            },
+            {
+                "titel" : "PAW_PBE O 08Apr2002",
+                "hash" : "7a25bc5b9a5393f46600a4939d357982"
+            },
+            {
+                "titel" : "PAW_PBE O 08Apr2002",
+                "hash" : "7a25bc5b9a5393f46600a4939d357982"
+            },
+            {
+                "titel" : "PAW_PBE O 08Apr2002",
+                "hash" : "7a25bc5b9a5393f46600a4939d357982"
+            },
+            {
+                "titel" : "PAW_PBE Cl 17Jan2003",
+                "hash" : "779b9901046c78fe51c5d80224642aeb"
+            },
+            {
+                "titel" : "PAW_PBE Cl 17Jan2003",
+                "hash" : "779b9901046c78fe51c5d80224642aeb"
+            },
+            {
+                "titel" : "PAW_PBE Cl 17Jan2003",
+                "hash" : "779b9901046c78fe51c5d80224642aeb"
+            },
+            {
+                "titel" : "PAW_PBE Cl 17Jan2003",
+                "hash" : "779b9901046c78fe51c5d80224642aeb"
+            },
+            {
+                "titel" : "PAW_PBE O 08Apr2002",
+                "hash" : "7a25bc5b9a5393f46600a4939d357982"
+            },
+            {
+                "titel" : "PAW_PBE O 08Apr2002",
+                "hash" : "7a25bc5b9a5393f46600a4939d357982"
+            },
+            {
+                "titel" : "PAW_PBE O 08Apr2002",
+                "hash" : "7a25bc5b9a5393f46600a4939d357982"
+            },
+            {
+                "titel" : "PAW_PBE O 08Apr2002",
+                "hash" : "7a25bc5b9a5393f46600a4939d357982"
+            },
+            {
+                "titel" : "PAW_PBE Te 08Apr2002",
+                "hash" : "72719856e22fb1d3032df6f96d98a0f2"
+            },
+            {
+                "titel" : "PAW_PBE Te 08Apr2002",
+                "hash" : "72719856e22fb1d3032df6f96d98a0f2"
+            },
+            {
+                "titel" : "PAW_PBE O 08Apr2002",
+                "hash" : "7a25bc5b9a5393f46600a4939d357982"
+            },
+            {
+                "titel" : "PAW_PBE O 08Apr2002",
+                "hash" : "7a25bc5b9a5393f46600a4939d357982"
+            },
+            {
+                "titel" : "PAW_PBE O 08Apr2002",
+                "hash" : "7a25bc5b9a5393f46600a4939d357982"
+            },
+            {
+                "titel" : "PAW_PBE O 08Apr2002",
+                "hash" : "7a25bc5b9a5393f46600a4939d357982"
+            },
+            {
+                "titel" : "PAW_PBE Cl 17Jan2003",
+                "hash" : "779b9901046c78fe51c5d80224642aeb"
+            },
+            {
+                "titel" : "PAW_PBE Cl 17Jan2003",
+                "hash" : "779b9901046c78fe51c5d80224642aeb"
+            },
+            {
+                "titel" : "PAW_PBE Cl 17Jan2003",
+                "hash" : "779b9901046c78fe51c5d80224642aeb"
+            },
+            {
+                "titel" : "PAW_PBE Cl 17Jan2003",
+                "hash" : "779b9901046c78fe51c5d80224642aeb"
+            },
+            {
+                "titel" : "PAW_PBE Co 06Sep2000",
+                "hash" : "b169bca4e137294d2ab3df8cbdd09083"
+            },
+            {
+                "titel" : "PAW_PBE Co 06Sep2000",
+                "hash" : "b169bca4e137294d2ab3df8cbdd09083"
+            },
+            {
+                "titel" : "PAW_PBE Cl 17Jan2003",
+                "hash" : "779b9901046c78fe51c5d80224642aeb"
+            },
+            {
+                "titel" : "PAW_PBE Cl 17Jan2003",
+                "hash" : "779b9901046c78fe51c5d80224642aeb"
+            },
+            {
+                "titel" : "PAW_PBE Cl 17Jan2003",
+                "hash" : "779b9901046c78fe51c5d80224642aeb"
+            },
+            {
+                "titel" : "PAW_PBE Cl 17Jan2003",
+                "hash" : "779b9901046c78fe51c5d80224642aeb"
+            },
+            {
+                "titel" : "PAW_PBE Co 06Sep2000",
+                "hash" : "b169bca4e137294d2ab3df8cbdd09083"
+            },
+            {
+                "titel" : "PAW_PBE Co 06Sep2000",
+                "hash" : "b169bca4e137294d2ab3df8cbdd09083"
+            }
+        ],
+        "xc_override" : null,
+        "pseudo_potential" : {
+            "functional" : "pbe",
+            "pot_type" : "paw",
+            "labels" : [
+                "Cl",
+                "O",
+                "Te",
+                "O",
+                "Cl",
+                "O",
+                "Te",
+                "O",
+                "Cl",
+                "Co",
+                "Cl",
+                "Co"
+            ]
+        },
+        "parameters" : {
+            "SYSTEM" : "unknown system",
+            "LCOMPAT" : false,
+            "PREC" : "accura",
+            "ENMAX" : 520.0,
+            "ENAUG" : 605.392,
+            "EDIFF" : 0.0001,
+            "IALGO" : 68,
+            "IWAVPR" : 11,
+            "NBANDS" : 81,
+            "NELECT" : 112.0,
+            "ISMEAR" : -5,
+            "SIGMA" : 0.2,
+            "LREAL" : true,
+            "ROPT" : [
+                -0.00025,
+                -0.00025,
+                -0.00025,
+                -0.00025,
+                -0.00025,
+                -0.00025,
+                -0.00025,
+                -0.00025,
+                -0.00025,
+                -0.00025,
+                -0.00025,
+                -0.00025
+            ],
+            "LMAXPAW" : -100,
+            "LMAXMIX" : 4,
+            "ISTART" : 0,
+            "ICHARG" : 1,
+            "INIWAV" : 1,
+            "ISPIN" : 2,
+            "LNONCOLLINEAR" : false,
+            "MAGMOM" : [
+                0.6,
+                0.6,
+                0.6,
+                0.6,
+                0.6,
+                0.6,
+                0.6,
+                0.6,
+                0.6,
+                0.6,
+                0.6,
+                5.0,
+                5.0,
+                5.0,
+                0.6,
+                5.0
+            ],
+            "NUPDOWN" : -1.0,
+            "LSORBIT" : false,
+            "SAXIS" : [
+                0.0,
+                0.0,
+                1.0
+            ],
+            "LSPIRAL" : false,
+            "QSPIRAL" : [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "LZEROZ" : false,
+            "LASPH" : false,
+            "LMETAGGA" : false,
+            "NELM" : 100,
+            "NELMDL" : -5,
+            "NELMIN" : 2,
+            "ENINI" : 520.0,
+            "LDIAG" : true,
+            "WEIMIN" : 0.001,
+            "EBREAK" : 3.1e-07,
+            "DEPER" : 0.3,
+            "NRMM" : 4,
+            "TIME" : 0.4,
+            "AMIX" : 0.4,
+            "BMIX" : 1.0,
+            "AMIN" : 0.1,
+            "AMIX_MAG" : 1.6,
+            "BMIX_MAG" : 1.0,
+            "IMIX" : 4,
+            "MAXMIX" : -45,
+            "WC" : 100.0,
+            "INIMIX" : 1,
+            "MIXPRE" : 1,
+            "MREMOVE" : 5,
+            "LDIPOL" : false,
+            "LMONO" : false,
+            "IDIPOL" : 0,
+            "EPSILON" : 1.0,
+            "DIPOL" : [
+                -100.0,
+                -100.0,
+                -100.0
+            ],
+            "EFIELD" : 0.0,
+            "NGX" : 40,
+            "NGY" : 50,
+            "NGZ" : 64,
+            "NGXF" : 80,
+            "NGYF" : 100,
+            "NGZF" : 128,
+            "ADDGRID" : false,
+            "NSW" : 99,
+            "IBRION" : 1,
+            "ISIF" : 3,
+            "PSTRESS" : 0.0,
+            "EDIFFG" : 0.001,
+            "NFREE" : 0,
+            "POTIM" : 0.5,
+            "SMASS" : -3.0,
+            "TEBEG" : 0.0001,
+            "TEEND" : 0.0001,
+            "NBLOCK" : 1,
+            "KBLOCK" : 99,
+            "NPACO" : 256,
+            "APACO" : 16.0,
+            "ISYM" : 2,
+            "SYMPREC" : 1e-05,
+            "LORBIT" : false,
+            "RWIGS" : [
+                -1.0,
+                -1.0,
+                -1.0,
+                -1.0,
+                -1.0,
+                -1.0,
+                -1.0,
+                -1.0,
+                -1.0,
+                -1.0,
+                -1.0,
+                -1.0
+            ],
+            "NEDOS" : 301,
+            "EMIN" : 10.0,
+            "EMAX" : -10.0,
+            "EFERMI" : 0.0,
+            "NWRITE" : 2,
+            "LWAVE" : false,
+            "LCHARG" : true,
+            "LPARD" : false,
+            "LVTOT" : false,
+            "LELF" : false,
+            "LOPTICS" : false,
+            "STM" : [
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0
+            ],
+            "NPAR" : 1,
+            "NSIM" : 4,
+            "NBLK" : 32,
+            "LPLANE" : true,
+            "LSCALAPACK" : false,
+            "LSCAAWARE" : false,
+            "LSCALU" : false,
+            "LASYNC" : false,
+            "IDIOT" : 3,
+            "LMUSIC" : false,
+            "POMASS" : [
+                35.453,
+                16.0,
+                127.6,
+                16.0,
+                35.453,
+                16.0,
+                127.6,
+                16.0,
+                35.453,
+                58.933,
+                35.453,
+                58.933
+            ],
+            "LCORR" : true,
+            "LREAL_COMPAT" : false,
+            "GGA_COMPAT" : true,
+            "LBERRY" : false,
+            "ICORELEVEL" : 0,
+            "LDAU" : true,
+            "LDAUTYPE" : [
+                2
+            ],
+            "LDAUL" : [
+                0
+            ],
+            "LDAUU" : [
+                0.0
+            ],
+            "LDAUJ" : [
+                0.0
+            ],
+            "LDAUPRINT" : 0,
+            "I_CONSTRAINED_M" : 0,
+            "GGA" : "--",
+            "VOSKOWN" : 0,
+            "LHFCALC" : false,
+            "LHFONE" : false,
+            "LRHFCALC" : false,
+            "LTHOMAS" : false,
+            "LMODELHF" : false,
+            "ENCUTFOCK" : 0.0,
+            "ENCUT4O" : -1.0,
+            "EXXOEP" : 0,
+            "FOURORBIT" : 0,
+            "AEXX" : 0.0,
+            "HFALPHA" : 0.0,
+            "ALDAX" : 1.0,
+            "AGGAX" : 1.0,
+            "ALDAC" : 1.0,
+            "AGGAC" : 1.0,
+            "NKREDX" : 1,
+            "NKREDY" : 1,
+            "NKREDZ" : 1,
+            "SHIFTRED" : false,
+            "ODDONLY" : false,
+            "EVENONLY" : false,
+            "LMAXFOCK" : 0,
+            "NMAXFOCKAE" : 0,
+            "HFSCREEN" : 0.0,
+            "HFSCREENC" : 0.0,
+            "MODEL_GW" : 0,
+            "MODEL_EPS0" : 10.31900526,
+            "MODEL_ALPHA" : 1.0,
+            "LEPSILON" : false,
+            "LRPA" : false,
+            "LNABLA" : false,
+            "LVEL" : false,
+            "KINTER" : 0,
+            "CSHIFT" : 0.1,
+            "OMEGAMAX" : -1.0,
+            "ORBITALMAG" : false,
+            "LMAGBLOCH" : false,
+            "LCHIMAG" : false,
+            "LGAUGE" : true,
+            "MAGATOM" : 0,
+            "MAGDIPOL" : [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "AVECCONST" : [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "LTCTE" : false,
+            "LTETE" : false,
+            "L2ORDER" : false,
+            "LGWLF" : false,
+            "ENCUTGW" : 346.66666667,
+            "ENCUTGWSOFT" : -2.0,
+            "ENCUTLF" : -1.0,
+            "LMAXMP2" : -1,
+            "SCISSOR" : 0.0,
+            "NOMEGA" : 0,
+            "NOMEGAR" : 0,
+            "NBANDSGW" : -1,
+            "NBANDSLF" : -1,
+            "DIM" : 3,
+            "ANTIRES" : 0,
+            "LUSEW" : false,
+            "OMEGATL" : -200.0,
+            "OMEGAGRID" : 0,
+            "SELFENERGY" : false,
+            "LSPECTRAL" : false,
+            "ODDONLYGW" : false,
+            "EVENONLYGW" : false,
+            "NKREDLFX" : 1,
+            "NKREDLFY" : 1,
+            "NKREDLFZ" : 1,
+            "MAXMEM" : 1024,
+            "TELESCOPE" : 0
+        },
+        "incar" : {
+            "PREC" : "accurate",
+            "ALGO" : "Fast",
+            "ISPIN" : 2,
+            "ICHARG" : 1,
+            "NELM" : 100,
+            "IBRION" : 1,
+            "EDIFF" : 0.0001,
+            "NSW" : 99,
+            "ISIF" : 3,
+            "ENCUT" : 520.0,
+            "MAGMOM" : [
+                0.6,
+                0.6,
+                0.6,
+                0.6,
+                0.6,
+                0.6,
+                0.6,
+                0.6,
+                0.6,
+                0.6,
+                0.6,
+                5.0,
+                5.0,
+                5.0,
+                0.6,
+                5.0
+            ],
+            "LREAL" : "Auto",
+            "ISMEAR" : -5,
+            "SIGMA" : 0.2,
+            "LMAXMIX" : 4,
+            "LWAVE" : false,
+            "LORBIT" : false,
+            "LPEAD" : false,
+            "LCALCPOL" : false,
+            "LCALCEPS" : false,
+            "EFIELD_PEAD" : [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "LEFG" : false,
+            "LDAU" : true,
+            "LDAUTYPE" : [
+                2
+            ],
+            "LDAUL" : [
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                2,
+                0,
+                2
+            ],
+            "LDAUU" : [
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                3.32,
+                0.0,
+                3.32
+            ],
+            "LDAUJ" : [
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0
+            ]
+        }
+    },
+    "output" : {
+        "structure" : {
+            "@module" : "pymatgen.core.structure",
+            "@class" : "Structure",
+            "charge" : null,
+            "lattice" : {
+                "matrix" : [
+                    [
+                        4.87503495,
+                        -0.00010314,
+                        -1.3544
+                    ],
+                    [
+                        -0.00012155,
+                        6.74028524,
+                        4.213e-05
+                    ],
+                    [
+                        0.03119645,
+                        7.203e-05,
+                        8.55088908
+                    ]
+                ],
+                "a" : 5.05968033914786,
+                "b" : 6.74028524122764,
+                "c" : 8.55094598755858,
+                "alpha" : 89.9991630075578,
+                "beta" : 105.317518063952,
+                "gamma" : 90.0022593505773,
+                "volume" : 281.25953630278
+            },
+            "sites" : [
+                {
+                    "species" : [
+                        {
+                            "element" : "Cl",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.16063903,
+                        0.74998854,
+                        0.49755777
+                    ],
+                    "xyz" : [
+                        0.798551760570978,
+                        5.05515595710777,
+                        4.03702339694734
+                    ],
+                    "label" : "Cl",
+                    "properties" : {
+                        "magmom" : 0.065
+                    }
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "O",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.76165034,
+                        0.96320076,
+                        0.16141803
+                    ],
+                    "xyz" : [
+                        3.717990619629,
+                        6.49218093610942,
+                        0.348729029194131
+                    ],
+                    "label" : "O",
+                    "properties" : {
+                        "magmom" : 0.081
+                    }
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "O",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.23827726,
+                        0.46327565,
+                        0.83861353
+                    ],
+                    "xyz" : [
+                        1.18771542419295,
+                        3.12264585516238,
+                        6.84818807287639
+                    ],
+                    "label" : "O",
+                    "properties" : {
+                        "magmom" : 0.081
+                    }
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "O",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.23830741,
+                        0.03675093,
+                        0.83859805
+                    ],
+                    "xyz" : [
+                        1.18791376765536,
+                        0.247747576226547,
+                        6.84799690046697
+                    ],
+                    "label" : "O",
+                    "properties" : {
+                        "magmom" : 0.081
+                    }
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "Te",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.40618477,
+                        0.24994075,
+                        0.75413034
+                    ],
+                    "xyz" : [
+                        2.00366075905484,
+                        1.68468437421074,
+                        5.89835876671848
+                    ],
+                    "label" : "Te",
+                    "properties" : {
+                        "magmom" : 0.032
+                    }
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "O",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.74893836,
+                        0.25000296,
+                        0.92694574
+                    ],
+                    "xyz" : [
+                        3.67998770896652,
+                        1.68508078364351,
+                        6.91185862375922
+                    ],
+                    "label" : "O",
+                    "properties" : {
+                        "magmom" : 0.083
+                    }
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "Cl",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.74521998,
+                        0.74999604,
+                        0.80086186
+                    ],
+                    "xyz" : [
+                        3.65786633289204,
+                        5.05516806256149,
+                        5.83878658968365
+                    ],
+                    "label" : "Cl",
+                    "properties" : {
+                        "magmom" : 0.104
+                    }
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "O",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.25106481,
+                        0.74999839,
+                        0.07309656
+                    ],
+                    "xyz" : [
+                        1.22613891434002,
+                        5.05518244846148,
+                        0.285029995457735
+                    ],
+                    "label" : "O",
+                    "properties" : {
+                        "magmom" : 0.083
+                    }
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "Te",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.59388595,
+                        0.75005973,
+                        0.24584105
+                    ],
+                    "xyz" : [
+                        2.90279296082804,
+                        5.05557298177134,
+                        1.29783201919716
+                    ],
+                    "label" : "Te",
+                    "properties" : {
+                        "magmom" : 0.032
+                    }
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "O",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.76168194,
+                        0.53677373,
+                        0.16140314
+                    ],
+                    "xyz" : [
+                        3.71819603842377,
+                        3.61794111553163,
+                        0.348540942044956
+                    ],
+                    "label" : "O",
+                    "properties" : {
+                        "magmom" : 0.081
+                    }
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "Cl",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.25479684,
+                        0.25000525,
+                        0.19913897
+                    ],
+                    "xyz" : [
+                        1.24832554093208,
+                        1.68509476073144,
+                        1.35772893660063
+                    ],
+                    "label" : "Cl",
+                    "properties" : {
+                        "magmom" : 0.104
+                    }
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "Co",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.23109237,
+                        0.74999463,
+                        0.77468361
+                    ],
+                    "xyz" : [
+                        1.15065959708624,
+                        5.05520970026165,
+                        6.31127371254974
+                    ],
+                    "label" : "Co",
+                    "properties" : {
+                        "magmom" : 2.683
+                    }
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "Co",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.76886657,
+                        0.25000615,
+                        0.22527685
+                    ],
+                    "xyz" : [
+                        3.75524885037627,
+                        1.6850496885477,
+                        0.884975006992897
+                    ],
+                    "label" : "Co",
+                    "properties" : {
+                        "magmom" : 2.683
+                    }
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "Co",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        1.155e-05,
+                        0.50000395,
+                        7.69e-06
+                    ],
+                    "xyz" : [
+                        -4.2289257495e-06,
+                        3.37016924348934,
+                        7.11781834387e-05
+                    ],
+                    "label" : "Co",
+                    "properties" : {
+                        "magmom" : 2.697
+                    }
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "Cl",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        0.83937162,
+                        0.2500055,
+                        0.50241981
+                    ],
+                    "xyz" : [
+                        4.10760930985127,
+                        1.68505799807885,
+                        3.15930167750839
+                    ],
+                    "label" : "Cl",
+                    "properties" : {
+                        "magmom" : 0.065
+                    }
+                },
+                {
+                    "species" : [
+                        {
+                            "element" : "Co",
+                            "occu" : 1
+                        }
+                    ],
+                    "abc" : [
+                        1.119e-05,
+                        0.99999702,
+                        7.02e-06
+                    ],
+                    "xyz" : [
+                        -6.67789976115e-05,
+                        6.7402651533015,
+                        8.70013797942e-05
+                    ],
+                    "label" : "Co",
+                    "properties" : {
+                        "magmom" : 2.697
+                    }
+                }
+            ]
+        },
+        "density" : 4.30244320015863,
+        "energy" : -79.70665916,
+        "energy_per_atom" : -4.9816661975,
+        "bandgap" : 2.4452,
+        "cbm" : 4.5251,
+        "vbm" : 2.0799,
+        "is_gap_direct" : false,
+        "is_metal" : false,
+        "spacegroup" : {
+            "source" : "spglib",
+            "symbol" : "P2_1/m",
+            "number" : 11,
+            "point_group" : "2/m",
+            "crystal_system" : "monoclinic",
+            "hall" : "-P 2yb"
+        }
+    },
+    "state" : "successful",
+    "analysis" : {
+        "delta_volume" : 6.08606301155083,
+        "delta_volume_percent" : 0.0221171864379153,
+        "max_force" : 0.061076220946379,
+        "warnings" : [],
+        "errors" : []
+    },
+    "last_updated" : "2013-06-23T16:27:42.000Z",
+    "transformations" : {},
+    "custodian" : [
+        {
+            "corrections" : [],
+            "job" : {
+                "settings_override" : null,
+                "suffix" : ".relax1",
+                "auto_gamma" : true,
+                "output_file" : "vasp.out",
+                "auto_npar" : false,
+                "@module" : "custodian.vasp.jobs",
+                "default_vasp_input_set" : {
+                    "user_incar_settings" : null,
+                    "constrain_total_magmom" : false,
+                    "name" : "MIT",
+                    "@class" : "MITVaspInputSet",
+                    "@module" : "pymatgen.io.vaspio_set"
+                },
+                "gamma_vasp_cmd" : [
+                    "aprun",
+                    "-n",
+                    "32",
+                    "gvasp"
+                ],
+                "vasp_cmd" : [
+                    "mpirun",
+                    "-n",
+                    "32",
+                    "vasp"
+                ],
+                "gzipped" : false,
+                "backup" : true,
+                "final" : false,
+                "@class" : "VaspJob"
+            }
+        },
+        {
+            "corrections" : [],
+            "job" : {
+                "settings_override" : [
+                    {
+                        "action" : {
+                            "_set" : {
+                                "ISTART" : 1
+                            }
+                        },
+                        "dict" : "INCAR"
+                    },
+                    {
+                        "action" : {
+                            "_file_copy" : {
+                                "dest" : "POSCAR"
+                            }
+                        },
+                        "filename" : "CONTCAR"
+                    }
+                ],
+                "suffix" : ".relax2",
+                "auto_gamma" : true,
+                "output_file" : "vasp.out",
+                "auto_npar" : false,
+                "@module" : "custodian.vasp.jobs",
+                "default_vasp_input_set" : {
+                    "user_incar_settings" : null,
+                    "constrain_total_magmom" : false,
+                    "name" : "MIT",
+                    "@class" : "MITVaspInputSet",
+                    "@module" : "pymatgen.io.vaspio_set"
+                },
+                "gamma_vasp_cmd" : [
+                    "aprun",
+                    "-n",
+                    "32",
+                    "gvasp"
+                ],
+                "vasp_cmd" : [
+                    "mpirun",
+                    "-n",
+                    "32",
+                    "vasp"
+                ],
+                "gzipped" : false,
+                "backup" : false,
+                "final" : true,
+                "@class" : "VaspJob"
+            }
+        }
+    ],
+    "orig_inputs" : {
+        "potcar" : {
+            "functional" : "PBE",
+            "symbols" : [
+                "Cl",
+                "O",
+                "Te",
+                "O",
+                "Cl",
+                "O",
+                "Te",
+                "O",
+                "Cl",
+                "Co",
+                "Cl",
+                "Co"
+            ],
+            "@module" : "pymatgen.io.vasp.inputs",
+            "@class" : "Potcar"
+        },
+        "incar" : {
+            "ALGO" : "Fast",
+            "EDIFF" : 0.0001,
+            "ENCUT" : 520,
+            "IBRION" : 1,
+            "ICHARG" : 1,
+            "ISIF" : 3,
+            "ISMEAR" : -5,
+            "ISPIN" : 2,
+            "LDAU" : true,
+            "LDAUJ" : [
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0
+            ],
+            "LDAUL" : [
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                2,
+                0,
+                2
+            ],
+            "LDAUTYPE" : 2,
+            "LDAUU" : [
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                3.32,
+                0,
+                3.32
+            ],
+            "LMAXMIX" : 4,
+            "LORBIT" : 11,
+            "LREAL" : "Auto",
+            "LWAVE" : false,
+            "MAGMOM" : [
+                0.6,
+                0.6,
+                0.6,
+                0.6,
+                0.6,
+                0.6,
+                0.6,
+                0.6,
+                0.6,
+                0.6,
+                0.6,
+                5,
+                5,
+                5,
+                0.6,
+                5
+            ],
+            "NELM" : 100,
+            "NPAR" : 1,
+            "NSW" : 99,
+            "PREC" : "Accurate",
+            "SIGMA" : 0.2,
+            "@module" : "pymatgen.io.vasp.inputs",
+            "@class" : "Incar"
+        },
+        "kpoints" : {
+            "comment" : "Automatic kpoint scheme",
+            "nkpoints" : 0,
+            "generation_style" : "Monkhorst",
+            "kpoints" : [
+                [
+                    6,
+                    4,
+                    4
+                ]
+            ],
+            "usershift" : [
+                0,
+                0,
+                0
+            ],
+            "kpts_weights" : null,
+            "coord_type" : null,
+            "labels" : null,
+            "tet_number" : 0,
+            "tet_weight" : 0,
+            "tet_connections" : null,
+            "@module" : "pymatgen.io.vasp.inputs",
+            "@class" : "Kpoints"
+        },
+        "poscar" : {
+            "@module" : "pymatgen.io.vasp.inputs",
+            "@class" : "Poscar",
+            "structure" : {
+                "@module" : "pymatgen.core.structure",
+                "@class" : "Structure",
+                "lattice" : {
+                    "matrix" : [
+                        [
+                            4.85343059212385,
+                            6.04126165923e-05,
+                            -1.29721955888892
+                        ],
+                        [
+                            6.91070227106e-05,
+                            6.66863986414793,
+                            -8.24090625084e-05
+                        ],
+                        [
+                            0.109988050864569,
+                            -8.61947386175e-05,
+                            8.47259033824259
+                        ]
+                    ],
+                    "a" : 5.02380006570498,
+                    "b" : 6.6686398650152,
+                    "c" : 8.47330422081282,
+                    "alpha" : 90.0012831189018,
+                    "beta" : 104.220410424159,
+                    "gamma" : 89.9985545549042,
+                    "volume" : 275.173473532171
+                },
+                "sites" : [
+                    {
+                        "species" : [
+                            {
+                                "element" : "Cl",
+                                "occu" : 1
+                            }
+                        ],
+                        "abc" : [
+                            0.160692092124477,
+                            0.749979095140858,
+                            0.500566390643178
+                        ],
+                        "xyz" : [
+                            0.835016066286838,
+                            5.00130705277447,
+                            4.03257923507557
+                        ],
+                        "label" : "Cl",
+                        "properties" : {
+                            "velocities" : [
+                                0.0,
+                                0.0,
+                                0.0
+                            ]
+                        }
+                    },
+                    {
+                        "species" : [
+                            {
+                                "element" : "O",
+                                "occu" : 1
+                            }
+                        ],
+                        "abc" : [
+                            0.764107085729787,
+                            0.96455099115692,
+                            0.16327595579065
+                        ],
+                        "xyz" : [
+                            3.72656576691727,
+                            6.43227527881251,
+                            0.392076141061965
+                        ],
+                        "label" : "O",
+                        "properties" : {
+                            "velocities" : [
+                                0.0,
+                                0.0,
+                                0.0
+                            ]
+                        }
+                    },
+                    {
+                        "species" : [
+                            {
+                                "element" : "O",
+                                "occu" : 1
+                            }
+                        ],
+                        "abc" : [
+                            0.235850317178947,
+                            0.464575668048583,
+                            0.836716435122868
+                        ],
+                        "xyz" : [
+                            1.23674405982518,
+                            3.0980299476423,
+                            6.78316765441084
+                        ],
+                        "label" : "O",
+                        "properties" : {
+                            "velocities" : [
+                                0.0,
+                                0.0,
+                                0.0
+                            ]
+                        }
+                    },
+                    {
+                        "species" : [
+                            {
+                                "element" : "O",
+                                "occu" : 1
+                            }
+                        ],
+                        "abc" : [
+                            0.235867627654008,
+                            0.0354279540073287,
+                            0.836728840520845
+                        ],
+                        "xyz" : [
+                            1.23679978233912,
+                            0.236198394155325,
+                            6.78328567043985
+                        ],
+                        "label" : "O",
+                        "properties" : {
+                            "velocities" : [
+                                0.0,
+                                0.0,
+                                0.0
+                            ]
+                        }
+                    },
+                    {
+                        "species" : [
+                            {
+                                "element" : "Te",
+                                "occu" : 1
+                            }
+                        ],
+                        "abc" : [
+                            0.412549776425686,
+                            0.249977389812936,
+                            0.751400531491405
+                        ],
+                        "xyz" : [
+                            2.08494406074877,
+                            1.66696934328125,
+                            5.83112064386744
+                        ],
+                        "label" : "Te",
+                        "properties" : {
+                            "velocities" : [
+                                0.0,
+                                0.0,
+                                0.0
+                            ]
+                        }
+                    },
+                    {
+                        "species" : [
+                            {
+                                "element" : "O",
+                                "occu" : 1
+                            }
+                        ],
+                        "abc" : [
+                            0.754765044517832,
+                            0.249982529084906,
+                            0.922307024567344
+                        ],
+                        "xyz" : [
+                            3.76465978440774,
+                            1.66700955811447,
+                            6.83521300630248
+                        ],
+                        "label" : "O",
+                        "properties" : {
+                            "velocities" : [
+                                0.0,
+                                0.0,
+                                0.0
+                            ]
+                        }
+                    },
+                    {
+                        "species" : [
+                            {
+                                "element" : "Cl",
+                                "occu" : 1
+                            }
+                        ],
+                        "abc" : [
+                            0.741256986076674,
+                            0.750008214534492,
+                            0.803518932074337
+                        ],
+                        "xyz" : [
+                            3.68606864485641,
+                            5.0015102000529,
+                            5.84625187251248
+                        ],
+                        "label" : "Cl",
+                        "properties" : {
+                            "velocities" : [
+                                0.0,
+                                0.0,
+                                0.0
+                            ]
+                        }
+                    },
+                    {
+                        "species" : [
+                            {
+                                "element" : "O",
+                                "occu" : 1
+                            }
+                        ],
+                        "abc" : [
+                            0.245222438182061,
+                            0.750016335875889,
+                            0.0777520334252487
+                        ],
+                        "xyz" : [
+                            1.19877370935117,
+                            5.00159694889706,
+                            0.340591975946173
+                        ],
+                        "label" : "O",
+                        "properties" : {
+                            "velocities" : [
+                                0.0,
+                                0.0,
+                                0.0
+                            ]
+                        }
+                    },
+                    {
+                        "species" : [
+                            {
+                                "element" : "Te",
+                                "occu" : 1
+                            }
+                        ],
+                        "abc" : [
+                            0.587520693525747,
+                            0.750033140123147,
+                            0.24860474406942
+                        ],
+                        "xyz" : [
+                            2.87888629125681,
+                            5.00171496289873,
+                            1.34412100822233
+                        ],
+                        "label" : "Te",
+                        "properties" : {
+                            "velocities" : [
+                                0.0,
+                                0.0,
+                                0.0
+                            ]
+                        }
+                    },
+                    {
+                        "species" : [
+                            {
+                                "element" : "O",
+                                "occu" : 1
+                            }
+                        ],
+                        "abc" : [
+                            0.764114732349919,
+                            0.535447094198994,
+                            0.163293010841053
+                        ],
+                        "xyz" : [
+                            3.72657510101634,
+                            3.57073592468955,
+                            0.392246084221906
+                        ],
+                        "label" : "O",
+                        "properties" : {
+                            "velocities" : [
+                                0.0,
+                                0.0,
+                                0.0
+                            ]
+                        }
+                    },
+                    {
+                        "species" : [
+                            {
+                                "element" : "Cl",
+                                "occu" : 1
+                            }
+                        ],
+                        "abc" : [
+                            0.258757020452288,
+                            0.249989789176678,
+                            0.196488918304381
+                        ],
+                        "xyz" : [
+                            1.27748794818078,
+                            1.66709056961124,
+                            1.32908484144274
+                        ],
+                        "label" : "Cl",
+                        "properties" : {
+                            "velocities" : [
+                                0.0,
+                                0.0,
+                                0.0
+                            ]
+                        }
+                    },
+                    {
+                        "species" : [
+                            {
+                                "element" : "Co",
+                                "occu" : 1
+                            }
+                        ],
+                        "abc" : [
+                            0.233165129540522,
+                            0.750003734700252,
+                            0.775121034901736
+                        ],
+                        "xyz" : [
+                            1.21695665506659,
+                            5.0014520782425,
+                            6.26475481768156
+                        ],
+                        "label" : "Co",
+                        "properties" : {
+                            "velocities" : [
+                                0.0,
+                                0.0,
+                                0.0
+                            ]
+                        }
+                    },
+                    {
+                        "species" : [
+                            {
+                                "element" : "Co",
+                                "occu" : 1
+                            }
+                        ],
+                        "abc" : [
+                            0.766792619567399,
+                            0.249996023014811,
+                            0.224823788408838
+                        ],
+                        "xyz" : [
+                            3.74631996437912,
+                            1.66716039027587,
+                            0.91012087182743
+                        ],
+                        "label" : "Co",
+                        "properties" : {
+                            "velocities" : [
+                                0.0,
+                                0.0,
+                                0.0
+                            ]
+                        }
+                    },
+                    {
+                        "species" : [
+                            {
+                                "element" : "Co",
+                                "occu" : 1
+                            }
+                        ],
+                        "abc" : [
+                            1.41058153896e-05,
+                            0.500004328784573,
+                            1.35316697435e-05
+                        ],
+                        "xyz" : [
+                            0.00010450372842348,
+                            3.33434879886514,
+                            5.51450667263238e-05
+                        ],
+                        "label" : "Co",
+                        "properties" : {
+                            "velocities" : [
+                                0.0,
+                                0.0,
+                                0.0
+                            ]
+                        }
+                    },
+                    {
+                        "species" : [
+                            {
+                                "element" : "Cl",
+                                "occu" : 1
+                            }
+                        ],
+                        "abc" : [
+                            0.839306388350428,
+                            0.250014152762199,
+                            0.499377267929408
+                        ],
+                        "xyz" : [
+                            4.12845811146431,
+                            1.66726200671313,
+                            3.14223374909615
+                        ],
+                        "label" : "Cl",
+                        "properties" : {
+                            "velocities" : [
+                                0.0,
+                                0.0,
+                                0.0
+                            ]
+                        }
+                    },
+                    {
+                        "species" : [
+                            {
+                                "element" : "Co",
+                                "occu" : 1
+                            }
+                        ],
+                        "abc" : [
+                            1.79425088352e-05,
+                            0.999993559577428,
+                            1.15602395523e-05
+                        ],
+                        "xyz" : [
+                            0.000157460787128268,
+                            6.66859691537675,
+                            -7.73873121718553e-06
+                        ],
+                        "label" : "Co",
+                        "properties" : {
+                            "velocities" : [
+                                0.0,
+                                0.0,
+                                0.0
+                            ]
+                        }
+                    }
+                ]
+            },
+            "true_names" : true,
+            "selective_dynamics" : null,
+            "velocities" : [
+                [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                [
+                    0.0,
+                    0.0,
+                    0.0
+                ]
+            ],
+            "predictor_corrector" : null,
+            "comment" : "Co4 Te2 Cl4 O6"
+        }
+    },
+    "task_id" : "mp-637730",
+    "sbxn" : [
+        "basf",
+        "core",
+        "jcesr",
+        "mkhorton",
+        "shyamd",
+        "vw"
+    ],
+    "task_type" : "GGA+U Structure Optimization",
+    "tags" : [
+        "mp_2018",
+        "mp_production_old",
+        "prod"
+    ]
+}


### PR DESCRIPTION
Sigh it seems there are still lots of bugs in validation. This PR is attempting to fix them all
- add static input sets to validation
- only warn not deprecate on kspacing too large
- ensure LDAU checking happens whenever input has U-Values instead of just input_set expects U-values
- fix negative skip bug in max scf gradient checking
- Only checks the SCF gradient when validating input set to ensure this makes sense (IE not for NSCF calcs)
