### PR TITLE
New EmmetBaseModel

### DIFF
--- a/emmet-builders/emmet/builders/materials/provenance.py
+++ b/emmet-builders/emmet/builders/materials/provenance.py
@@ -4,12 +4,10 @@ from typing import Dict, Iterable, List, Optional, Tuple
 
 from maggma.core import Builder, Store
 from maggma.utils import grouper
-from pymatgen.analysis.structure_matcher import OrderDisorderElementComparator
-from pymatgen.core import Structure
-from pymatgen.util.provenance import StructureNL
+from pymatgen.core.structure import Structure
 
 from emmet.builders.settings import EmmetBuildSettings
-from emmet.core.provenance import ProvenanceDoc
+from emmet.core.provenance import ProvenanceDoc, SNLDict
 from emmet.core.utils import group_structures
 
 
@@ -214,7 +212,7 @@ class ProvenanceBuilder(Builder):
         snl_strucs = []
         for snl in snls:
             struc = Structure.from_dict(snl)
-            struc.snl = snl
+            struc.snl = SNLDict(**snl)
             snl_strucs.append(struc)
 
         groups = group_structures(

--- a/emmet-core/emmet/core/base.py
+++ b/emmet-core/emmet/core/base.py
@@ -23,6 +23,6 @@ class EmmetBaseModel(BaseModel):
     )
 
     build_date: datetime = Field(
-        default_factory=datetime.utcnow(),
+        default_factory=datetime.utcnow,
         description="The build date for this document",
     )

--- a/emmet-core/emmet/core/base.py
+++ b/emmet-core/emmet/core/base.py
@@ -1,0 +1,28 @@
+""" Base emmet model to add default metadata """
+from datetime import datetime
+from typing import List, Optional, Type, TypeVar
+
+from pydantic import BaseModel, Field
+from pymatgen.core import __version__ as pmg_version
+
+from emmet.core import __version__
+
+T = TypeVar("T", bound="EmmetBaseModel")
+
+
+class EmmetBaseModel(BaseModel):
+    """
+    Base Model for default emmet metadata
+    """
+
+    emmet_version: str = Field(
+        __version__, description="The version of emmet this document was built with"
+    )
+    pymatgen_version: str = Field(
+        pmg_version, description="The version of pymatgen this document was built with"
+    )
+
+    build_date: datetime = Field(
+        default_factory=datetime.utcnow(),
+        description="The build date for this document",
+    )

--- a/emmet-core/emmet/core/optimade.py
+++ b/emmet-core/emmet/core/optimade.py
@@ -7,6 +7,7 @@ from optimade.models import Species, StructureResourceAttributes
 from pymatgen.core.composition import Composition, formula_double_format
 from pymatgen.core.structure import Structure
 
+from emmet.core.base import BaseModel, EmmetBaseModel
 from emmet.core.mpid import MPID
 
 letters = "ABCDEFGHIJKLMNOPQRSTUVXYZ"
@@ -75,7 +76,7 @@ def hill_formula(comp: Composition) -> str:
     return "".join(formula)
 
 
-class OptimadeMaterialsDoc(StructureResourceAttributes):
+class OptimadeMaterialsDoc(StructureResourceAttributes, EmmetBaseModel):
     """Optimade Structure resource with a few extra MP specific fields for materials"""
 
     material_id: MPID

--- a/emmet-core/emmet/core/structure.py
+++ b/emmet-core/emmet/core/structure.py
@@ -8,12 +8,13 @@ from pymatgen.core.composition import Composition
 from pymatgen.core.periodic_table import Element
 from pymatgen.core.structure import Structure
 
+from emmet.core.base import EmmetBaseModel
 from emmet.core.symmetry import SymmetryData
 
 T = TypeVar("T", bound="StructureMetadata")
 
 
-class StructureMetadata(BaseModel):
+class StructureMetadata(EmmetBaseModel):
     """
     Mix-in class for structure metadata
     """

--- a/emmet-core/emmet/core/structure_group.py
+++ b/emmet-core/emmet/core/structure_group.py
@@ -7,7 +7,7 @@ from typing import Iterable, List, Union
 from monty.json import MontyDecoder
 from pydantic import BaseModel, Field, validator
 from pymatgen.analysis.structure_matcher import ElementComparator, StructureMatcher
-from pymatgen.core import Composition
+from pymatgen.core.composition import Composition
 from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEntry
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 

--- a/emmet-core/emmet/core/stubs.py
+++ b/emmet-core/emmet/core/stubs.py
@@ -5,7 +5,7 @@ outside the standard MSONable model
 """
 from typing import Dict
 
-import pymatgen.core.structure
+import pymatgen.core.composition
 from pydantic import BaseModel
 from pymatgen.core.periodic_table import Element
 
@@ -30,8 +30,8 @@ def get_validators(cls):
 def validate_composition(cls, v):
     if isinstance(v, pymatgen.core.structure.Composition):
         return v
-    return pymatgen.core.structure.Composition(**v)
+    return pymatgen.core.composition.Composition(**v)
 
 
-pymatgen.core.structure.Composition.__pydantic_model__ = StubComposition
-pymatgen.core.structure.Composition.__get_validators__ = get_validators
+pymatgen.core.composition.Composition.__pydantic_model__ = StubComposition
+pymatgen.core.composition.Composition.__get_validators__ = get_validators

--- a/emmet-core/emmet/core/summary.py
+++ b/emmet-core/emmet/core/summary.py
@@ -4,7 +4,6 @@ from pydantic import BaseModel, Field
 from pymatgen.core.periodic_table import Element
 from pymatgen.core.structure import Structure
 
-from emmet.core.base import EmmetBaseModel
 from emmet.core.electronic_structure import BandstructureData, DosData
 from emmet.core.material_property import PropertyDoc
 from emmet.core.mpid import MPID
@@ -84,7 +83,7 @@ class GBSearchData(BaseModel):
     rotation_angle: float = Field(None, description="Rotation angle in degrees")
 
 
-class SummaryDoc(EmmetBaseModel):
+class SummaryDoc(PropertyDoc):
     """
     Summary information about materials and their properties, useful for materials
     screening studies and searching.

--- a/emmet-core/emmet/core/summary.py
+++ b/emmet-core/emmet/core/summary.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field
 from pymatgen.core.periodic_table import Element
 from pymatgen.core.structure import Structure
 
+from emmet.core.base import EmmetBaseModel
 from emmet.core.electronic_structure import BandstructureData, DosData
 from emmet.core.material_property import PropertyDoc
 from emmet.core.mpid import MPID
@@ -83,7 +84,7 @@ class GBSearchData(BaseModel):
     rotation_angle: float = Field(None, description="Rotation angle in degrees")
 
 
-class SummaryDoc(PropertyDoc):
+class SummaryDoc(EmmetBaseModel):
     """
     Summary information about materials and their properties, useful for materials
     screening studies and searching.

--- a/emmet-core/emmet/core/task.py
+++ b/emmet-core/emmet/core/task.py
@@ -2,12 +2,13 @@
 from datetime import datetime
 from typing import ClassVar, List
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
+from emmet.core.base import EmmetBaseModel
 from emmet.core.mpid import MPID
 
 
-class TaskDocument(BaseModel):
+class TaskDocument(EmmetBaseModel):
     """
     Definition of Task Document
     """

--- a/emmet-core/emmet/core/vasp/validation.py
+++ b/emmet-core/emmet/core/vasp/validation.py
@@ -2,11 +2,12 @@ from datetime import datetime
 from typing import Dict, List, Union
 
 import numpy as np
-from pydantic import BaseModel, Field, PyObject
+from pydantic import Field, PyObject
 from pymatgen.core.structure import Structure
 from pymatgen.io.vasp.sets import VaspInputSet
 
 from emmet.core import SETTINGS
+from emmet.core.base import EmmetBaseModel
 from emmet.core.mpid import MPID
 from emmet.core.utils import DocEnum
 from emmet.core.vasp.task import TaskDocument
@@ -23,7 +24,7 @@ class DeprecationMessage(DocEnum):
     LDAU = "I001", "LDAU Parameters don't match the inputset"
 
 
-class ValidationDoc(BaseModel):
+class ValidationDoc(EmmetBaseModel):
     """
     Validation document for a VASP calculation
     """


### PR DESCRIPTION
This PR adds a new EmmetBaseModel for documents to inherit from so that certain fields are always present at the top level. This is recommended for top-level document models and not for sub-fields. 