### PR TITLE
Enhance post-processing to avoid overwrite issues

### DIFF
--- a/emmet-api/emmet/api/routes/_consumer/query_operator.py
+++ b/emmet-api/emmet/api/routes/_consumer/query_operator.py
@@ -8,9 +8,7 @@ class UserSettingsPostQuery(QueryOperator):
     """Query operators to provide user settings information to post"""
 
     def query(
-        self,
-        consumer_id: str = Query(..., title="Consumer ID",),
-        settings: Dict = Body(..., title="User settings",),
+        self, consumer_id: str = Query(..., title="Consumer ID",), settings: Dict = Body(..., title="User settings",),
     ) -> STORE_PARAMS:
 
         self.cid = consumer_id
@@ -20,9 +18,12 @@ class UserSettingsPostQuery(QueryOperator):
 
         return {"criteria": crit}
 
-    def post_process(self, written):
+    def post_process(self, docs, query):
 
-        d = [{"consumer_id": self.cid, "settings": self.settings}]
+        cid = query["criteria"]["consumer_id"]
+        settings = query["criteria"]["settings"]
+
+        d = [{"consumer_id": cid, "settings": settings}]
 
         return d
 
@@ -30,9 +31,7 @@ class UserSettingsPostQuery(QueryOperator):
 class UserSettingsGetQuery(QueryOperator):
     """Query operators to provide user settings information"""
 
-    def query(
-        self, consumer_id: str = Query(..., title="Consumer ID",),
-    ) -> STORE_PARAMS:
+    def query(self, consumer_id: str = Query(..., title="Consumer ID",),) -> STORE_PARAMS:
 
         crit = {"consumer_id": consumer_id}
 

--- a/emmet-api/emmet/api/routes/_general_store/query_operator.py
+++ b/emmet-api/emmet/api/routes/_general_store/query_operator.py
@@ -22,9 +22,15 @@ class GeneralStorePostQuery(QueryOperator):
 
         return {"criteria": crit}
 
-    def post_process(self, written):
+    def post_process(self, docs, query):
 
-        d = [{"kind": self.kind, "markdown": self.markdown, "meta": self.metadata}]
+        d = [
+            {
+                "kind": query["criteria"]["kind"],
+                "markdown": query["criteria"]["markdown"],
+                "meta": query["criteria"]["meta"],
+            }
+        ]
 
         return d
 

--- a/emmet-api/emmet/api/routes/materials/query_operators.py
+++ b/emmet-api/emmet/api/routes/materials/query_operators.py
@@ -21,8 +21,7 @@ class FormulaQuery(QueryOperator):
     def query(
         self,
         formula: Optional[str] = Query(
-            None,
-            description="Query by formula including anonymized formula or by including wild cards",
+            None, description="Query by formula including anonymized formula or by including wild cards",
         ),
     ) -> STORE_PARAMS:
 
@@ -73,12 +72,10 @@ class ElementsQuery(QueryOperator):
     def query(
         self,
         elements: Optional[str] = Query(
-            None,
-            description="Query by elements in the material composition as a comma-separated list",
+            None, description="Query by elements in the material composition as a comma-separated list",
         ),
         exclude_elements: Optional[str] = Query(
-            None,
-            description="Query by excluded elements in the material composition as a comma-separated list",
+            None, description="Query by excluded elements in the material composition as a comma-separated list",
         ),
     ) -> STORE_PARAMS:
 
@@ -107,10 +104,7 @@ class DeprecationQuery(QueryOperator):
     """
 
     def query(
-        self,
-        deprecated: Optional[bool] = Query(
-            False, description="Whether the material is marked as deprecated",
-        ),
+        self, deprecated: Optional[bool] = Query(False, description="Whether the material is marked as deprecated",),
     ) -> STORE_PARAMS:
 
         crit = {}
@@ -128,15 +122,9 @@ class SymmetryQuery(QueryOperator):
 
     def query(
         self,
-        crystal_system: Optional[CrystalSystem] = Query(
-            None, description="Crystal system of the material",
-        ),
-        spacegroup_number: Optional[int] = Query(
-            None, description="Space group number of the material",
-        ),
-        spacegroup_symbol: Optional[str] = Query(
-            None, description="Space group symbol of the material",
-        ),
+        crystal_system: Optional[CrystalSystem] = Query(None, description="Crystal system of the material",),
+        spacegroup_number: Optional[int] = Query(None, description="Space group number of the material",),
+        spacegroup_symbol: Optional[str] = Query(None, description="Space group symbol of the material",),
     ) -> STORE_PARAMS:
 
         crit = {}  # type: dict
@@ -163,22 +151,13 @@ class MultiTaskIDQuery(QueryOperator):
     """
 
     def query(
-        self,
-        task_ids: Optional[str] = Query(
-            None, description="Comma-separated list of task_ids to query on"
-        ),
+        self, task_ids: Optional[str] = Query(None, description="Comma-separated list of task_ids to query on"),
     ) -> STORE_PARAMS:
 
         crit = {}
 
         if task_ids:
-            crit.update(
-                {
-                    "task_ids": {
-                        "$in": [task_id.strip() for task_id in task_ids.split(",")]
-                    }
-                }
-            )
+            crit.update({"task_ids": {"$in": [task_id.strip() for task_id in task_ids.split(",")]}})
 
         return {"criteria": crit}
 
@@ -193,24 +172,13 @@ class MultiMaterialIDQuery(QueryOperator):
 
     def query(
         self,
-        material_ids: Optional[str] = Query(
-            None, description="Comma-separated list of material_id values to query on"
-        ),
+        material_ids: Optional[str] = Query(None, description="Comma-separated list of material_id values to query on"),
     ) -> STORE_PARAMS:
 
         crit = {}
 
         if material_ids:
-            crit.update(
-                {
-                    "material_id": {
-                        "$in": [
-                            material_id.strip()
-                            for material_id in material_ids.split(",")
-                        ]
-                    }
-                }
-            )
+            crit.update({"material_id": {"$in": [material_id.strip() for material_id in material_ids.split(",")]}})
 
         return {"criteria": crit}
 
@@ -222,23 +190,16 @@ class FindStructureQuery(QueryOperator):
 
     def query(
         self,
-        structure: Structure = Body(
-            ..., description="Pymatgen structure object to query with",
-        ),
-        ltol: float = Query(
-            0.2, description="Fractional length tolerance. Default is 0.2.",
-        ),
+        structure: Structure = Body(..., description="Pymatgen structure object to query with",),
+        ltol: float = Query(0.2, description="Fractional length tolerance. Default is 0.2.",),
         stol: float = Query(
             0.3,
             description="Site tolerance. Defined as the fraction of the average free \
                     length per atom := ( V / Nsites ) ** (1/3). Default is 0.3.",
         ),
-        angle_tol: float = Query(
-            5, description="Angle tolerance in degrees. Default is 5 degrees.",
-        ),
+        angle_tol: float = Query(5, description="Angle tolerance in degrees. Default is 5 degrees.",),
         limit: int = Query(
-            1,
-            description="Maximum number of matches to show. Defaults to 1, only showing the best match.",
+            1, description="Maximum number of matches to show. Defaults to 1, only showing the best match.",
         ),
     ) -> STORE_PARAMS:
 
@@ -254,15 +215,14 @@ class FindStructureQuery(QueryOperator):
             s = Structure.from_dict(structure)
         except Exception:
             raise HTTPException(
-                status_code=404,
-                detail="Body cannot be converted to a pymatgen structure object.",
+                status_code=404, detail="Body cannot be converted to a pymatgen structure object.",
             )
 
         crit.update({"composition_reduced": dict(s.composition.to_reduced_dict)})
 
         return {"criteria": crit}
 
-    def post_process(self, docs):
+    def post_process(self, docs, query):
 
         s1 = Structure.from_dict(self.structure)
 
@@ -295,11 +255,7 @@ class FindStructureQuery(QueryOperator):
                 )
 
         response = sorted(
-            matches[: self.limit],
-            key=lambda x: (
-                x["normalized_rms_displacement"],
-                x["max_distance_paired_sites"],
-            ),
+            matches[: self.limit], key=lambda x: (x["normalized_rms_displacement"], x["max_distance_paired_sites"],),
         )
 
         return response
@@ -316,9 +272,7 @@ class FormulaAutoCompleteQuery(QueryOperator):
     def query(
         self,
         formula: str = Query(..., description="Human readable chemical formula.",),
-        limit: int = Query(
-            10, description="Maximum number of matches to show. Defaults to 10.",
-        ),
+        limit: int = Query(10, description="Maximum number of matches to show. Defaults to 10.",),
     ) -> STORE_PARAMS:
 
         self.formula = formula
@@ -357,26 +311,9 @@ class FormulaAutoCompleteQuery(QueryOperator):
         final_terms = ["".join(entry) for entry in permutations(ind_str)]
 
         pipeline = [
-            {
-                "$search": {
-                    "index": "formula_autocomplete",
-                    "text": {"path": "formula_pretty", "query": final_terms},
-                }
-            },
-            {
-                "$project": {
-                    "_id": 0,
-                    "formula_pretty": 1,
-                    "elements": 1,
-                    "length": {"$strLenCP": "$formula_pretty"},
-                }
-            },
-            {
-                "$match": {
-                    "length": {"$gte": len(final_terms[0])},
-                    "elements": {"$all": eles},
-                }
-            },
+            {"$search": {"index": "formula_autocomplete", "text": {"path": "formula_pretty", "query": final_terms}}},
+            {"$project": {"_id": 0, "formula_pretty": 1, "elements": 1, "length": {"$strLenCP": "$formula_pretty"}}},
+            {"$match": {"length": {"$gte": len(final_terms[0])}, "elements": {"$all": eles}}},
             {"$limit": limit},
             {"$sort": {"length": 1}},
             {"$project": {"elements": 0, "length": 0}},

--- a/emmet-api/emmet/api/routes/mpcomplete/query_operator.py
+++ b/emmet-api/emmet/api/routes/mpcomplete/query_operator.py
@@ -26,13 +26,13 @@ class MPCompletePostQuery(QueryOperator):
 
         return {"criteria": crit}
 
-    def post_process(self, written):
+    def post_process(self, docs, query):
 
         d = [
             {
-                "structure": self.structure,
-                "public_email": self.public_email,
-                "public_name": self.public_name,
+                "structure": query["criteria"]["structure"],
+                "public_email": query["criteria"]["public_email"],
+                "public_name": query["criteria"]["public_name"],
             }
         ]
 

--- a/emmet-api/emmet/api/routes/robocrys/query_operators.py
+++ b/emmet-api/emmet/api/routes/robocrys/query_operators.py
@@ -69,7 +69,7 @@ class RoboTextSearchQuery(QueryOperator):
         ]
         return {"pipeline": pipeline}
 
-    def post_process(self, docs):
+    def post_process(self, docs, query):
         self.total_doc = docs[0]["total_doc"]
         return docs
 

--- a/emmet-api/emmet/api/routes/summary/query_operators.py
+++ b/emmet-api/emmet/api/routes/summary/query_operators.py
@@ -28,17 +28,14 @@ class HasPropsQuery(QueryOperator):
     def query(
         self,
         has_props: Optional[str] = Query(
-            None,
-            description="Comma-delimited list of possible properties given by HasPropsEnum to search for.",
+            None, description="Comma-delimited list of possible properties given by HasPropsEnum to search for.",
         ),
     ) -> STORE_PARAMS:
 
         crit = {}
 
         if has_props:
-            crit = {
-                "has_props": {"$all": [prop.strip() for prop in has_props.split(",")]}
-            }
+            crit = {"has_props": {"$all": [prop.strip() for prop in has_props.split(",")]}}
 
         return {"criteria": crit}
 
@@ -49,27 +46,27 @@ class MaterialIDsSearchQuery(QueryOperator):
     """
 
     def query(
-        self,
-        material_ids: Optional[str] = Query(
-            None, description="Comma-separated list of material_ids to query on"
-        ),
+        self, material_ids: Optional[str] = Query(None, description="Comma-separated list of material_ids to query on"),
     ) -> STORE_PARAMS:
 
         crit = {}
 
         if material_ids:
-            crit.update(
-                {
-                    "material_id": {
-                        "$in": [
-                            material_id.strip()
-                            for material_id in material_ids.split(",")
-                        ]
-                    }
-                }
-            )
+            crit.update({"material_id": {"$in": [material_id.strip() for material_id in material_ids.split(",")]}})
 
         return {"criteria": crit}
+
+    def post_process(self, docs, query):
+
+        if not query.get("sort", None):
+            mpid_list = query.get("criteria", {}).get("material_id", {}).get("$in", None)
+
+            if mpid_list is not None:
+                mpid_mapping = {mpid: ind for ind, mpid in enumerate(mpid_list)}
+
+                docs = sorted(docs, key=lambda d: mpid_mapping[d["material_id"]])
+
+        return docs
 
 
 class SearchIsStableQuery(QueryOperator):
@@ -78,10 +75,7 @@ class SearchIsStableQuery(QueryOperator):
     """
 
     def query(
-        self,
-        is_stable: Optional[bool] = Query(
-            None, description="Whether the material is stable."
-        ),
+        self, is_stable: Optional[bool] = Query(None, description="Whether the material is stable."),
     ):
 
         crit = {}
@@ -102,9 +96,7 @@ class SearchHasReconstructedQuery(QueryOperator):
 
     def query(
         self,
-        has_reconstructed: Optional[bool] = Query(
-            None, description="Whether the material has reconstructed surfaces."
-        ),
+        has_reconstructed: Optional[bool] = Query(None, description="Whether the material has reconstructed surfaces."),
     ):
 
         crit = {}
@@ -124,10 +116,7 @@ class SearchMagneticQuery(QueryOperator):
     """
 
     def query(
-        self,
-        ordering: Optional[Ordering] = Query(
-            None, description="Magnetic ordering of the material."
-        ),
+        self, ordering: Optional[Ordering] = Query(None, description="Magnetic ordering of the material."),
     ) -> STORE_PARAMS:
 
         crit = defaultdict(dict)  # type: dict
@@ -147,10 +136,7 @@ class SearchIsTheoreticalQuery(QueryOperator):
     """
 
     def query(
-        self,
-        theoretical: Optional[bool] = Query(
-            None, description="Whether the material is theoretical."
-        ),
+        self, theoretical: Optional[bool] = Query(None, description="Whether the material is theoretical."),
     ):
 
         crit = {}
@@ -171,12 +157,8 @@ class SearchESQuery(QueryOperator):
 
     def query(
         self,
-        is_gap_direct: Optional[bool] = Query(
-            None, description="Whether a band gap is direct or not."
-        ),
-        is_metal: Optional[bool] = Query(
-            None, description="Whether the material is considered a metal."
-        ),
+        is_gap_direct: Optional[bool] = Query(None, description="Whether a band gap is direct or not."),
+        is_metal: Optional[bool] = Query(None, description="Whether the material is considered a metal."),
     ) -> STORE_PARAMS:
 
         crit = defaultdict(dict)  # type: dict
@@ -202,9 +184,7 @@ class SearchStatsQuery(QueryOperator):
     """
 
     def __init__(self, search_doc):
-        valid_numeric_fields = tuple(
-            sorted(k for k, v in search_doc.__fields__.items() if v.type_ == float)
-        )
+        valid_numeric_fields = tuple(sorted(k for k, v in search_doc.__fields__.items() if v.type_ == float))
 
         def query(
             field: Literal[valid_numeric_fields] = Query(  # type: ignore
@@ -212,9 +192,7 @@ class SearchStatsQuery(QueryOperator):
                 title=f"SearchDoc field to query on, must be a numerical field, "
                 f"choose from: {', '.join(valid_numeric_fields)}",
             ),
-            num_samples: Optional[int] = Query(
-                None, title="If specified, will only sample this number of documents.",
-            ),
+            num_samples: Optional[int] = Query(None, title="If specified, will only sample this number of documents.",),
             min_val: Optional[float] = Query(
                 None,
                 title="If specified, will only consider documents with field values "
@@ -225,9 +203,7 @@ class SearchStatsQuery(QueryOperator):
                 title="If specified, will only consider documents with field values "
                 "less than or equal to this minimum value.",
             ),
-            num_points: int = Query(
-                100, title="The number of values in the returned distribution."
-            ),
+            num_points: int = Query(100, title="The number of values in the returned distribution."),
         ) -> STORE_PARAMS:
 
             self.num_points = num_points
@@ -256,7 +232,7 @@ class SearchStatsQuery(QueryOperator):
         " Stub query function for abstract class "
         pass
 
-    def post_process(self, docs):
+    def post_process(self, docs, query):
 
         if docs:
             field = list(docs[0].keys())[0]

--- a/emmet-api/emmet/api/routes/synthesis/query_operators.py
+++ b/emmet-api/emmet/api/routes/synthesis/query_operators.py
@@ -192,7 +192,7 @@ class SynthesisSearchQuery(QueryOperator):
 
         return {"pipeline": pipeline}
 
-    def post_process(self, docs):
+    def post_process(self, docs, query):
         self.total_doc = 0
 
         if len(docs) > 0:

--- a/emmet-api/emmet/api/routes/tasks/query_operators.py
+++ b/emmet-api/emmet/api/routes/tasks/query_operators.py
@@ -45,7 +45,7 @@ class TrajectoryQuery(QueryOperator):
         """
 
         d = [
-            {"task_id": doc["task_id"], "trajectories": jsanitize(calcs_reversed_to_trajectory(doc["calcs_reversed"])),}
+            {"task_id": doc["task_id"], "trajectories": jsanitize(calcs_reversed_to_trajectory(doc["calcs_reversed"]))}
             for doc in docs
         ]
 

--- a/emmet-api/emmet/api/routes/tasks/query_operators.py
+++ b/emmet-api/emmet/api/routes/tasks/query_operators.py
@@ -12,22 +12,13 @@ class MultipleTaskIDsQuery(QueryOperator):
     """
 
     def query(
-        self,
-        task_ids: Optional[str] = Query(
-            None, description="Comma-separated list of task_ids to query on"
-        ),
+        self, task_ids: Optional[str] = Query(None, description="Comma-separated list of task_ids to query on"),
     ) -> STORE_PARAMS:
 
         crit = {}
 
         if task_ids:
-            crit.update(
-                {
-                    "task_id": {
-                        "$in": [task_id.strip() for task_id in task_ids.split(",")]
-                    }
-                }
-            )
+            crit.update({"task_id": {"$in": [task_id.strip() for task_id in task_ids.split(",")]}})
 
         return {"criteria": crit}
 
@@ -38,22 +29,13 @@ class TrajectoryQuery(QueryOperator):
     """
 
     def query(
-        self,
-        task_ids: Optional[str] = Query(
-            None, description="Comma-separated list of task_ids to query on"
-        ),
+        self, task_ids: Optional[str] = Query(None, description="Comma-separated list of task_ids to query on"),
     ) -> STORE_PARAMS:
 
         crit = {}
 
         if task_ids:
-            crit.update(
-                {
-                    "task_id": {
-                        "$in": [task_id.strip() for task_id in task_ids.split(",")]
-                    }
-                }
-            )
+            crit.update({"task_id": {"$in": [task_id.strip() for task_id in task_ids.split(",")]}})
 
         return {"criteria": crit}
 
@@ -63,12 +45,7 @@ class TrajectoryQuery(QueryOperator):
         """
 
         d = [
-            {
-                "task_id": doc["task_id"],
-                "trajectories": jsanitize(
-                    calcs_reversed_to_trajectory(doc["calcs_reversed"])
-                ),
-            }
+            {"task_id": doc["task_id"], "trajectories": jsanitize(calcs_reversed_to_trajectory(doc["calcs_reversed"])),}
             for doc in docs
         ]
 
@@ -81,10 +58,7 @@ class DeprecationQuery(QueryOperator):
     """
 
     def query(
-        self,
-        task_ids: str = Query(
-            ..., description="Comma-separated list of task_ids to query on"
-        ),
+        self, task_ids: str = Query(..., description="Comma-separated list of task_ids to query on"),
     ) -> STORE_PARAMS:
 
         self.task_ids = [task_id.strip() for task_id in task_ids.split(",")]
@@ -96,7 +70,7 @@ class DeprecationQuery(QueryOperator):
 
         return {"criteria": crit}
 
-    def post_process(self, docs, **kwargs):
+    def post_process(self, docs, query):
         """
         Post processing to generatore deprecation data
         """

--- a/emmet-api/emmet/api/routes/tasks/query_operators.py
+++ b/emmet-api/emmet/api/routes/tasks/query_operators.py
@@ -57,7 +57,7 @@ class TrajectoryQuery(QueryOperator):
 
         return {"criteria": crit}
 
-    def post_process(self, docs):
+    def post_process(self, docs, query):
         """
         Post processing to generatore trajectory data
         """
@@ -96,7 +96,7 @@ class DeprecationQuery(QueryOperator):
 
         return {"criteria": crit}
 
-    def post_process(self, docs):
+    def post_process(self, docs, **kwargs):
         """
         Post processing to generatore deprecation data
         """

--- a/emmet-api/requirements.txt
+++ b/emmet-api/requirements.txt
@@ -1,6 +1,6 @@
 uvicorn @ git+https://github.com/immerrr/uvicorn.git@implement-gunicorn-access-log-format#egg=uvicorn-0.16.0
 gunicorn==20.1.0
-boto3==1.20.27
+boto3>=1.20.27
 fastapi==0.72.0
 emmet-core>=0.21.19
 maggma>=0.44.2

--- a/emmet-api/requirements.txt
+++ b/emmet-api/requirements.txt
@@ -3,6 +3,6 @@ gunicorn==20.1.0
 boto3==1.20.27
 fastapi==0.72.0
 emmet-core>=0.21.19
-maggma>=0.38.1
+maggma>=0.44.2
 ddtrace==0.57.1
 setproctitle==1.2.2

--- a/emmet-builders/emmet/builders/vasp/thermo.py
+++ b/emmet-builders/emmet/builders/vasp/thermo.py
@@ -254,7 +254,7 @@ class ThermoBuilder(Builder):
                 d["material_id"]: d.get("average_oxidation_states", {})
                 for d in self.oxidation_states.query(
                     properties=["material_id", "average_oxidation_states"],
-                    criteria={"material_id": {"$in": material_ids}, "state": "successful",},
+                    criteria={"material_id": {"$in": material_ids}, "state": "successful"},
                 )
             }
 

--- a/emmet-builders/emmet/builders/vasp/thermo.py
+++ b/emmet-builders/emmet/builders/vasp/thermo.py
@@ -119,25 +119,17 @@ class ThermoBuilder(Builder):
         # Remove overlapping chemical systems
         processed = set()
         to_process_chemsys = []
-        for chemsys in sorted(
-            updated_chemsys | new_chemsys | affected_chemsys,
-            key=lambda x: len(x),
-            reverse=True,
-        ):
+        for chemsys in sorted(updated_chemsys | new_chemsys | affected_chemsys, key=lambda x: len(x), reverse=True,):
             if chemsys not in processed:
                 processed |= chemsys_permutations(chemsys)
                 to_process_chemsys.append(chemsys)
 
-        self.logger.info(
-            f"Found {len(to_process_chemsys)} chemical systems with new/updated materials to process"
-        )
+        self.logger.info(f"Found {len(to_process_chemsys)} chemical systems with new/updated materials to process")
         self.total = len(to_process_chemsys)
 
         # Yield the chemical systems in order of increasing size
         # Will build them in a similar manner to fast Pourbaix
-        for chemsys in sorted(
-            to_process_chemsys, key=lambda x: len(x.split("-")), reverse=False
-        ):
+        for chemsys in sorted(to_process_chemsys, key=lambda x: len(x.split("-")), reverse=False):
             entries = self.get_entries(chemsys)
             yield entries
 
@@ -148,25 +140,19 @@ class ThermoBuilder(Builder):
 
         entries = [ComputedStructureEntry.from_dict(entry) for entry in item]
         # determine chemsys
-        elements = sorted(
-            set([el.symbol for e in entries for el in e.composition.elements])
-        )
+        elements = sorted(set([el.symbol for e in entries for el in e.composition.elements]))
         chemsys = "-".join(elements)
 
         self.logger.debug(f"Processing {len(entries)} entries for {chemsys}")
 
-        material_entries: Dict[str, Dict[str, ComputedStructureEntry]] = defaultdict(
-            dict
-        )
+        material_entries: Dict[str, Dict[str, ComputedStructureEntry]] = defaultdict(dict)
         pd_entries = []
         for entry in entries:
             material_entries[entry.entry_id][entry.data["run_type"]] = entry
 
         if self.compatibility:
             with warnings.catch_warnings():
-                warnings.filterwarnings(
-                    "ignore", message="Failed to guess oxidation states.*"
-                )
+                warnings.filterwarnings("ignore", message="Failed to guess oxidation states.*")
                 pd_entries = self.compatibility.process_entries(entries)
         else:
             pd_entries = entries
@@ -181,10 +167,7 @@ class ThermoBuilder(Builder):
             pd_data = None
 
             if self.phase_diagram:
-                if (
-                    self.num_phase_diagram_eles is None
-                    or len(elements) <= self.num_phase_diagram_eles
-                ):
+                if self.num_phase_diagram_eles is None or len(elements) <= self.num_phase_diagram_eles:
                     pd_doc = PhaseDiagramDoc(chemsys=chemsys, phase_diagram=pd)
                     pd_data = jsanitize(pd_doc.dict(), allow_bson=True)
 
@@ -198,14 +181,10 @@ class ThermoBuilder(Builder):
             for e in entries:
                 elsyms.extend([el.symbol for el in e.composition.elements])
 
-            self.logger.warning(
-                f"Phase diagram error in chemsys {'-'.join(sorted(set(elsyms)))}: {p}"
-            )
+            self.logger.warning(f"Phase diagram error in chemsys {'-'.join(sorted(set(elsyms)))}: {p}")
             return []
         except Exception as e:
-            self.logger.error(
-                f"Got unexpected error while processing {[ent_.entry_id for ent_ in entries]}: {e}"
-            )
+            self.logger.error(f"Got unexpected error while processing {[ent_.entry_id for ent_ in entries]}: {e}")
             return []
 
         return docs_pd_pair
@@ -217,8 +196,6 @@ class ThermoBuilder(Builder):
             items ([[tuple(List[dict],List[dict])]]): a list of list of thermo dictionaries to update
         """
 
-        # print(len(items))
-
         thermo_docs = [item[0] for item in items]
         phase_diagram_docs = [item[1] for item in items]
 
@@ -227,17 +204,13 @@ class ThermoBuilder(Builder):
         phase_diagram_docs = list(filter(None, chain.from_iterable(phase_diagram_docs)))
 
         # Check if already updated this run
-        thermo_docs = [
-            i for i in thermo_docs if i["material_id"] not in self._completed_tasks
-        ]
+        thermo_docs = [i for i in thermo_docs if i["material_id"] not in self._completed_tasks]
 
         self._completed_tasks |= {i["material_id"] for i in thermo_docs}
 
         for item in thermo_docs:
             if isinstance(item["last_updated"], dict):
-                item["last_updated"] = MontyDecoder().process_decoded(
-                    item["last_updated"]
-                )
+                item["last_updated"] = MontyDecoder().process_decoded(item["last_updated"])
 
         if self.phase_diagram:
             self.phase_diagram.update(phase_diagram_docs)
@@ -262,26 +235,16 @@ class ThermoBuilder(Builder):
         all_chemsys = chemsys_permutations(chemsys)
         cached_chemsys = all_chemsys & set(self._entries_cache.keys())
         query_chemsys = all_chemsys - cached_chemsys
-        all_entries = list(
-            chain.from_iterable(self._entries_cache[c] for c in cached_chemsys)
-        )
+        all_entries = list(chain.from_iterable(self._entries_cache[c] for c in cached_chemsys))
 
-        self.logger.debug(
-            f"Getting {len(cached_chemsys)} sub-chemsys from cache for {chemsys}"
-        )
-        self.logger.debug(
-            f"Getting {len(query_chemsys)} sub-chemsys from DB for {chemsys}"
-        )
+        self.logger.debug(f"Getting {len(cached_chemsys)} sub-chemsys from cache for {chemsys}")
+        self.logger.debug(f"Getting {len(query_chemsys)} sub-chemsys from DB for {chemsys}")
 
         # Second grab the materials docs
         new_q = dict(self.query)
         new_q["chemsys"] = {"$in": list(query_chemsys)}
         new_q["deprecated"] = False
-        materials_docs = list(
-            self.materials.query(
-                criteria=new_q, properties=["material_id", "entries", "deprecated"]
-            )
-        )
+        materials_docs = list(self.materials.query(criteria=new_q, properties=["material_id", "entries", "deprecated"]))
 
         # Get Oxidation state data for each material
         oxi_states_data = {}
@@ -291,10 +254,7 @@ class ThermoBuilder(Builder):
                 d["material_id"]: d.get("average_oxidation_states", {})
                 for d in self.oxidation_states.query(
                     properties=["material_id", "average_oxidation_states"],
-                    criteria={
-                        "material_id": {"$in": material_ids},
-                        "state": "successful",
-                    },
+                    criteria={"material_id": {"$in": material_ids}, "state": "successful",},
                 )
             }
 
@@ -305,9 +265,7 @@ class ThermoBuilder(Builder):
         # Convert the entries into ComputedEntries and store
         for doc in materials_docs:
             for r_type, entry_dict in doc.get("entries", {}).items():
-                entry_dict["data"]["oxidation_states"] = oxi_states_data.get(
-                    entry_dict["entry_id"], {}
-                )
+                entry_dict["data"]["oxidation_states"] = oxi_states_data.get(entry_dict["entry_id"], {})
                 entry_dict["data"]["run_type"] = r_type
                 elsyms = sorted(set([el for el in entry_dict["composition"]]))
                 self._entries_cache["-".join(elsyms)].append(entry_dict)
@@ -322,9 +280,7 @@ class ThermoBuilder(Builder):
 
         updated_mats = self.thermo.newer_in(self.materials, criteria=self.query)
         updated_chemsys = set(
-            self.materials.distinct(
-                "chemsys", {"material_id": {"$in": list(updated_mats)}, **self.query}
-            )
+            self.materials.distinct("chemsys", {"material_id": {"$in": list(updated_mats)}, **self.query})
         )
         self.logger.debug(f"Found {len(updated_chemsys)} updated chemical systems")
 
@@ -348,9 +304,7 @@ class ThermoBuilder(Builder):
         # First get all chemsys with any of the elements we've marked
         affected_chemsys = set()
         affected_els = list({el for c in chemical_systems for el in c.split("-")})
-        possible_affected_chemsys = self.materials.distinct(
-            "chemsys", {"elements": {"$in": affected_els}}
-        )
+        possible_affected_chemsys = self.materials.distinct("chemsys", {"elements": {"$in": affected_els}})
 
         sub_chemsys = defaultdict(list)
         # Build a dictionary mapping sub_chemsys to all super_chemsys
@@ -362,8 +316,6 @@ class ThermoBuilder(Builder):
         for chemsys in chemical_systems:
             affected_chemsys |= set(sub_chemsys[chemsys])
 
-        self.logger.debug(
-            f"Found {len(affected_chemsys)} chemical systems affected by this build"
-        )
+        self.logger.debug(f"Found {len(affected_chemsys)} chemical systems affected by this build")
 
         return affected_chemsys

--- a/emmet-builders/requirements.txt
+++ b/emmet-builders/requirements.txt
@@ -1,2 +1,2 @@
-maggma>=0.38.1
+maggma>=0.44.2
 emmet-core>=0.21.19

--- a/tests/emmet-api/_consumer/test_query_operators.py
+++ b/tests/emmet-api/_consumer/test_query_operators.py
@@ -17,17 +17,15 @@ def test_user_settings_post_query():
     with ScratchDir("."):
         dumpfn(op, "temp.json")
         new_op = loadfn("temp.json")
-        assert new_op.query(
-            consumer_id="test", settings={"test": "test", "test2": 10}
-        ) == {
-            "criteria": {
-                "consumer_id": "test",
-                "settings": {"test": "test", "test2": 10},
-            }
+        query = {
+            "criteria": {"consumer_id": "test", "settings": {"test": "test", "test2": 10},}
+        }
+        assert new_op.query(consumer_id="test", settings={"test": "test", "test2": 10}) == {
+            "criteria": {"consumer_id": "test", "settings": {"test": "test", "test2": 10},}
         }
 
     docs = [{"consumer_id": "test", "settings": {"test": "test", "test2": 10}}]
-    assert op.post_process(docs) == docs
+    assert op.post_process(docs, query) == docs
 
 
 def test_user_settings_get_query():

--- a/tests/emmet-api/_general_store/test_query_operators.py
+++ b/tests/emmet-api/_general_store/test_query_operators.py
@@ -23,18 +23,19 @@ def test_user_settings_post_query():
     with ScratchDir("."):
         dumpfn(op, "temp.json")
         new_op = loadfn("temp.json")
-        assert new_op.query(
-            kind="test", meta={"test": "test", "test2": 10}, markdown="test"
-        ) == {
+        query = {
             "criteria": {
                 "kind": "test",
                 "meta": {"test": "test", "test2": 10},
                 "markdown": "test",
             }
         }
+        assert new_op.query(
+            kind="test", meta={"test": "test", "test2": 10}, markdown="test"
+        ) == query
 
     docs = [{"kind": "test", "meta": {"test": "test", "test2": 10}, "markdown": "test"}]
-    assert op.post_process(docs) == docs
+    assert op.post_process(docs, query) == docs
 
 
 def test_user_settings_get_query():

--- a/tests/emmet-api/materials/test_query_operators.py
+++ b/tests/emmet-api/materials/test_query_operators.py
@@ -146,15 +146,16 @@ def test_find_structure_query():
     structure = Structure.from_file(
         os.path.join(MAPISettings().TEST_FILES, "Si_mp_149.cif")
     )
-    assert op.query(
-        structure=structure.as_dict(), ltol=0.2, stol=0.3, angle_tol=5, limit=1
-    ) == {
+    query = {
         "criteria": {"composition_reduced": dict(structure.composition.to_reduced_dict)}
     }
+    assert op.query(
+        structure=structure.as_dict(), ltol=0.2, stol=0.3, angle_tol=5, limit=1
+    ) == query
 
     docs = [{"structure": structure.as_dict(), "material_id": "mp-149"}]
 
-    assert op.post_process(docs) == [
+    assert op.post_process(docs, query) == [
         {
             "material_id": "mp-149",
             "normalized_rms_displacement": 0,

--- a/tests/emmet-api/mpcomplete/test_query_operators.py
+++ b/tests/emmet-api/mpcomplete/test_query_operators.py
@@ -33,17 +33,18 @@ def test_mpcomplete_post_query():
     with ScratchDir("."):
         dumpfn(op, "temp.json")
         new_op = loadfn("temp.json")
-        assert new_op.query(
-            structure=structure.as_dict(),
-            public_name="Test Test",
-            public_email="test@test.com",
-        ) == {
+        query = {
             "criteria": {
                 "structure": structure.as_dict(),
                 "public_name": "Test Test",
                 "public_email": "test@test.com",
             }
         }
+        assert new_op.query(
+            structure=structure.as_dict(),
+            public_name="Test Test",
+            public_email="test@test.com",
+        ) == query
 
     docs = [
         {
@@ -52,7 +53,7 @@ def test_mpcomplete_post_query():
             "public_email": "test@test.com",
         }
     ]
-    assert op.post_process(docs) == docs
+    assert op.post_process(docs, query) == docs
 
 
 def test_mocomplete_get_query():

--- a/tests/emmet-api/robocrys/test_query_operators.py
+++ b/tests/emmet-api/robocrys/test_query_operators.py
@@ -55,9 +55,10 @@ def test_robocrys_search_query():
     with ScratchDir("."):
         dumpfn(op, "temp.json")
         new_op = loadfn("temp.json")
-        assert new_op.query(keywords="cubic, octahedra", skip=0, limit=10) == {
+        query = {
             "pipeline": pipeline
         }
+        assert new_op.query(keywords="cubic, octahedra", skip=0, limit=10) == query
 
-    assert op.post_process([{"total_doc": 10}]) == [{"total_doc": 10}]
+    assert op.post_process([{"total_doc": 10}], query) == [{"total_doc": 10}]
     assert op.meta() == {"total_doc": 10}

--- a/tests/emmet-api/summary/test_query_operators.py
+++ b/tests/emmet-api/summary/test_query_operators.py
@@ -111,7 +111,7 @@ def test_search_stats_query():
 
     docs = [{"band_gap": 1}, {"band_gap": 2}, {"band_gap": 3}]
 
-    assert isinstance(op.post_process(docs)[0], SummaryStats)
+    assert isinstance(op.post_process(docs, {"pipeline": pipeline})[0], SummaryStats)
 
 
 def test_search_es_query():

--- a/tests/emmet-api/summary/test_query_operators.py
+++ b/tests/emmet-api/summary/test_query_operators.py
@@ -36,16 +36,18 @@ def test_has_props_query():
 def test_material_ids_query():
     op = MaterialIDsSearchQuery()
 
-    assert op.query(material_ids="mp-149, mp-13") == {
-        "criteria": {"material_id": {"$in": ["mp-149", "mp-13"]}}
-    }
+    query = {"criteria": {"material_id": {"$in": ["mp-149", "mp-13"]}}}
+
+    assert op.query(material_ids="mp-149, mp-13") == query
+
+    docs = [{"material_id": "mp-13"}, {"material_id": "mp-149"}]
+
+    assert op.post_process(docs, query)[0] == docs[1]
 
     with ScratchDir("."):
         dumpfn(op, "temp.json")
         new_op = loadfn("temp.json")
-        assert new_op.query(material_ids="mp-149, mp-13") == {
-            "criteria": {"material_id": {"$in": ["mp-149", "mp-13"]}}
-        }
+        assert new_op.query(material_ids="mp-149, mp-13") == query
 
 
 def test_is_stable_query():
@@ -73,16 +75,12 @@ def test_magnetic_query():
 def test_has_reconstructed_query():
     op = SearchHasReconstructedQuery()
 
-    assert op.query(has_reconstructed=False) == {
-        "criteria": {"has_reconstructed": False}
-    }
+    assert op.query(has_reconstructed=False) == {"criteria": {"has_reconstructed": False}}
 
     with ScratchDir("."):
         dumpfn(op, "temp.json")
         new_op = loadfn("temp.json")
-        assert new_op.query(has_reconstructed=False) == {
-            "criteria": {"has_reconstructed": False}
-        }
+        assert new_op.query(has_reconstructed=False) == {"criteria": {"has_reconstructed": False}}
 
 
 def test_is_theoretical_query():
@@ -105,9 +103,7 @@ def test_search_stats_query():
         {"$project": {"band_gap": 1, "_id": 0}},
     ]
 
-    assert op.query(
-        field="band_gap", num_samples=10, min_val=0, max_val=5, num_points=100
-    ) == {"pipeline": pipeline}
+    assert op.query(field="band_gap", num_samples=10, min_val=0, max_val=5, num_points=100) == {"pipeline": pipeline}
 
     docs = [{"band_gap": 1}, {"band_gap": 2}, {"band_gap": 3}]
 
@@ -117,6 +113,4 @@ def test_search_stats_query():
 def test_search_es_query():
     op = SearchESQuery()
 
-    assert op.query(is_gap_direct=False, is_metal=False) == {
-        "criteria": {"is_gap_direct": False, "is_metal": False}
-    }
+    assert op.query(is_gap_direct=False, is_metal=False) == {"criteria": {"is_gap_direct": False, "is_metal": False}}

--- a/tests/emmet-api/tasks/test_query_operators.py
+++ b/tests/emmet-api/tasks/test_query_operators.py
@@ -37,14 +37,15 @@ def test_trajectory_query():
     with ScratchDir("."):
         dumpfn(op, "temp.json")
         new_op = loadfn("temp.json")
-
-        assert new_op.query(task_ids=" mp-149, mp-13") == {
+        query = {
             "criteria": {"task_id": {"$in": ["mp-149", "mp-13"]}}
         }
 
+        assert new_op.query(task_ids=" mp-149, mp-13") == query
+
     with open(os.path.join(MAPISettings().TEST_FILES, "tasks_Li_Fe_V.json")) as file:
         tasks = load(file)
-    docs = op.post_process(tasks)
+    docs = op.post_process(tasks, query)
     assert docs[0]["trajectories"][0]["@class"] == "Trajectory"
 
 
@@ -58,16 +59,17 @@ def test_deprecation_query():
     with ScratchDir("."):
         dumpfn(op, "temp.json")
         new_op = loadfn("temp.json")
-
-        assert new_op.query(task_ids=" mp-149, mp-13") == {
+        query = {
             "criteria": {"deprecated_tasks": {"$in": ["mp-149", "mp-13"]}}
         }
+
+        assert new_op.query(task_ids=" mp-149, mp-13") == query
 
     docs = [
         {"task_id": "mp-149", "deprecated_tasks": ["mp-149"]},
         {"task_id": "mp-13", "deprecated_tasks": ["mp-1234"]},
     ]
-    r = op.post_process(docs)
+    r = op.post_process(docs, query)
 
     assert r[0] == {
         "task_id": "mp-149",


### PR DESCRIPTION
This PR:

- Makes `material_ids` queries use input to maintain data order if no other sorting present
- Force pass necessary query parameters to all other `post_processing` methods to ensure no overwrite of data in production