### PR TITLE
Change structure quality scores for materials builder

### DIFF
--- a/emmet-core/emmet/core/settings.py
+++ b/emmet-core/emmet/core/settings.py
@@ -101,7 +101,7 @@ class EmmetSettings(BaseSettings):
     )
 
     VASP_STRUCTURE_QUALITY_SCORES: Dict[str, int] = Field(
-        {"PBESol": 5, "R2SCAN": 4, "SCAN": 3, "GGA+U": 2, "GGA": 1},
+        {"R2SCAN": 5, "SCAN": 4, "GGA+U": 3, "GGA": 2, "PBESol": 1},
         description="Dictionary Mapping VASP calculation run types to rung level for VASP materials builder structure data",
     )
 


### PR DESCRIPTION
Change structure quality scores for the materials builder from:

`PBESol > R2SCAN > SCAN > GGA+U > GGA`

to 

` R2SCAN > SCAN > GGA+U > GGA > PBESol`