### PR TITLE
Permit electrodes with non-TM redox active species

### DIFF
--- a/emmet-core/emmet/core/electrode.py
+++ b/emmet-core/emmet/core/electrode.py
@@ -289,19 +289,22 @@ class InsertionElectrodeDoc(InsertionVoltagePairDoc):
 
         # Check if more than one working ion per transition metal and warn
         warnings = []
-        transition_metal_fraction = sum(
-            [
-                discharge_comp.get_atomic_fraction(element)
-                for element in discharge_comp
-                if element.is_transition_metal
-            ]
-        )
-        if (
-            discharge_comp.get_atomic_fraction(working_ion_ele)
-            / transition_metal_fraction
-            > 1.0
-        ):
-            warnings.append("More than one working ion per transition metal")
+        if any([element.is_transition_metal for element in discharge_comp]):
+            transition_metal_fraction = sum(
+                [
+                    discharge_comp.get_atomic_fraction(element)
+                    for element in discharge_comp
+                    if element.is_transition_metal
+                ]
+            )
+            if (
+                discharge_comp.get_atomic_fraction(working_ion_ele)
+                / transition_metal_fraction
+                > 1.0
+            ):
+                warnings.append("More than one working ion per transition metal")
+        else:
+            warnings.append("Transition metal not found")
 
         return cls(
             battery_id=battery_id,


### PR DESCRIPTION
There are valid electrodes that contain redox active species which are not transition metals (e.g. Sn, Sb, Bi, C). The InsertionElectrodeDocument had a check which assumes the presence of transition metals in the host material which created an error for any electrodes that contained non-transition-metal redox active species.

An if statement has been added to check for the presence of a transition metal to avoid this error and a warning has been added ("Transition metal not found") instead. Now the InsertionElectrodesBuilder can successfully process electrodes that only contain Sn, Sb, Bi, or C as the redox active specie.