### PR TITLE
Allow for parsing of material docs without GGA/GGA+U (i.e. without corrections)

### DIFF
--- a/emmet-builders/emmet/builders/vasp/thermo.py
+++ b/emmet-builders/emmet/builders/vasp/thermo.py
@@ -48,11 +48,7 @@ class ThermoBuilder(Builder):
         self.materials = materials
         self.thermo = thermo
         self.query = query if query else {}
-        self.compatibility = (
-            compatibility
-            if compatibility
-            else MaterialsProject2020Compatibility("Advanced")
-        )
+        self.compatibility = compatibility
         self.oxidation_states = oxidation_states
         self.phase_diagram = phase_diagram
         self.num_phase_diagram_eles = num_phase_diagram_eles
@@ -166,11 +162,14 @@ class ThermoBuilder(Builder):
         for entry in entries:
             material_entries[entry.entry_id][entry.data["run_type"]] = entry
 
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore", message="Failed to guess oxidation states.*"
-            )
-            pd_entries = self.compatibility.process_entries(entries)
+        if self.compatibility:
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore", message="Failed to guess oxidation states.*"
+                )
+                pd_entries = self.compatibility.process_entries(entries)
+        else:
+            pd_entries = entries
         self.logger.debug(f"{len(pd_entries)} remain in {chemsys} after filtering")
 
         try:


### PR DESCRIPTION
By default, `ThermoBuilder` has `None` as the compatibility scheme in its default kwargs. However, this `None` gets turned into `MaterialsProject2020Compatibility` downstream. This is a problem when parsing new data without the MP compatibility scheme, like the r2SCAN data, because then `pd_entries` is None and no thermo docs get populated.

This PR fixes the above issue by actually having `None` disable compatibility schemes and making it so the `self.compatibility.process_entries(entries)` line in the thermo builder only runs if there is a compatibility scheme requested.

Thanks for the help, @rkingsbury!