### PR TITLE
Aneb utils func

### DIFF
--- a/emmet-core/emmet/core/mobility/utils.py
+++ b/emmet-core/emmet/core/mobility/utils.py
@@ -1,0 +1,6 @@
+from emmet.core.mobility.migrationgraph import MigrationGraphDoc
+
+def get_aneb_wf_inputs(
+    mgdoc: MigrationGraphDoc
+):
+

--- a/emmet-core/emmet/core/mobility/utils.py
+++ b/emmet-core/emmet/core/mobility/utils.py
@@ -1,6 +1,42 @@
+from typing import Tuple, List, Dict
 from emmet.core.mobility.migrationgraph import MigrationGraphDoc
+
 
 def get_aneb_wf_inputs(
     mgdoc: MigrationGraphDoc
-):
+) -> Tuple[List, List[str], Dict]:
+    """
+    This is a utils function that takes a MigrationGraphDoc object and converts the site dict and combo into inputs for aneb wf on atomate (compatibility for atomate2 to come).
+    Using the results of this function as inputs for atomate's aneb wf will avoid unnecessary enpoint calculations, since MGDoc's site dict contains sites that are not used in sites combo.
+    """
+    if mgdoc.inserted_ion_coords is None or mgdoc.insert_coords_combo is None:
+        raise TypeError("Please make sure that the MGDoc passed in has inserted_ion_coords and inserted_coords_combo fields filled.")
+
+    else:
+        mgdoc_sites_mapping = {}
+        anebwf_sites_list = []
+        aneb_combo_list = []
+        combo_mapping = {}
+
+        for one_combo in mgdoc.insert_coords_combo:
+            ini, end = list(map(int, one_combo.split("+")))
+
+            if ini in mgdoc_sites_mapping.keys():
+                aneb_ini = mgdoc_sites_mapping[ini]
+            else:
+                anebwf_sites_list.append(mgdoc.inserted_ion_coords[ini])
+                aneb_ini = len(anebwf_sites_list) - 1
+                mgdoc_sites_mapping[ini] = aneb_ini
+            if end in mgdoc_sites_mapping.keys():
+                aneb_end = mgdoc_sites_mapping[end]
+            else:
+                anebwf_sites_list.append(mgdoc.inserted_ion_coords[end])
+                aneb_end = len(anebwf_sites_list) - 1
+                mgdoc_sites_mapping[end] = aneb_end
+
+            aneb_combo = f"{aneb_ini}+{aneb_end}"
+            aneb_combo_list.append(aneb_combo)
+            combo_mapping[aneb_combo] = one_combo
+
+        return anebwf_sites_list, aneb_combo_list, combo_mapping
 

--- a/emmet-core/emmet/core/mobility/utils.py
+++ b/emmet-core/emmet/core/mobility/utils.py
@@ -13,9 +13,9 @@ def get_aneb_wf_inputs(
         raise TypeError("Please make sure that the MGDoc passed in has inserted_ion_coords and inserted_coords_combo fields filled.")
 
     else:
-        mgdoc_sites_mapping = {}
         anebwf_sites_list = []
         aneb_combo_list = []
+        mgdoc_sites_mapping = {}  # type: dict
         combo_mapping = {}
 
         for one_combo in mgdoc.insert_coords_combo:
@@ -24,13 +24,13 @@ def get_aneb_wf_inputs(
             if ini in mgdoc_sites_mapping.keys():
                 aneb_ini = mgdoc_sites_mapping[ini]
             else:
-                anebwf_sites_list.append(mgdoc.inserted_ion_coords[ini])
+                anebwf_sites_list.append(list(mgdoc.inserted_ion_coords[ini]["site"].frac_coords))
                 aneb_ini = len(anebwf_sites_list) - 1
                 mgdoc_sites_mapping[ini] = aneb_ini
             if end in mgdoc_sites_mapping.keys():
                 aneb_end = mgdoc_sites_mapping[end]
             else:
-                anebwf_sites_list.append(mgdoc.inserted_ion_coords[end])
+                anebwf_sites_list.append(list(mgdoc.inserted_ion_coords[end]["site"].frac_coords))
                 aneb_end = len(anebwf_sites_list) - 1
                 mgdoc_sites_mapping[end] = aneb_end
 
@@ -39,4 +39,3 @@ def get_aneb_wf_inputs(
             combo_mapping[aneb_combo] = one_combo
 
         return anebwf_sites_list, aneb_combo_list, combo_mapping
-


### PR DESCRIPTION
A simple utils function that takes a `MigrationGraphDoc` object and converts it into a set of aneb wf inputs. This is to avoid unnecessary redundant end point calculations, as not all sites in the doc are used in the ANEB calculation.
