### PR TITLE
BSON made optional in emmet-core

### DIFF
--- a/emmet-core/emmet/core/utils.py
+++ b/emmet-core/emmet/core/utils.py
@@ -4,7 +4,6 @@ from itertools import groupby
 from typing import Any, Iterator, List, Tuple, Dict, Union
 import copy
 
-import bson
 import numpy as np
 from monty.json import MSONable
 from pydantic import BaseModel
@@ -16,6 +15,11 @@ from pymatgen.analysis.structure_matcher import (
 from pymatgen.core.structure import Structure, Molecule
 
 from emmet.core.settings import EmmetSettings
+
+try:
+    import bson
+except ImportError:
+    bson = None  # type: ignore
 
 SETTINGS = EmmetSettings()
 
@@ -165,6 +169,7 @@ def jsanitize(obj, strict=False, allow_bson=False):
         or (bson is not None and isinstance(obj, bson.objectid.ObjectId))
     ):
         return obj
+
     if isinstance(obj, (list, tuple, set)):
         return [jsanitize(i, strict=strict, allow_bson=allow_bson) for i in obj]
     if np is not None and isinstance(obj, np.ndarray):

--- a/emmet-core/setup.py
+++ b/emmet-core/setup.py
@@ -32,13 +32,14 @@ setup(
         "pydantic==1.10.1",
         "pybtex~=0.24",
         "typing-extensions>=3.7,<5.0",
-        "spglib<3.0.0",
+        "spglib<2.0.0",
     ],
     extras_require={
         "all": [
             "robocrys>=0.2.7",
             "pymatgen-analysis-diffusion>=2022.1.15",
             "pymatgen-analysis-alloys>=0.0.3",
+            "bson",
         ],
     },
     python_requires=">=3.8",

--- a/emmet-core/setup.py
+++ b/emmet-core/setup.py
@@ -39,7 +39,6 @@ setup(
             "robocrys>=0.2.7",
             "pymatgen-analysis-diffusion>=2022.1.15",
             "pymatgen-analysis-alloys>=0.0.3",
-            "bson",
         ],
     },
     python_requires=">=3.8",


### PR DESCRIPTION
`bson` package made optional to allow for `jsanitize` util to be used with API client. 