### PR TITLE
Fix phase diagram ensure index

### DIFF
--- a/emmet-builders/emmet/builders/vasp/thermo.py
+++ b/emmet-builders/emmet/builders/vasp/thermo.py
@@ -80,7 +80,8 @@ class ThermoBuilder(Builder):
         self.thermo.ensure_index("last_updated")
 
         # Search index for phase_diagram
-        self.phase_diagram.ensure_index("chemsys")
+        if self.phase_diagram:
+            self.phase_diagram.ensure_index("chemsys")
 
     def prechunk(self, number_splits: int) -> Iterable[Dict]:
         updated_chemsys = self.get_updated_chemsys()


### PR DESCRIPTION
This PR fixes a bug in the thermo builder with ensuring indexes on the optional phase diagram store.