### PR TITLE
Remove `matminer` as a dependency

### DIFF
--- a/emmet-builders/requirements.txt
+++ b/emmet-builders/requirements.txt
@@ -1,2 +1,3 @@
 maggma>=0.47.3
 emmet-core>=0.26.2
+matminer==0.7.8

--- a/emmet-builders/setup.py
+++ b/emmet-builders/setup.py
@@ -20,7 +20,7 @@ setup(
     author_email="feedback@materialsproject.org",
     url="https://github.com/materialsproject/emmet",
     packages=find_namespace_packages(include=["emmet.*"]),
-    install_requires=["emmet-core", "maggma>=0.47.3"],
+    install_requires=["emmet-core", "maggma>=0.47.3", "matminer>=0.7.3"],
     python_requires=">=3.8",
     license="modified BSD",
     zip_safe=False,

--- a/emmet-core/requirements.txt
+++ b/emmet-core/requirements.txt
@@ -6,6 +6,5 @@ typing-extensions==4.3.0
 seekpath==2.0.1
 setuptools-scm==7.0.5
 robocrys==0.2.7
-matminer==0.7.8
 pymatgen-analysis-diffusion==2022.1.15
 pymatgen-analysis-alloys==0.0.3

--- a/emmet-core/setup.py
+++ b/emmet-core/setup.py
@@ -33,7 +33,6 @@ setup(
         "pybtex~=0.24",
         "typing-extensions>=3.7,<5.0",
         "robocrys>=0.2.7",
-        "matminer>=0.7.3",
         "pymatgen-analysis-diffusion>=2022.1.15",
         "pymatgen-analysis-alloys>=0.0.3"
     ],


### PR DESCRIPTION
Removes `matminer` as a dependency of `emmet-core`.

This is only used in builders.