### PR TITLE
Disable sort disk use for s3 endpoints

### DIFF
--- a/emmet-api/emmet/api/routes/charge_density/resources.py
+++ b/emmet-api/emmet/api/routes/charge_density/resources.py
@@ -21,6 +21,7 @@ def charge_density_resource(s3_store):
         enable_default_search=True,
         enable_get_by_key=False,
         disable_validation=True,
+        query_disk_use=False,
     )
 
     return resource

--- a/emmet-api/emmet/api/routes/electronic_structure/resources.py
+++ b/emmet-api/emmet/api/routes/electronic_structure/resources.py
@@ -89,6 +89,7 @@ def bs_obj_resource(s3_store):
         enable_get_by_key=False,
         enable_default_search=True,
         sub_path="/bandstructure/object/",
+        query_disk_use=False,
         disable_validation=True,
     )
     return resource
@@ -132,6 +133,7 @@ def dos_obj_resource(s3_store):
         enable_get_by_key=False,
         enable_default_search=True,
         sub_path="/dos/object/",
+        query_disk_use=False,
         disable_validation=True,
     )
     return resource

--- a/emmet-api/emmet/api/routes/thermo/resources.py
+++ b/emmet-api/emmet/api/routes/thermo/resources.py
@@ -31,6 +31,7 @@ def phase_diagram_resource(phase_diagram_store):
         disable_validation=True,
         enable_default_search=False,
         header_processor=GlobalHeaderProcessor(),
+        query_disk_use=False,
     )
 
     return resource


### PR DESCRIPTION
`query_disk_use=False` set for all S3 endpoints to ensure proper data retrieval.