### PR TITLE
Add quantities associated with `get_decomp_and_phase_separation_energy`

### DIFF
--- a/emmet-core/emmet/core/thermo.py
+++ b/emmet-core/emmet/core/thermo.py
@@ -77,9 +77,9 @@ class ThermoDoc(PropertyDoc):
         description="Decomposition enthalpy as defined by `get_decomp_and_phase_separation_energy` in pymatgen."
     )
 
-    decomposition_enthalpy_entries: Dict[MPID, float] = Field(
+    decomposition_enthalpy_decomposes_to: DecompositionProduct = Field(
         None,
-        description="Entries associated with decomposition_enthalpy, as a dictionary of material_id to amount."
+        description="List of decomposition data associated with the decomposition_enthalpy quantity."
     )
 
     energy_type: str = Field(
@@ -150,7 +150,14 @@ class ThermoDoc(PropertyDoc):
             try:
                 decomp, energy = pd.get_decomp_and_phase_separation_energy(e)
                 d["decomposition_enthalpy"] = energy
-                d["decomposition_enthalpy_entries"] = {de.entry_id: amt for de, amt in decomp.items()}
+                d["decomposition_enthalpy_decomposes_to"] = [
+                    {
+                        "material_id": de.entry_id,
+                        "formula": de.composition.formula,
+                        "amount": amt,
+                    }
+                    for de, amt in decomp.items()
+                ]
             except ValueError:
                 # try/except so this quantity does not take down the builder if it fails:
                 # it includes an optimization step that can be fragile in some instances,

--- a/emmet-core/emmet/core/thermo.py
+++ b/emmet-core/emmet/core/thermo.py
@@ -76,7 +76,7 @@ class ThermoDoc(PropertyDoc):
         None,
         description="Decomposition enthalpy as defined by `get_decomp_and_phase_separation_energy` in pymatgen."
     )
-    
+
     decomposition_enthalpy_entries: Dict[MPID, float] = Field(
         None,
         description="Entries associated with decomposition_enthalpy, as a dictionary of material_id to amount."
@@ -151,8 +151,8 @@ class ThermoDoc(PropertyDoc):
                 decomp, energy = pd.get_decomp_and_phase_separation_energy(e)
                 d["decomposition_enthalpy"] = energy
                 d["decomposition_enthalpy_entries"] = {de.entry_id: amt for de, amt in decomp.items()}
-            except:
-                # bare except so this quantity does not take down the builder if it fails:
+            except ValueError:
+                # try/except so this quantity does not take down the builder if it fails:
                 # it includes an optimization step that can be fragile in some instances,
                 # most likely failure is ValueError, "invalid value encountered in true_divide"
                 d["warnings"] = ["Could not calculate decomposition enthalpy for this entry."]

--- a/emmet-core/emmet/core/thermo.py
+++ b/emmet-core/emmet/core/thermo.py
@@ -72,6 +72,16 @@ class ThermoDoc(PropertyDoc):
         description="List of decomposition data for this material. Only valid for metastable or unstable material.",
     )
 
+    decomposition_enthalpy: float = Field(
+        None,
+        description="Decomposition enthalpy as defined by `get_decomp_and_phase_separation_energy` in pymatgen."
+    )
+    
+    decomposition_enthalpy_entries: Dict[MPID, float] = Field(
+        None,
+        description="Entries associated with decomposition_enthalpy, as a dictionary of material_id to amount."
+    )
+
     energy_type: str = Field(
         ...,
         description="The type of calculation this energy evaluation comes from.",
@@ -136,6 +146,16 @@ class ThermoDoc(PropertyDoc):
                     }
                     for de, amt in decomp.items()
                 ]
+
+            try:
+                decomp, energy = pd.get_decomp_and_phase_separation_energy(e)
+                d["decomposition_enthalpy"] = energy
+                d["decomposition_enthalpy_entries"] = {de.entry_id: amt for de, amt in decomp.items()}
+            except:
+                # bare except so this quantity does not take down the builder if it fails:
+                # it includes an optimization step that can be fragile in some instances,
+                # most likely failure is ValueError, "invalid value encountered in true_divide"
+                d["warnings"] = ["Could not calculate decomposition enthalpy for this entry."]
 
             d["energy_type"] = e.parameters.get("run_type", "Unknown")
             d["entry_types"] = [e.parameters.get("run_type", "Unknown")]

--- a/emmet-core/emmet/core/thermo.py
+++ b/emmet-core/emmet/core/thermo.py
@@ -77,7 +77,7 @@ class ThermoDoc(PropertyDoc):
         description="Decomposition enthalpy as defined by `get_decomp_and_phase_separation_energy` in pymatgen."
     )
 
-    decomposition_enthalpy_decomposes_to: DecompositionProduct = Field(
+    decomposition_enthalpy_decomposes_to: List[DecompositionProduct] = Field(
         None,
         description="List of decomposition data associated with the decomposition_enthalpy quantity."
     )


### PR DESCRIPTION
Naming these quantities is a little tricky, did not want this decomposition pathway to be confused with `decomposes_to`. Open to alternative suggestions.

Have included pathway as a dict mapping `entry.id` to `amt`, but could do a list like `DecompositionProduct` instead if we want to be more verbose.