### PR TITLE
Ensure electrode groups only pull non-deprecated materials

### DIFF
--- a/emmet-builders/emmet/builders/materials/electrodes.py
+++ b/emmet-builders/emmet/builders/materials/electrodes.py
@@ -108,6 +108,9 @@ class StructureGroupBuilder(Builder):
         self.stol = stol
         self.angle_tol = angle_tol
         self.check_newer = check_newer
+
+        self.query["deprecated"] = False # Ensure only non-deprecated materials are chosen
+
         super().__init__(sources=[materials], targets=[sgroups], **kwargs)
 
     def prechunk(self, number_splits: int) -> Iterator[Dict]:  # pragma: no cover

--- a/emmet-builders/emmet/builders/materials/electrodes.py
+++ b/emmet-builders/emmet/builders/materials/electrodes.py
@@ -109,7 +109,7 @@ class StructureGroupBuilder(Builder):
         self.angle_tol = angle_tol
         self.check_newer = check_newer
 
-        self.query["deprecated"] = False # Ensure only non-deprecated materials are chosen
+        self.query["deprecated"] = False  # Ensure only non-deprecated materials are chosen
 
         super().__init__(sources=[materials], targets=[sgroups], **kwargs)
 


### PR DESCRIPTION
This PR ensures the `StructureGroupBuilder` only pulls non-deprecated materials. This fixes issues with the downstream `InsertionElectrodesBuilder` not building specific known electrode documents. 