### PR TITLE
Materials builder scan changes

### DIFF
--- a/emmet-builders/emmet/builders/vasp/materials.py
+++ b/emmet-builders/emmet/builders/vasp/materials.py
@@ -244,7 +244,7 @@ class MaterialsBuilder(Builder):
                 materials.append(
                     MaterialsDoc.from_tasks(
                         group,
-                        quality_scores=self.settings.VASP_QUALITY_SCORES,
+                        structure_quality_scores=self.settings.VASP_STRUCTURE_QUALITY_SCORES,
                         use_statics=self.settings.VASP_USE_STATICS,
                     )
                 )

--- a/emmet-core/emmet/core/settings.py
+++ b/emmet-core/emmet/core/settings.py
@@ -130,6 +130,10 @@ class EmmetSettings(BaseSettings):
         description="Default input sets for task validation",
     )
 
+    VASP_PSEUDO_DIR: str = Field(
+        None, description="Pymatgen compatible directory of VASP pseudopotentials.",
+    )
+
     VASP_CHECKED_LDAU_FIELDS: List[str] = Field(
         ["LDAUU", "LDAUJ", "LDAUL"], description="LDAU fields to validate for tasks"
     )
@@ -181,6 +185,19 @@ class EmmetSettings(BaseSettings):
         if isinstance(value, dict):
             return {k: MontyDecoder().process_decoded(v) for k, v in value.items()}
         return value
+
+    @validator("VASP_PSEUDO_DIR", pre=True, always=True)
+    def get_default_dir(cls, value):
+        if value is not None:
+            return value
+        else:
+            try:
+                from pymatgen.core import SETTINGS
+
+                directory = SETTINGS.get("PMG_VASP_PSP_DIR", None)
+                return directory
+            except ImportError:
+                return None
 
     def as_dict(self):
         """

--- a/emmet-core/emmet/core/settings.py
+++ b/emmet-core/emmet/core/settings.py
@@ -99,9 +99,9 @@ class EmmetSettings(BaseSettings):
         description="Dictionary mapping Q-Chem task type to a quality score",
     )
 
-    VASP_QUALITY_SCORES: Dict[str, int] = Field(
+    VASP_STRUCTURE_QUALITY_SCORES: Dict[str, int] = Field(
         {"SCAN": 3, "GGA+U": 2, "GGA": 1},
-        description="Dictionary Mapping VASP calculation run types to rung level for VASP materials builders",
+        description="Dictionary Mapping VASP calculation run types to rung level for VASP materials builder structure data",
     )
 
     VASP_KPTS_TOLERANCE: float = Field(

--- a/emmet-core/emmet/core/settings.py
+++ b/emmet-core/emmet/core/settings.py
@@ -100,7 +100,7 @@ class EmmetSettings(BaseSettings):
     )
 
     VASP_STRUCTURE_QUALITY_SCORES: Dict[str, int] = Field(
-        {"SCAN": 3, "GGA+U": 2, "GGA": 1},
+        {"PBESol": 5, "R2SCAN": 4, "SCAN": 3, "GGA+U": 2, "GGA": 1},
         description="Dictionary Mapping VASP calculation run types to rung level for VASP materials builder structure data",
     )
 

--- a/emmet-core/emmet/core/summary.py
+++ b/emmet-core/emmet/core/summary.py
@@ -14,6 +14,7 @@ from emmet.core.chemenv import (
 from emmet.core.mpid import MPID
 from emmet.core.thermo import DecompositionProduct
 from emmet.core.xas import Edge, Type
+from emmet.core.elasticity import BulkModulus, ShearModulus
 
 T = TypeVar("T", bound="SummaryDoc")
 
@@ -312,41 +313,15 @@ class SummaryDoc(PropertyDoc):
 
     # Elasticity
 
-    k_voigt: float = Field(
-        None,
-        description="Voigt average of the bulk modulus in GPa.",
-        source="elasticity",
+    bulk_modulus: BulkModulus = Field(
+        None, description="Bulk modulus data in in GPa.", source="elasticity",
     )
 
-    k_reuss: float = Field(
-        None,
-        description="Reuss average of the bulk modulus in GPa.",
-        source="elasticity",
+    shear_modulus: ShearModulus = Field(
+        None, description="Shear modulus in GPa.", source="elasticity",
     )
 
-    k_vrh: float = Field(
-        None,
-        description="Voigt-Reuss-Hill average of the bulk modulus in GPa.",
-        source="elasticity",
-    )
-
-    g_voigt: float = Field(
-        None,
-        description="Voigt average of the shear modulus in GPa.",
-        source="elasticity",
-    )
-
-    g_reuss: float = Field(
-        None,
-        description="Reuss average of the shear modulus in GPa.",
-        source="elasticity",
-    )
-
-    g_vrh: float = Field(
-        None,
-        description="Voigt-Reuss-Hill average of the shear modulus in GPa.",
-        source="elasticity",
-    )
+    young_modulus: float = Field(None, description="Young's modulus (SI units)")
 
     universal_anisotropy: float = Field(
         None, description="Elastic anisotropy.", source="elasticity"
@@ -524,12 +499,9 @@ summary_fields: Dict[str, list] = {
         "is_magnetic",
     ],
     HasProps.elasticity.value: [
-        "k_voigt",
-        "k_reuss",
-        "k_vrh",
-        "g_voigt",
-        "g_reuss",
-        "g_vrh",
+        "bulk_modulus",
+        "shear_modulus",
+        "young_modulus",
         "universal_anisotropy",
         "homogeneous_poisson",
     ],

--- a/emmet-core/emmet/core/vasp/material.py
+++ b/emmet-core/emmet/core/vasp/material.py
@@ -43,7 +43,9 @@ class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
     def from_tasks(
         cls,
         task_group: List[TaskDocument],
-        quality_scores: Dict[str, int] = SETTINGS.VASP_QUALITY_SCORES,
+        structure_quality_scores: Dict[
+            str, int
+        ] = SETTINGS.VASP_STRUCTURE_QUALITY_SCORES,
         use_statics: bool = SETTINGS.VASP_USE_STATICS,
     ) -> "MaterialsDoc":
         """
@@ -51,7 +53,7 @@ class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
 
         Args:
             task_group: List of task document
-            quality_scores: quality scores for various calculation types
+            structure_quality_scores: quality scores for various calculation types
             use_statics: Use statics to define a material
         """
         if len(task_group) == 0:
@@ -86,7 +88,7 @@ class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
         material_id = min(possible_mat_ids)
 
         # Always prefer a static over a structure opt
-        task_quality_scores = {"Structure Optimization": 1, "Static": 2}
+        structure_task_quality_scores = {"Structure Optimization": 1, "Static": 2}
 
         def _structure_eval(task: TaskDocument):
             """
@@ -105,8 +107,8 @@ class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
 
             return (
                 -1 * int(task.is_valid),
-                -1 * quality_scores.get(task_run_type.value, 0),
-                -1 * task_quality_scores.get(task.task_type.value, 0),
+                -1 * structure_quality_scores.get(task_run_type.value, 0),
+                -1 * structure_task_quality_scores.get(task.task_type.value, 0),
                 -1 * special_tags,
                 task.output.energy_per_atom,
             )
@@ -138,6 +140,30 @@ class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
 
         # Entries
         # **current materials docs must contain at last one GGA or GGA+U entry
+
+        # Always prefer a static over a structure opt
+        entry_task_quality_scores = {"Structure Optimization": 1, "Static": 2}
+
+        def _entry_eval(task: TaskDocument):
+            """
+            Helper function to order entries and statics calcs by
+            - Spin polarization
+            - Special Tags
+            - Energy
+            """
+
+            _SPECIAL_TAGS = ["LASPH", "ISPIN"]
+            special_tags = sum(
+                task.input.parameters.get(tag, False) for tag in _SPECIAL_TAGS
+            )
+
+            return (
+                -1 * int(task.is_valid),
+                -1 * entry_task_quality_scores.get(task.task_type.value, 0),
+                -1 * special_tags,
+                task.output.energy_per_atom,
+            )
+
         entries = {}
         all_run_types = set(run_types.values())
 
@@ -149,7 +175,7 @@ class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
         for rt in all_run_types:
             relevant_calcs = sorted(
                 [doc for doc in structure_calcs if doc.run_type == rt and doc.is_valid],
-                key=_structure_eval,
+                key=_entry_eval,
             )
 
             if len(relevant_calcs) > 0:


### PR DESCRIPTION
- Materials builder now correctly includes a blessed entry for each calculation type found in the task list.
- There are now separate score settings for choosing a blessed calculation for materials structure data and thermo energy data.
- POTCAR hashes are now correctly validated in the `TaskValidation` builder according to each calculation's valid input set from pymatgen.