### PR TITLE
Small builder changes

### DIFF
--- a/emmet-builders/emmet/builders/vasp/task_validator.py
+++ b/emmet-builders/emmet/builders/vasp/task_validator.py
@@ -38,6 +38,7 @@ class TaskValidator(MapBuilder):
                 "input.hubbards",
                 "output.structure",
                 "output.bandgap",
+                "elements",
                 "calcs_reversed.output.ionic_steps.electronic_steps.e_fr_energy",
                 "tags",
                 # Need these two for proper run_type determination

--- a/emmet-builders/emmet/builders/vasp/thermo.py
+++ b/emmet-builders/emmet/builders/vasp/thermo.py
@@ -239,7 +239,9 @@ class ThermoBuilder(Builder):
         """Gets updated chemical system as defined by the updating of an existing material"""
 
         updated_mats = self.thermo.newer_in(self.materials, criteria=self.query)
-        updated_chemsys = set(self.materials.distinct("chemsys", {"material_id": {"$in": list(updated_mats)}}))
+        updated_chemsys = set(
+            self.materials.distinct("chemsys", {"material_id": {"$in": list(updated_mats)}, **self.query})
+        )
         self.logger.debug(f"Found {len(updated_chemsys)} updated chemical systems")
 
         return updated_chemsys

--- a/emmet-core/emmet/core/vasp/validation.py
+++ b/emmet-core/emmet/core/vasp/validation.py
@@ -167,6 +167,11 @@ class ValidationDoc(EmmetBaseModel):
                     " and compare with max SCF gradient tolerance"
                 )
 
+            # Check for Am and Po elements. These currently do not have proper elemental entries
+            # and will not get treated properly by the thermo builder.
+            if "Am" in task_doc.elements or "Po" in task_doc.elements:
+                reasons.append(DeprecationMessage.MANUAL)
+
         doc = ValidationDoc(
             task_id=task_doc.task_id,
             calc_type=calc_type,

--- a/tests/test_files/test_task.json
+++ b/tests/test_files/test_task.json
@@ -1,4 +1,10 @@
 {
+    "elements": [
+        "O",
+        "Ca",
+        "Mn",
+        "Zn"
+    ],
     "calcs_reversed": [
         {
             "output": {


### PR DESCRIPTION
This PR adds a fix to the way a manual query is used in `get_items` in the thermo builder. It also adds manual deprecation for materials with `Am` or `Po` elements.