### PR TITLE
Fix `tags` field in task document

### DIFF
--- a/emmet-core/emmet/core/tasks.py
+++ b/emmet-core/emmet/core/tasks.py
@@ -145,7 +145,7 @@ class TaskDoc(BaseModel):
     """
 
     tags: List[str] = Field(
-        None, title="tag", description="Metadata tagged to a given task."
+        [], title="tag", description="Metadata tagged to a given task."
     )
 
     state: TaskState = Field(None, description="State of this calculation")


### PR DESCRIPTION
Ensures that the tags field is at least an empty list in the task document model.