### PR TITLE
Fix Deprecated Materials Speed

### DIFF
--- a/emmet-builders/emmet/builders/vasp/materials.py
+++ b/emmet-builders/emmet/builders/vasp/materials.py
@@ -224,13 +224,15 @@ class MaterialsBuilder(Builder):
         for group in grouped_tasks:
             try:
                 materials.append(MaterialsDoc.from_tasks(group))
-            except Exception:
+            except Exception as e:
                 failed_ids = list({t_.task_id for t_ in group})
+                doc = MaterialsDoc.construct_deprecated_material(tasks)
+                doc.warnings.append(str(e))
+                materials.append(doc)
                 self.logger.warn(
-                    f"No valid ids found among ids {failed_ids}. This can be the case if the required "
-                    "calculation types are missing from your tasks database."
+                    f"Failed making material for {failed_ids}."
+                    f" Inserted as deprecated Material: {doc.material_id}"
                 )
-                materials.append(MaterialsDoc.construct_deprecated_material(tasks))
 
         self.logger.debug(f"Produced {len(materials)} materials for {formula}")
 

--- a/emmet-core/emmet/core/material.py
+++ b/emmet-core/emmet/core/material.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Mapping, Sequence, Type, TypeVar
+from typing import List, Mapping, Type, TypeVar
 
 from pydantic import BaseModel, Field
 from pymatgen.core import Structure
@@ -50,18 +50,18 @@ class MaterialsDoc(StructureMetadata):
         description="Whether this materials document is deprecated.",
     )
 
-    initial_structures: Sequence[Structure] = Field(
+    initial_structures: List[Structure] = Field(
         [],
         description="Initial structures used in the DFT optimizations corresponding to this material",
     )
 
-    task_ids: Sequence[MPID] = Field(
+    task_ids: List[MPID] = Field(
         [],
         title="Calculation IDs",
         description="List of Calculations IDs used to make this Materials Document",
     )
 
-    deprecated_tasks: Sequence[str] = Field([], title="Deprecated Tasks")
+    deprecated_tasks: List[str] = Field([], title="Deprecated Tasks")
 
     calc_types: Mapping[str, str] = Field(
         None,
@@ -78,13 +78,11 @@ class MaterialsDoc(StructureMetadata):
         default_factory=datetime.utcnow,
     )
 
-    origins: Sequence[PropertyOrigin] = Field(
+    origins: List[PropertyOrigin] = Field(
         None, description="Dictionary for tracking the provenance of properties"
     )
 
-    warnings: Sequence[str] = Field(
-        [], description="Any warnings related to this material"
-    )
+    warnings: List[str] = Field([], description="Any warnings related to this material")
 
     @classmethod
     def from_structure(  # type: ignore[override]

--- a/emmet-core/emmet/core/vasp/material.py
+++ b/emmet-core/emmet/core/vasp/material.py
@@ -198,15 +198,6 @@ class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
             task_group[0].output.structure, symprec=0.1
         ).get_conventional_standard_structure()
 
-        # Initial Structures
-        initial_structures = [task.input.structure for task in task_group]
-        sm = StructureMatcher(
-            ltol=0.1, stol=0.1, angle_tol=0.1, scale=False, attempt_supercell=False
-        )
-        initial_structures = [
-            group[0] for group in sm.group_structures(initial_structures)
-        ]
-
         # Deprecated
         deprecated = True
 
@@ -219,7 +210,6 @@ class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
             calc_types=calc_types,
             run_types=run_types,
             task_types=task_types,
-            initial_structures=initial_structures,
             deprecated=deprecated,
             deprecated_tasks=deprecated_tasks,
         )

--- a/emmet-core/emmet/core/vasp/material.py
+++ b/emmet-core/emmet/core/vasp/material.py
@@ -1,5 +1,5 @@
 """ Core definition of a Materials Document """
-from typing import Dict, List, Mapping, Sequence
+from typing import Dict, List, Mapping
 
 from pydantic import Field
 from pymatgen.analysis.structure_analyzer import SpacegroupAnalyzer
@@ -29,7 +29,7 @@ class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
         description="Run types for all the calculations that make up this material",
     )
 
-    origins: Sequence[PropertyOrigin] = Field(
+    origins: List[PropertyOrigin] = Field(
         None, description="Mappingionary for tracking the provenance of properties"
     )
 


### PR DESCRIPTION
This PR fixes some slowdowns caused by inserting deprecated materials docs.  It also stores the error so we can better diagnose why it failed. 