### PR TITLE
Electrode host structure bug fix

### DIFF
--- a/emmet-builders/emmet/builders/materials/electrodes.py
+++ b/emmet-builders/emmet/builders/materials/electrodes.py
@@ -413,22 +413,16 @@ class InsertionElectrodeBuilder(Builder):
         entries = [
             tdoc_["entries"][tdoc_["energy_type"]] for tdoc_ in item["thermo_docs"]
         ]
+
         entries = list(map(ComputedStructureEntry.from_dict, entries))
 
         working_ion_entry = ComputedEntry.from_dict(
             item["working_ion_doc"]["entries"][item["working_ion_doc"]["energy_type"]]
         )
-        working_ion = working_ion_entry.composition.reduced_formula
 
         decomp_energies = {
             d_["material_id"]: d_["energy_above_hull"] for d_ in item["thermo_docs"]
         }
-
-        least_wion_ent = min(
-            entries, key=lambda x: x.composition.get_atomic_fraction(working_ion)
-        )
-        host_structure = least_wion_ent.structure.copy()
-        host_structure.remove_species([item["working_ion"]])
 
         for ient in entries:
             ient.data["volume"] = ient.structure.volume
@@ -438,7 +432,6 @@ class InsertionElectrodeBuilder(Builder):
             grouped_entries=entries,
             working_ion_entry=working_ion_entry,
             battery_id=item["group_id"],
-            host_structure=host_structure,
         )
         if ie is None:
             return None  # {"failed_reason": "unable to create InsertionElectrode document"}

--- a/emmet-core/emmet/core/electrode.py
+++ b/emmet-core/emmet/core/electrode.py
@@ -179,7 +179,6 @@ class InsertionElectrodeDoc(InsertionVoltagePairDoc):
         grouped_entries: List[ComputedStructureEntry],
         working_ion_entry: ComputedEntry,
         battery_id: str,
-        host_structure: Structure,
     ) -> Union["InsertionElectrodeDoc", None]:
         try:
             ie = InsertionElectrode.from_entries(
@@ -189,7 +188,16 @@ class InsertionElectrodeDoc(InsertionVoltagePairDoc):
             )
         except IndexError:
             return None
+        # First get host structure
+
         d = ie.get_summary_dict()
+
+        least_wion_ent = next(
+            item for item in grouped_entries if item.entry_id == d["id_charge"]
+        )
+        host_structure = least_wion_ent.structure.copy()
+        host_structure.remove_species([d["working_ion"]])
+
         d["material_ids"] = d["stable_material_ids"] + d["unstable_material_ids"]
         d["num_steps"] = d.pop("nsteps", None)
         d["last_updated"] = datetime.utcnow()

--- a/tests/emmet-core/test_electrodes.py
+++ b/tests/emmet-core/test_electrodes.py
@@ -67,7 +67,6 @@ def test_InsertionDocs(insertion_elec):
             grouped_entries=elec.stable_entries,
             working_ion_entry=wion_entry,
             battery_id="mp-1234",
-            host_structure=struct,
         )
         assert ie.average_voltage == elec.get_average_voltage()
         assert len(ie.material_ids) > 2


### PR DESCRIPTION
Generation of the host structure now uses the charged material entry id to obtain the structure with the lowest working ion fraction.