### PR TITLE
Return proper error response in autocomplete endpoint

### DIFF
--- a/emmet-api/emmet/api/routes/materials/query_operators.py
+++ b/emmet-api/emmet/api/routes/materials/query_operators.py
@@ -326,7 +326,7 @@ class FormulaAutoCompleteQuery(QueryOperator):
 
         try:
             comp = Composition(formula)
-        except CompositionError:
+        except (CompositionError, ValueError):
             raise HTTPException(
                 status_code=400, detail="Invalid formula provided.",
             )


### PR DESCRIPTION
This PR ensures that the formula autocomplete endpoint in emmet-api returns a proper error code if the provided search text cannot be converted to a `Composition` object.