### PR TITLE
Fix calcs_reversed and output structure

### DIFF
--- a/emmet-builders/emmet/builders/vasp/task_validator.py
+++ b/emmet-builders/emmet/builders/vasp/task_validator.py
@@ -40,8 +40,7 @@ class TaskValidator(MapBuilder):
                 "output.bandgap",
                 "chemsys",
                 "calcs_reversed.output.ionic_steps.electronic_steps.e_fr_energy",
-                "calcs_reversed.output.outcar.magnetization",
-                "calcs_reversed.output.structure",
+                "calcs_reversed",
                 "tags",
                 # Need these two for proper run_type determination
                 "calcs_reversed.input.parameters",

--- a/emmet-builders/emmet/builders/vasp/task_validator.py
+++ b/emmet-builders/emmet/builders/vasp/task_validator.py
@@ -39,12 +39,7 @@ class TaskValidator(MapBuilder):
                 "output.structure",
                 "output.bandgap",
                 "chemsys",
-                "calcs_reversed.output.ionic_steps.electronic_steps.e_fr_energy",
                 "calcs_reversed",
-                "tags",
-                # Need these two for proper run_type determination
-                "calcs_reversed.input.parameters",
-                "calcs_reversed.input.incar",
             ],
             query=query,
             **kwargs,

--- a/emmet-core/emmet/core/vasp/validation.py
+++ b/emmet-core/emmet/core/vasp/validation.py
@@ -227,12 +227,12 @@ def _magmom_check(task_doc, chemsys):
             for site_num, mag in enumerate(
                 task_doc.calcs_reversed[0]["output"]["outcar"]["magnetization"]
             ):
-                if (
-                    task_doc.calcs_reversed[0]["output"]["structure"]["sites"][
-                        site_num
-                    ]["label"]
-                    == ele
-                ):
+                if "structure" in task_doc.calcs_reversed[0]["output"]:
+                    output_structure = task_doc.calcs_reversed[0]["output"]["structure"]
+                else:
+                    output_structure = task_doc.output.structure.as_dict()
+
+                if output_structure["sites"][site_num]["label"] == ele:
                     if abs(mag["tot"]) > max_val:
                         return True
 


### PR DESCRIPTION
Projects the full `calcs_reversed` data in the validation builder, and properly selects the output structure for magnetization validation.