### PR TITLE
[WIP] Builder updates for legacy data parity

### DIFF
--- a/emmet-core/emmet/core/material_property.py
+++ b/emmet-core/emmet/core/material_property.py
@@ -34,8 +34,9 @@ class PropertyDoc(StructureMetadata):
         description="Whether this property document is deprecated.",
     )
 
-    reasons: List[Union[DeprecationMessage, str]] = Field(
-        None, description="List of deprecation tags detailing why this document isn't valid"
+    deprecation_reasons: List[Union[DeprecationMessage, str]] = Field(
+        None,
+        description="List of deprecation tags detailing why this document isn't valid",
     )
 
     last_updated: datetime = Field(

--- a/emmet-core/emmet/core/structure.py
+++ b/emmet-core/emmet/core/structure.py
@@ -20,17 +20,10 @@ class StructureMetadata(EmmetBaseModel):
     """
 
     # Structure metadata
-    structure: Optional[Structure] = Field(
-        None, description="The structure for this metadata"
-    )
     nsites: int = Field(None, description="Total number of sites in the structure")
-    elements: List[Element] = Field(
-        None, description="List of elements in the material"
-    )
+    elements: List[Element] = Field(None, description="List of elements in the material")
     nelements: int = Field(None, title="Number of Elements")
-    composition: Composition = Field(
-        None, description="Full composition for the material"
-    )
+    composition: Composition = Field(None, description="Full composition for the material")
     composition_reduced: Composition = Field(
         None,
         title="Reduced Composition",
@@ -57,9 +50,7 @@ class StructureMetadata(EmmetBaseModel):
         description="Total volume for this structure in Angstroms^3",
     )
 
-    density: float = Field(
-        None, title="Density", description="Density in grams per cm^3"
-    )
+    density: float = Field(None, title="Density", description="Density in grams per cm^3")
 
     density_atomic: float = Field(
         None,
@@ -70,12 +61,7 @@ class StructureMetadata(EmmetBaseModel):
     symmetry: SymmetryData = Field(None, description="Symmetry data for this material")
 
     @classmethod
-    def from_composition(
-        cls: Type[T],
-        composition: Composition,
-        fields: Optional[List[str]] = None,
-        **kwargs
-    ) -> T:
+    def from_composition(cls: Type[T], composition: Composition, fields: Optional[List[str]] = None, **kwargs) -> T:
 
         fields = (
             [
@@ -107,13 +93,7 @@ class StructureMetadata(EmmetBaseModel):
         return cls(**{k: v for k, v in data.items() if k in fields}, **kwargs)
 
     @classmethod
-    def from_structure(
-        cls: Type[T],
-        structure: Structure,
-        fields: Optional[List[str]] = None,
-        include_structure: bool = False,
-        **kwargs
-    ) -> T:
+    def from_structure(cls: Type[T], structure: Structure, fields: Optional[List[str]] = None, **kwargs) -> T:
 
         fields = (
             [
@@ -151,8 +131,5 @@ class StructureMetadata(EmmetBaseModel):
             "density_atomic": structure.volume / structure.num_sites,
             "symmetry": symmetry,
         }
-
-        if include_structure:
-            kwargs.update({"structure": structure})
 
         return cls(**{k: v for k, v in data.items() if k in fields}, **kwargs)


### PR DESCRIPTION
This PR contains general builder updates to reorganize and clean data such that it is commensurate with current legacy builds.

- [ ] Explicit `structure` field removed as an option from `StructureMetdata` and class methods
- [ ] `reasons` renamed to `deprecation_reasons`
- [ ] Builders associated with models inheriting from `PropertyDoc` altered to always populate structure metadata