### PR TITLE
Theoretical field default change to None

### DIFF
--- a/emmet-core/emmet/core/provenance.py
+++ b/emmet-core/emmet/core/provenance.py
@@ -121,7 +121,7 @@ class ProvenanceDoc(PropertyDoc):
     tags: List[str] = Field([])
 
     theoretical: bool = Field(
-        True, description="If this material has any experimental provenance or not"
+        None, description="If this material has any experimental provenance or not"
     )
 
     database_IDs: Dict[Database, List[str]] = Field(

--- a/emmet-core/emmet/core/summary.py
+++ b/emmet-core/emmet/core/summary.py
@@ -401,7 +401,7 @@ class SummaryDoc(PropertyDoc):
     # Theoretical
 
     theoretical: bool = Field(
-        True, description="Whether the material is theoretical.", source="provenance"
+        None, description="Whether the material is theoretical.", source="provenance"
     )
 
     @classmethod


### PR DESCRIPTION
Change the default value for the `theoretical` field in `SummaryDoc` and `ProvenanceDoc` to `None` to avoid issues with `True` being populated for experimental material data returned via the API client.