### PR TITLE
fix bugs in MPID

### DIFF
--- a/emmet-core/emmet/core/mpid.py
+++ b/emmet-core/emmet/core/mpid.py
@@ -26,7 +26,7 @@ class MPID(str):
             self.parts = val.parts  # type: ignore
             self.string = val.string  # type: ignore
 
-        elif isinstance(val, int) or isinstance(val, str) and val.isnumeric():
+        elif isinstance(val, int) or (isinstance(val, str) and val.isnumeric()):
             self.parts = ("", int(val))
             self.string = str(val)
 
@@ -58,7 +58,7 @@ class MPID(str):
 
         other_parts = MPID(other).parts
 
-        if self.parts[0] != "" and other_parts[0] != "":
+        if (self.parts[0] != "" and other_parts[0] != ""):
             # both have prefixes; normal comparison
             return self.parts < other_parts
         elif self.parts[0] != "":

--- a/emmet-core/emmet/core/mpid.py
+++ b/emmet-core/emmet/core/mpid.py
@@ -10,6 +10,14 @@ class MPID(str):
     This class enables seemlessly mixing MPIDs and regular integer IDs
     Prefixed IDs are considered less than non-prefixed IDs to enable proper
     mixing with the Materials Project
+
+    Args:
+        val: Either 1) a prefixed string e.g. "mp-1234"
+                    2) an integer e.g. 1234
+                    3) a number stored as a string e.g. '1234'
+                    4) an MPID
+
+            Numbers stored as strings are coerced to ints
     """
 
     def __init__(self, val: Union["MPID", int, str]):
@@ -18,8 +26,8 @@ class MPID(str):
             self.parts = val.parts  # type: ignore
             self.string = val.string  # type: ignore
 
-        elif isinstance(val, int):
-            self.parts = (None, val)
+        elif isinstance(val, int) or isinstance(val, str) and val.isnumeric():
+            self.parts = ("", int(val))
             self.string = str(val)
 
         elif isinstance(val, str):
@@ -48,15 +56,24 @@ class MPID(str):
 
     def __lt__(self, other: Union["MPID", int, str]):
 
-        # Always sort MPIDs before pure integer IDs
-        if isinstance(other, int):
-            return True
-        elif isinstance(other, str):
-            other_parts = MPID(other).parts
-        else:
-            other_parts = other.parts
+        other_parts = MPID(other).parts
 
-        return self.parts < other_parts
+        if self.parts[0] != "" and other_parts[0] != "":
+            # both have prefixes; normal comparison
+            return self.parts < other_parts
+        elif self.parts[0] != "":
+            # other is a pure int, self is prefixed
+            # Always sort MPIDs before pure integer IDs
+            return True
+        elif other_parts[0] != "":
+            # self is pure int, other is prefixed
+            return False
+        else:
+            # both are pure ints; normal comparison
+            return self.parts[1] < other_parts[1]
+
+    def __gt__(self, other: Union["MPID", int, str]):
+        return not self.__lt__(other)
 
     def __hash__(self):
         return hash(self.string)

--- a/emmet-core/emmet/core/vasp/material.py
+++ b/emmet-core/emmet/core/vasp/material.py
@@ -7,6 +7,7 @@ from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.entries.computed_entries import ComputedStructureEntry
 
 from emmet.core import SETTINGS
+from emmet.core.mpid import MPID
 from emmet.core.material import MaterialsDoc as CoreMaterialsDoc
 from emmet.core.material import PropertyOrigin
 from emmet.core.structure import StructureMetadata
@@ -189,7 +190,7 @@ class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
         calc_types = {task.task_id: task.calc_type for task in task_group}
 
         # Material ID
-        material_id = min([task.task_id for task in task_group])
+        material_id = min([MPID(task.task_id) for task in task_group])
 
         # Choose any random structure for metadata
         structure = SpacegroupAnalyzer(

--- a/emmet-core/emmet/core/vasp/material.py
+++ b/emmet-core/emmet/core/vasp/material.py
@@ -7,7 +7,6 @@ from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.entries.computed_entries import ComputedStructureEntry
 
 from emmet.core import SETTINGS
-from emmet.core.mpid import MPID
 from emmet.core.material import MaterialsDoc as CoreMaterialsDoc
 from emmet.core.material import PropertyOrigin
 from emmet.core.structure import StructureMetadata
@@ -190,7 +189,7 @@ class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
         calc_types = {task.task_id: task.calc_type for task in task_group}
 
         # Material ID
-        material_id = min([MPID(task.task_id) for task in task_group])
+        material_id = min([task.task_id for task in task_group])
 
         # Choose any random structure for metadata
         structure = SpacegroupAnalyzer(

--- a/tests/emmet-core/test_mpid.py
+++ b/tests/emmet-core/test_mpid.py
@@ -8,8 +8,14 @@ def test_mpid():
     assert MPID("mp-3") < MPID("np-3")
     assert MPID("mp-3") > MPID("mp-2")
     assert 3 > MPID("mp-3")
+    assert MPID(MPID('mp-1234')) < MPID(1234)
+    assert 'mp-1234' < MPID(1234)
+    assert MPID('1234') > MPID('mp-1234')
+    assert MPID('1234') == MPID(1234)
+    assert MPID('1234') == '1234'
+    assert MPID("mp-12345") > MPID('mp-1234')
 
-    assert min([MPID("mp-44545"), MPID("mp-33"), MPID("mp-2134234")]) == MPID("mp-33")
+    assert min([MPID("mp-44545"), MPID("mp-33"), MPID("mp-2134234"), MPID(33), MPID('33')]) == MPID("mp-33")
 
     assert (
         len(set([MPID("mp-33"), MPID("mp-44545"), MPID("mp-33"), MPID("mp-2134234")]))


### PR DESCRIPTION
Fixes several bugs in `MPID` to make more robust, especially when building from a collection of task documents that has heterogeneous task ids (e.g., mixture of ints, MPID, prefixed strings)

## Contributor Checklist

- [ x ] I have broken down my PR scope into the following TODO tasks
   -  [ x ] Fix bugs in `MPID.__lt__` when comparing pure integer MPIDs and add more tests to cover edge cases
   -  [ x ] Support coercing number strings e.g. `'1234'` into `int` when instantiating `MPID`
- [ x ] I have run the tests locally and they passed.
- [ x ] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR
