### PR TITLE
Incorporate new mixing scheme into thermo builder

### DIFF
--- a/emmet-builders/emmet/builders/vasp/thermo.py
+++ b/emmet-builders/emmet/builders/vasp/thermo.py
@@ -276,11 +276,6 @@ class ThermoBuilder(Builder):
         new_q["chemsys"] = {"$in": list(query_chemsys)}
         new_q["deprecated"] = False
 
-        # only build with materials that have a GGA or GGA+U entry
-        new_q["$or"] = [
-            {"entries.GGA": {"$exists": True}},
-            {"entries.GGA+U": {"$exists": True}},
-        ]
         materials_docs = list(
             self.materials.query(
                 criteria=new_q, properties=["material_id", "entries", "deprecated"]
@@ -306,17 +301,16 @@ class ThermoBuilder(Builder):
             f"Got {len(materials_docs)} entries from DB for {len(query_chemsys)} sub-chemsys for {chemsys}"
         )
 
-        # Convert GGA and GGA+U entries into ComputedEntries and store
+        # Convert entries into ComputedEntries and store
         for doc in materials_docs:
             for r_type, entry_dict in doc.get("entries", {}).items():
-                if r_type == "GGA" or r_type == "GGA+U":
-                    entry_dict["data"]["oxidation_states"] = oxi_states_data.get(
-                        entry_dict["entry_id"], {}
-                    )
-                    entry_dict["data"]["run_type"] = r_type
-                    elsyms = sorted(set([el for el in entry_dict["composition"]]))
-                    self._entries_cache["-".join(elsyms)].append(entry_dict)
-                    all_entries.append(entry_dict)
+                entry_dict["data"]["oxidation_states"] = oxi_states_data.get(
+                    entry_dict["entry_id"], {}
+                )
+                entry_dict["data"]["run_type"] = r_type
+                elsyms = sorted(set([el for el in entry_dict["composition"]]))
+                self._entries_cache["-".join(elsyms)].append(entry_dict)
+                all_entries.append(entry_dict)
 
         self.logger.info(f"Total entries in {chemsys} : {len(all_entries)}")
 


### PR DESCRIPTION
This PR incorporates the new `MaterialsProjectDFTMixingScheme` into the thermo builder. This allows for proper integration of r2SCAN calculations into energy and phase diagram data.