### PR TITLE
Add element number cap to phase diagram generation in thermo

### DIFF
--- a/emmet-builders/emmet/builders/vasp/thermo.py
+++ b/emmet-builders/emmet/builders/vasp/thermo.py
@@ -181,9 +181,14 @@ class ThermoBuilder(Builder):
 
             pd_data = [None]
 
-            if self.phase_diagram and len(elements) <= self.num_phase_diagram_eles:  # type: ignore
-                pd_doc = PhaseDiagramDoc(chemsys=chemsys, phase_diagram=pd)
-                pd_data = jsanitize(pd_doc.dict(), allow_bson=True)
+            if self.phase_diagram:
+                if (
+                    self.num_phase_diagram_eles is None
+                    or len(elements) <= self.num_phase_diagram_eles
+                ):
+                    pd_data = self.phase_diagram.get_pd_data(chemsys, pd)
+                    pd_doc = PhaseDiagramDoc(chemsys=chemsys, phase_diagram=pd)
+                    pd_data = jsanitize(pd_doc.dict(), allow_bson=True)
 
             docs_pd_pair = (
                 jsanitize([d.dict() for d in docs], allow_bson=True),

--- a/emmet-builders/emmet/builders/vasp/thermo.py
+++ b/emmet-builders/emmet/builders/vasp/thermo.py
@@ -25,6 +25,7 @@ class ThermoBuilder(Builder):
         oxidation_states: Optional[Store] = None,
         query: Optional[Dict] = None,
         compatibility=None,
+        num_phase_diagram_eles: Optional[int] = None,
         **kwargs,
     ):
         """
@@ -40,6 +41,8 @@ class ThermoBuilder(Builder):
             query (dict): dictionary to limit materials to be analyzed
             compatibility (PymatgenCompatability): Compatability module
                 to ensure energies are compatible
+            num_phase_diagram_eles (int): Maximum number of elements to use in phase diagram construction
+                for data within the separate phase_diagram collection
         """
 
         self.materials = materials
@@ -52,6 +55,7 @@ class ThermoBuilder(Builder):
         )
         self.oxidation_states = oxidation_states
         self.phase_diagram = phase_diagram
+        self.num_phase_diagram_eles = num_phase_diagram_eles
         self._completed_tasks: Set[str] = set()
         self._entries_cache: Dict[str, List[ComputedStructureEntry]] = defaultdict(list)
 
@@ -177,7 +181,7 @@ class ThermoBuilder(Builder):
 
             pd_data = [None]
 
-            if self.phase_diagram:
+            if self.phase_diagram and len(elements) <= self.num_phase_diagram_eles:  # type: ignore
                 pd_doc = PhaseDiagramDoc(chemsys=chemsys, phase_diagram=pd)
                 pd_data = jsanitize(pd_doc.dict(), allow_bson=True)
 


### PR DESCRIPTION
This PR adds the ability to specify a chemical system size cap to phase diagrams stored within the optional `phase_diagram` store within the thermo builder.