### PR TITLE
Update Redox Elements

### DIFF
--- a/emmet-builders/emmet/builders/materials/electrodes.py
+++ b/emmet-builders/emmet/builders/materials/electrodes.py
@@ -32,6 +32,7 @@ REDOX_ELEMENTS = [
     "Cu",
     "Nb",
     "Mo",
+    "Ag",
     "Sn",
     "Sb",
     "W",

--- a/emmet-builders/emmet/builders/materials/electrodes.py
+++ b/emmet-builders/emmet/builders/materials/electrodes.py
@@ -38,7 +38,6 @@ REDOX_ELEMENTS = [
     "Re",
     "Bi",
     "C",
-    "Hf",
 ]
 
 WORKING_IONS = ["Li", "Be", "Na", "Mg", "K", "Ca", "Rb", "Sr", "Cs", "Ba"]


### PR DESCRIPTION
Per the June 13, 2022 meeting and discussion with Kristin and other Persson Group members, we would like to make the InsertionElectrodes builder consistent with the screening process used for identifying intercalation electrodes in research. Therefore the list of redox active elements was updated to remove Hf (only affects two battery entries on MP) and add Ag.
