### PR TITLE
Build POTCAR hash cache in validation builder

### DIFF
--- a/emmet-builders/emmet/builders/vasp/task_validator.py
+++ b/emmet-builders/emmet/builders/vasp/task_validator.py
@@ -1,4 +1,5 @@
 from typing import Dict, Optional
+from collections import defaultdict
 
 from maggma.builders import MapBuilder
 from maggma.core import Store
@@ -29,6 +30,23 @@ class TaskValidator(MapBuilder):
         self.settings = EmmetBuildSettings.autoload(settings)
         self.query = query
         self.kwargs = kwargs
+        self._potcar_hashes = None
+
+        # Set up potcar cache if appropriate
+        if self.settings.VASP_VALIDATE_POTCAR_HASHES:
+            from pymatgen.io.vasp.inputs import PotcarSingle
+
+            potcar_hashes = defaultdict(dict)  # type: dict
+
+            for (calc_type, input_set) in self.settings.VASP_DEFAULT_INPUT_SETS.items():
+                functional = input_set.CONFIG["POTCAR_FUNCTIONAL"]
+                for potcar_symbol in input_set.CONFIG["POTCAR"].values():
+                    potcar = PotcarSingle.from_symbol_and_functional(
+                        symbol=potcar_symbol, functional=functional
+                    )
+                    potcar_hashes[calc_type][potcar_symbol] = potcar.get_potcar_hash()
+
+            self._potcar_hashes = potcar_hashes
 
         super().__init__(
             source=tasks,
@@ -58,9 +76,9 @@ class TaskValidator(MapBuilder):
             kpts_tolerance=self.settings.VASP_KPTS_TOLERANCE,
             kspacing_tolerance=self.settings.VASP_KSPACING_TOLERANCE,
             input_sets=self.settings.VASP_DEFAULT_INPUT_SETS,
-            pseudo_dir=self.settings.VASP_PSEUDO_DIR,
             LDAU_fields=self.settings.VASP_CHECKED_LDAU_FIELDS,
             max_allowed_scf_gradient=self.settings.VASP_MAX_SCF_GRADIENT,
+            potcar_hashes=self._potcar_hashes,
         )
 
         bad_tags = list(set(task_doc.tags).intersection(self.settings.DEPRECATED_TAGS))

--- a/emmet-core/emmet/core/settings.py
+++ b/emmet-core/emmet/core/settings.py
@@ -200,20 +200,6 @@ class EmmetSettings(BaseSettings):
             return {k: MontyDecoder().process_decoded(v) for k, v in value.items()}
         return value
 
-    @validator("VASP_PSEUDO_DIR", pre=True, always=True)
-    def get_default_dir(cls, value):
-        if value is not None:
-            os.environ["PMG_VASP_PSP_DIR"] = value
-            return value
-        else:
-            try:
-                from pymatgen.core import SETTINGS
-
-                directory = SETTINGS.get("PMG_VASP_PSP_DIR", None)
-                return directory
-            except ImportError:
-                return None
-
     def as_dict(self):
         """
         HotPatch to enable serializing EmmetSettings via Monty

--- a/emmet-core/emmet/core/settings.py
+++ b/emmet-core/emmet/core/settings.py
@@ -144,8 +144,8 @@ class EmmetSettings(BaseSettings):
         description="Default input sets for task validation",
     )
 
-    VASP_PSEUDO_DIR: str = Field(
-        None, description="Pymatgen compatible directory of VASP pseudopotentials.",
+    VASP_VALIDATE_POTCAR_HASHES: bool = Field(
+        True, description="Whether to validate POTCAR hash values."
     )
 
     VASP_CHECKED_LDAU_FIELDS: List[str] = Field(

--- a/tests/emmet-builders/test_materials.py
+++ b/tests/emmet-builders/test_materials.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from emmet.builders.settings import EmmetBuildSettings
 
 import pytest
 from maggma.stores import JSONStore, MemoryStore
@@ -15,8 +16,11 @@ def tasks_store(test_dir):
 
 @pytest.fixture(scope="session")
 def validation_store(tasks_store):
+    settings = EmmetBuildSettings(VASP_VALIDATE_POTCAR_HASHES=False)
     validation_store = MemoryStore()
-    builder = TaskValidator(tasks=tasks_store, task_validation=validation_store)
+    builder = TaskValidator(
+        tasks=tasks_store, task_validation=validation_store, settings=settings
+    )
     builder.run()
     return validation_store
 

--- a/tests/emmet-builders/test_vasp.py
+++ b/tests/emmet-builders/test_vasp.py
@@ -1,6 +1,7 @@
 import pytest
 from maggma.stores import JSONStore, MemoryStore
 
+from emmet.builders.settings import EmmetBuildSettings
 from emmet.builders.vasp.task_validator import TaskValidator
 
 intermediate_stores = ["validation"]
@@ -17,7 +18,10 @@ def validation_store():
 
 
 def test_validator(tasks_store, validation_store):
-    builder = TaskValidator(tasks=tasks_store, task_validation=validation_store)
+    settings = EmmetBuildSettings(VASP_VALIDATE_POTCAR_HASHES=False)
+    builder = TaskValidator(
+        tasks=tasks_store, task_validation=validation_store, settings=settings
+    )
     builder.run()
     assert validation_store.count() == tasks_store.count()
     assert validation_store.count({"valid": True}) == tasks_store.count()


### PR DESCRIPTION
To speed up POTCAR hash validation, the `TaskValidation` builder now creates an initial hash dictionary which is used to store all input set hash values. This avoids instantiating pymatgen `PotcarSingle` or `Potcar` objects.