### PR TITLE
Fix validation projection

### DIFF
--- a/emmet-builders/emmet/builders/vasp/task_validator.py
+++ b/emmet-builders/emmet/builders/vasp/task_validator.py
@@ -40,6 +40,8 @@ class TaskValidator(MapBuilder):
                 "output.bandgap",
                 "chemsys",
                 "calcs_reversed.output.ionic_steps.electronic_steps.e_fr_energy",
+                "calcs_reversed.output.outcar.magnetization",
+                "calcs_reversed.output.structure",
                 "tags",
                 # Need these two for proper run_type determination
                 "calcs_reversed.input.parameters",


### PR DESCRIPTION
Ensures all proper output data is included in the task doc processed by the validation builder.