### PR TITLE
Fix pip install with `--no-binary`

### DIFF
--- a/emmet-api/setup.py
+++ b/emmet-api/setup.py
@@ -8,11 +8,12 @@ if "+" in fallback_version:
 setup(
     name="emmet-api",
     use_scm_version={
-        "root": "..",
+        "root": ".",
         "relative_to": __file__,
-        "write_to": "emmet-api/emmet/api/_version.py",
+        "write_to": "emmet/api/_version.py",
         "write_to_template": '__version__ = "{version}"',
         "fallback_version": fallback_version,
+        "search_parent_directories": True,
     },
     setup_requires=["setuptools_scm"],
     description="Emmet API Library",

--- a/emmet-builders/setup.py
+++ b/emmet-builders/setup.py
@@ -8,11 +8,12 @@ if "+" in fallback_version:
 setup(
     name="emmet-builders",
     use_scm_version={
-        "root": "..",
+        "root": ".",
         "relative_to": __file__,
-        "write_to": "emmet-builders/emmet/builders/_version.py",
+        "write_to": "emmet/builders/_version.py",
         "write_to_template": '__version__ = "{version}"',
         "fallback_version": fallback_version,
+        "search_parent_directories": True,
     },
     setup_requires=["setuptools_scm"],
     description="Builders for the Emmet Library",

--- a/emmet-core/setup.py
+++ b/emmet-core/setup.py
@@ -9,11 +9,12 @@ if "+" in fallback_version:
 setup(
     name="emmet-core",
     use_scm_version={
-        "root": "..",
+        "root": ".",
         "relative_to": __file__,
-        "write_to": "emmet-core/emmet/core/_version.py",
+        "write_to": "emmet/core/_version.py",
         "write_to_template": '__version__ = "{version}"',
         "fallback_version": fallback_version,
+        "search_parent_directories": True,
     },
     setup_requires=["setuptools_scm>=6,<8"],
     description="Core Emmet Library",


### PR DESCRIPTION
Force `get_version()` from `setuptools_scm` to search parent directories for git metadata.

Fixes #564 