### PR TITLE
Unpin `pymatgen-analysis-alloys` dependency

### DIFF
--- a/emmet-core/requirements.txt
+++ b/emmet-core/requirements.txt
@@ -8,4 +8,4 @@ setuptools-scm==7.0.5
 robocrys==0.2.7
 matminer==0.7.8
 pymatgen-analysis-diffusion==2022.1.15
-pymatgen-analysis-alloys==0.0.2
+pymatgen-analysis-alloys==0.0.3

--- a/emmet-core/setup.py
+++ b/emmet-core/setup.py
@@ -35,7 +35,7 @@ setup(
         "robocrys>=0.2.7",
         "matminer>=0.7.3",
         "pymatgen-analysis-diffusion>=2022.1.15",
-        "pymatgen-analysis-alloys==0.0.2"
+        "pymatgen-analysis-alloys>=0.0.3"
     ],
     python_requires=">=3.8",
     license="modified BSD",


### PR DESCRIPTION
Alloy versions >= 0.03 to be installed