### PR TITLE
Optimize phase diagram building in the thermo builder

### DIFF
--- a/emmet-builders/emmet/builders/vasp/thermo.py
+++ b/emmet-builders/emmet/builders/vasp/thermo.py
@@ -207,7 +207,7 @@ class ThermoBuilder(Builder):
         """
         Inserts the thermo and phase diagram docs into the thermo collection
         Args:
-            items ([[tuple(List[dict],dict)]]): a list of list of thermo dictionaries to update
+            items ([[tuple(List[dict],List[dict])]]): a list of list of thermo dictionaries to update
         """
 
         # print(len(items))


### PR DESCRIPTION
This PR optimizes the way phase diagrams are handled in the updated thermo builder. This should fix memory and speed issues. 