### PR TITLE
Migration Graph Builder bug fix

### DIFF
--- a/emmet-builders/emmet/builders/mobility/migration_graph.py
+++ b/emmet-builders/emmet/builders/mobility/migration_graph.py
@@ -24,7 +24,7 @@ class MigrationGraphBuilder(MapBuilder):
         angle_tol: float = 5,
         **kwargs,
     ):
-        self.insertion_electode = insertion_electrode
+        self.insertion_electrode = insertion_electrode
         self.migration_graph = migration_graph
         self.algorithm = algorithm
         self.min_hop_distance = min_hop_distance

--- a/tests/emmet-builders/test_mobility.py
+++ b/tests/emmet-builders/test_mobility.py
@@ -25,3 +25,5 @@ def test_migration_graph_builder(ie_store, mg_store):
     assert mg_store.count() == 2
     assert mg_store.count({"state": "successful"}) == 2
     assert mg_store.count({"deprecated": False}) == 2
+    d = builder.as_dict()
+    assert type(d) is dict


### PR DESCRIPTION
typo in migration graph builder caused .as_dict() to fail. Fixed typo and added test.