### PR TITLE
Bump maggma to fix key endpoint projection issues

### DIFF
--- a/emmet-api/requirements.txt
+++ b/emmet-api/requirements.txt
@@ -3,6 +3,6 @@ gunicorn==20.1.0
 boto3>=1.20.27
 fastapi==0.72.0
 emmet-core>=0.21.19
-maggma>=0.46.0
+maggma>=0.46.1
 ddtrace==0.57.1
 setproctitle==1.2.2

--- a/emmet-builders/requirements.txt
+++ b/emmet-builders/requirements.txt
@@ -1,2 +1,2 @@
-maggma>=0.45.0
-emmet-core>=0.21.19
+maggma>=0.46.1
+emmet-core>=0.24.1

--- a/emmet-builders/setup.py
+++ b/emmet-builders/setup.py
@@ -20,7 +20,7 @@ setup(
     author_email="feedback@materialsproject.org",
     url="https://github.com/materialsproject/emmet",
     packages=find_namespace_packages(include=["emmet.*"]),
-    install_requires=["emmet-core", "maggma>=0.45.0"],
+    install_requires=["emmet-core", "maggma>=0.46.1"],
     python_requires=">=3.8",
     license="modified BSD",
     zip_safe=False,


### PR DESCRIPTION
Bump maggma version to fix projection parameter issues on key terminated API endpoints. `fields` -> `_fields`