### PR TITLE
Permitting Electrodes with Extractable Ions

### DIFF
--- a/emmet-builders/emmet/builders/materials/electrodes.py
+++ b/emmet-builders/emmet/builders/materials/electrodes.py
@@ -154,14 +154,12 @@ class StructureGroupBuilder(Builder):
             - get the oldest timestamp for the target documents (min_target_time)
             - if min_target_time is < max_mat_time then nuke all the target documents
         """
-        other_wions = list(set(WORKING_IONS) - {self.working_ion})
         # All potentially interesting chemsys must contain the working ion
         base_query = {
             "$and": [
                 self.query.copy(),
                 {"elements": {"$in": REDOX_ELEMENTS}},
                 {"elements": {"$in": [self.working_ion]}},
-                {"elements": {"$nin": other_wions}},
             ]
         }
         self.logger.debug(f"Initial Chemsys QUERY: {base_query}")

--- a/emmet-builders/emmet/builders/materials/electrodes.py
+++ b/emmet-builders/emmet/builders/materials/electrodes.py
@@ -41,7 +41,7 @@ REDOX_ELEMENTS = [
     "Hf",
 ]
 
-WORKING_IONS = ["Li", "Be", "Na", "Mg", "K", "Ca", "Rb", "Sr", "Cs", "Ba"]
+WORKING_IONS = ["Li", "Na", "K", "Mg", "Ca", "Zn", "Al"]
 
 MAT_PROPS = ["structure", "material_id", "formula_pretty", "entries"]
 


### PR DESCRIPTION
The previous StructureGroupBuilder base query did not permit the processing of structures that contained ["Li", "Be", "Na", "Mg", "K", "Ca", "Rb", "Sr", "Cs", "Ba"]. However, it is possible to have insertion electrodes that contain extractable ions (e.g. ["H", "Li", "Na", "K", "Rb", "Cs", "Ag", "Cu"]) and these types of systems were being excluded from the InsertionElectrodeBuilder.

This requirement has been removed from the StructureGroupBuilder to allow the analysis of Insertion Electrodes with extractable ions. Note this is a significant change because the Insertion Electrodes will no longer be limited to systems that only contain a single mobile species, however all analysis will still only assume one species as the working ion.