### PR TITLE
StructureGroupBuilder and StructureGroupDoc minor fixes

### DIFF
--- a/emmet-builders/emmet/builders/materials/electrodes.py
+++ b/emmet-builders/emmet/builders/materials/electrodes.py
@@ -283,6 +283,8 @@ class StructureGroupBuilder(Builder):
                 return ComputedStructureEntry.from_dict(mdoc["entries"]["GGA+U"])
             elif "GGA" in mdoc["entries"].keys():
                 return ComputedStructureEntry.from_dict(mdoc["entries"]["GGA"])
+            else:
+                return None
 
     def process_item(self, item: Any) -> Any:
         if item is None:

--- a/emmet-builders/emmet/builders/materials/electrodes.py
+++ b/emmet-builders/emmet/builders/materials/electrodes.py
@@ -275,13 +275,14 @@ class StructureGroupBuilder(Builder):
     def _entry_from_mat_doc(self, mdoc):
         # Note since we are just structure grouping we don't need to be careful with energy or correction
         # All of the energy analysis is left to other builders
-        d_ = {
-            "entry_id": mdoc["material_id"],
-            "structure": mdoc["structure"],
-            "energy": list(mdoc["entries"].values())[0]["energy"],
-            "correction": list(mdoc["entries"].values())[0]["correction"]
-        }
-        return ComputedStructureEntry.from_dict(d_)
+        entries = [ComputedStructureEntry.from_dict(v) for v in mdoc["entries"].values()]
+        if len(entries) == 1:
+            return entries[0]
+        else:
+            if "GGA+U" in mdoc["entries"].keys():
+                return ComputedStructureEntry.from_dict(mdoc["entries"]["GGA+U"])
+            elif "GGA" in mdoc["entries"].keys():
+                return ComputedStructureEntry.from_dict(mdoc["entries"]["GGA"])
 
     def process_item(self, item: Any) -> Any:
         if item is None:

--- a/emmet-core/emmet/core/structure_group.py
+++ b/emmet-core/emmet/core/structure_group.py
@@ -65,11 +65,10 @@ class StructureGroupDoc(BaseModel):
         description="A list of materials ids for all of the materials that were grouped together."
     )
 
-    host_material_id: str = Field(
+    host_material_ids: list = Field(
         None,
-        description="Material id that corresponds to the host structure, which is defined as the structure with the"
-                    "lowest concentration of ignored specie and lowest energy if there are multiple structures with the"
-                    "host concentration."
+        description="Material id(s) that correspond(s) to the host structure(s), which has/have the lowest"
+                    "concentration of ignored specie."
     )
 
     insertion_material_ids: list = Field(


### PR DESCRIPTION
There are 2 small bugs found and things should now be working as expected after testing the StructureGroupBuilder on the MP materials collection and not just my personal materials collection.

1) The field name was not updated for the "host_material_ids" since a small change was made to the field
2) The StructureGroupBuilder and StructureGroupDoc originally did not consider energy data, but now that it is being used to determine the lowest energy "host_material_id" when there are multiple potential ids to choose from, the existing method of generating a ComputedStructureEntry in the " _entry_from_mat_doc" method needed to be revised. This is a more robust method because it uses all the information available in the MaterialsDoc's entries field and checks for the run type, which is not always just GGA or GGA+U especially in the MP materials collection. The MP compatibility scheme can only apply to calculations performed with GGA or GGA+U, and GGA+U is prioritized because it is a higher level of theory.

@munrojm  @acrutt 
