### PR TITLE
Materials and thermo builder fixes

### DIFF
--- a/emmet-builders/emmet/builders/vasp/thermo.py
+++ b/emmet-builders/emmet/builders/vasp/thermo.py
@@ -245,7 +245,10 @@ class ThermoBuilder(Builder):
                 d["material_id"]: d.get("average_oxidation_states", {})
                 for d in self.oxidation_states.query(
                     properties=["material_id", "average_oxidation_states"],
-                    criteria={"material_id": {"$in": material_ids}, "successful": True},
+                    criteria={
+                        "material_id": {"$in": material_ids},
+                        "state": "successful",
+                    },
                 )
             }
 

--- a/emmet-core/emmet/core/mpid.py
+++ b/emmet-core/emmet/core/mpid.py
@@ -58,12 +58,7 @@ class MPID(str):
 
         if self.parts[0] != "" and other_parts[0] != "":
             # both have prefixes; normal comparison
-
-            # if prefixes are different, sort using int value
-            if self.parts[0] != other_parts[0]:
-                return self.parts[1] < other_parts[1]
-            else:  # compare normally
-                return self.parts < other_parts
+            return self.parts[1] < other_parts[1]
         elif self.parts[0] != "":
             # other is a pure int, self is prefixed
             # Always sort MPIDs before pure integer IDs

--- a/emmet-core/emmet/core/mpid.py
+++ b/emmet-core/emmet/core/mpid.py
@@ -58,7 +58,7 @@ class MPID(str):
 
         if self.parts[0] != "" and other_parts[0] != "":
             # both have prefixes; normal comparison
-            return self.parts[1] < other_parts[1]
+            return self.parts < other_parts
         elif self.parts[0] != "":
             # other is a pure int, self is prefixed
             # Always sort MPIDs before pure integer IDs

--- a/emmet-core/emmet/core/mpid.py
+++ b/emmet-core/emmet/core/mpid.py
@@ -38,9 +38,7 @@ class MPID(str):
 
         else:
 
-            raise ValueError(
-                "Must provide an MPID, int, or string of the format prefix-number"
-            )
+            raise ValueError("Must provide an MPID, int, or string of the format prefix-number")
 
     def __eq__(self, other: object):
         if isinstance(other, MPID):
@@ -58,9 +56,14 @@ class MPID(str):
 
         other_parts = MPID(other).parts
 
-        if (self.parts[0] != "" and other_parts[0] != ""):
+        if self.parts[0] != "" and other_parts[0] != "":
             # both have prefixes; normal comparison
-            return self.parts < other_parts
+
+            # if prefixes are different, sort using int value
+            if self.parts[0] != other_parts[0]:
+                return self.parts[1] < other_parts[1]
+            else:  # compare normally
+                return self.parts < other_parts
         elif self.parts[0] != "":
             # other is a pure int, self is prefixed
             # Always sort MPIDs before pure integer IDs
@@ -85,8 +88,7 @@ class MPID(str):
     @classmethod
     def __modify_schema__(cls, field_schema):
         field_schema.update(
-            pattern=r"^([A-Za-z]*-)?(\d+)(-[A-Za-z0-9]+)*$",
-            examples=["mp-3534", "3453", "mp-834-Ag"],
+            pattern=r"^([A-Za-z]*-)?(\d+)(-[A-Za-z0-9]+)*$", examples=["mp-3534", "3453", "mp-834-Ag"],
         )
 
     @classmethod

--- a/emmet-core/emmet/core/thermo.py
+++ b/emmet-core/emmet/core/thermo.py
@@ -15,12 +15,16 @@ class DecompositionProduct(BaseModel):
     Entry metadata for a decomposition process
     """
 
-    material_id: MPID = Field(None, description="The material this decomposition points to")
+    material_id: MPID = Field(
+        None, description="The material this decomposition points to"
+    )
     formula: str = Field(
-        None, description="The formula of the decomposed material this material decomposes to",
+        None,
+        description="The formula of the decomposed material this material decomposes to",
     )
     amount: float = Field(
-        None, description="The amount of the decomposed material by formula units this this material decomposes to",
+        None,
+        description="The amount of the decomposed material by formula units this this material decomposes to",
     )
 
 
@@ -36,17 +40,23 @@ class ThermoDoc(PropertyDoc):
     )
 
     energy_per_atom: float = Field(
-        ..., description="The total corrected DFT energy of this material per atom in eV/atom",
+        ...,
+        description="The total corrected DFT energy of this material per atom in eV/atom",
     )
 
     energy_uncertainy_per_atom: float = Field(None, description="")
 
-    formation_energy_per_atom: float = Field(None, description="The formation energy per atom in eV/atom")
+    formation_energy_per_atom: float = Field(
+        None, description="The formation energy per atom in eV/atom"
+    )
 
-    energy_above_hull: float = Field(..., description="The energy above the hull in eV/Atom")
+    energy_above_hull: float = Field(
+        ..., description="The energy above the hull in eV/Atom"
+    )
 
     is_stable: bool = Field(
-        False, description="Flag for whether this material is on the hull and therefore stable",
+        False,
+        description="Flag for whether this material is on the hull and therefore stable",
     )
 
     equilibrium_reaction_energy_per_atom: float = Field(
@@ -61,10 +71,13 @@ class ThermoDoc(PropertyDoc):
     )
 
     energy_type: str = Field(
-        ..., description="The type of calculation this energy evaluation comes from. TODO: Convert to enum?",
+        ...,
+        description="The type of calculation this energy evaluation comes from. TODO: Convert to enum?",
     )
 
-    entry_types: List[str] = Field(description="List of available energy types computed for this material")
+    entry_types: List[str] = Field(
+        description="List of available energy types computed for this material"
+    )
 
     entries: Dict[str, Union[ComputedEntry, ComputedStructureEntry]] = Field(
         ...,
@@ -72,8 +85,15 @@ class ThermoDoc(PropertyDoc):
         " The keys for this dictionary are names of various calculation types",
     )
 
+    phase_diagram: PhaseDiagram = Field(
+        None,
+        description="Phase diagram for the entire chemical system of this material.",
+    )
+
     @classmethod
-    def from_entries(cls, entries: List[Union[ComputedEntry, ComputedStructureEntry]], **kwargs):
+    def from_entries(
+        cls, entries: List[Union[ComputedEntry, ComputedStructureEntry]], **kwargs
+    ):
 
         entries_by_comp = defaultdict(list)
         for e in entries:
@@ -81,7 +101,8 @@ class ThermoDoc(PropertyDoc):
 
         # Only use lowest entry per composition to speed up QHull in Phase Diagram
         reduced_entries = [
-            sorted(comp_entries, key=lambda e: e.energy_per_atom)[0] for comp_entries in entries_by_comp.values()
+            sorted(comp_entries, key=lambda e: e.energy_per_atom)[0]
+            for comp_entries in entries_by_comp.values()
         ]
 
         pd = PhaseDiagram(reduced_entries)
@@ -93,11 +114,13 @@ class ThermoDoc(PropertyDoc):
 
             d = {
                 "material_id": e.entry_id,
-                "uncorrected_energy_per_atom": e.uncorrected_energy / e.composition.num_atoms,
+                "uncorrected_energy_per_atom": e.uncorrected_energy
+                / e.composition.num_atoms,
                 "energy_per_atom": e.uncorrected_energy / e.composition.num_atoms,
                 "formation_energy_per_atom": pd.get_form_energy_per_atom(e),
                 "energy_above_hull": ehull,
                 "is_stable": e in pd.stable_entries,
+                "phase_diagram": pd.as_dict(),
             }
 
             if "last_updated" in e.data:
@@ -105,10 +128,16 @@ class ThermoDoc(PropertyDoc):
 
             # Store different info if stable vs decomposes
             if d["is_stable"]:
-                d["equilibrium_reaction_energy_per_atom"] = pd.get_equilibrium_reaction_energy(e)
+                d[
+                    "equilibrium_reaction_energy_per_atom"
+                ] = pd.get_equilibrium_reaction_energy(e)
             else:
                 d["decomposes_to"] = [
-                    {"material_id": de.entry_id, "formula": de.composition.formula, "amount": amt}
+                    {
+                        "material_id": de.entry_id,
+                        "formula": de.composition.formula,
+                        "amount": amt,
+                    }
                     for de, amt in decomp.items()
                 ]
 
@@ -122,6 +151,8 @@ class ThermoDoc(PropertyDoc):
                 elif k in e.data:
                     d[k] = e.data[k]
 
-            docs.append(ThermoDoc.from_structure(meta_structure=e.structure, **d, **kwargs))
+            docs.append(
+                ThermoDoc.from_structure(meta_structure=e.structure, **d, **kwargs)
+            )
 
         return docs


### PR DESCRIPTION
This PR contains:

- [x] Fixed a small bug in the thermo builder when querying for oxidation states. This should fix formation energy differences seen in the new build.
- [x] Decision has been made to keep priority sorting of `mp-` mpids over others such as `mvc-`. 
- [x] Phase diagram added to the thermo doc and thermo builder.