### PR TITLE
Remove output structure from polar builders

### DIFF
--- a/emmet-builders/emmet/builders/materials/dielectric.py
+++ b/emmet-builders/emmet/builders/materials/dielectric.py
@@ -144,11 +144,10 @@ class DielectricBuilder(Builder):
                     "last_updated",
                     "input.is_hubbard",
                     "orig_inputs.kpoints",
-                    "orig_inputs.poscar",
+                    "orig_inputs.poscar.structure",
                     "input.parameters",
                     "output.epsilon_static",
                     "output.epsilon_ionic",
-                    "output.structure",
                 ],
                 criteria={self.tasks.key: str(task_id)},
             )

--- a/emmet-builders/emmet/builders/materials/piezoelectric.py
+++ b/emmet-builders/emmet/builders/materials/piezoelectric.py
@@ -166,11 +166,10 @@ class PiezoelectricBuilder(Builder):
                     "last_updated",
                     "input.is_hubbard",
                     "orig_inputs.kpoints",
-                    "orig_inputs.poscar",
+                    "orig_inputs.poscar.structure",
                     "input.parameters",
                     "output.piezo_tensor",
                     "output.piezo_ionic_tensor",
-                    "output.structure",
                 ],
                 criteria={self.tasks.key: str(task_id)},
             )


### PR DESCRIPTION
This PR removes pulling the unused output structure from the task doc in the dielectric and piezoelectric builders to reduce processing time.