### PR TITLE
Elements to chemsys in validation check

### DIFF
--- a/emmet-builders/emmet/builders/vasp/task_validator.py
+++ b/emmet-builders/emmet/builders/vasp/task_validator.py
@@ -38,7 +38,7 @@ class TaskValidator(MapBuilder):
                 "input.hubbards",
                 "output.structure",
                 "output.bandgap",
-                "elements",
+                "chemsys",
                 "calcs_reversed.output.ionic_steps.electronic_steps.e_fr_energy",
                 "tags",
                 # Need these two for proper run_type determination

--- a/emmet-core/emmet/core/vasp/validation.py
+++ b/emmet-core/emmet/core/vasp/validation.py
@@ -70,6 +70,7 @@ class ValidationDoc(EmmetBaseModel):
         calc_type = task_doc.calc_type
         inputs = task_doc.orig_inputs
         bandgap = task_doc.output.bandgap
+        chemsys = task_doc.chemsys
 
         reasons = []
         data = {}
@@ -169,7 +170,7 @@ class ValidationDoc(EmmetBaseModel):
 
             # Check for Am and Po elements. These currently do not have proper elemental entries
             # and will not get treated properly by the thermo builder.
-            if "Am" in task_doc.elements or "Po" in task_doc.elements:
+            if ("Am" in chemsys) or ("Po" in chemsys):
                 reasons.append(DeprecationMessage.MANUAL)
 
         doc = ValidationDoc(

--- a/tests/test_files/test_task.json
+++ b/tests/test_files/test_task.json
@@ -1,10 +1,5 @@
 {
-    "elements": [
-        "O",
-        "Ca",
-        "Mn",
-        "Zn"
-    ],
+    "chemsys": "Ca-Mn-O-Zn",
     "calcs_reversed": [
         {
             "output": {


### PR DESCRIPTION
Patch fix to exchange `elements` to `chemsys` in task validation.