### PR TITLE
Remove upward dep pin of pymatgen and monty

### DIFF
--- a/emmet-core/setup.py
+++ b/emmet-core/setup.py
@@ -14,8 +14,8 @@ setup(
     package_data={"emmet.core.vasp.calc_types": ["*.yaml"], "emmet.core.subtrates": ["*.json"]},
     include_package_data=True,
     install_requires=[
-        "pymatgen>=2021.3,<2023.0",
-        "monty>=2021.3,<2023.0",
+        "pymatgen>=2021.3",
+        "monty>=2021.3",
         "pydantic>=1.10.2",
         "pybtex~=0.24",
         "typing-extensions>=3.7,<5.0",


### PR DESCRIPTION
This PR is to unblock https://github.com/materialsproject/pymatgen/pull/2798 which started failing CI due to `emmet-core`'s pinning `"pymatgen>=2021.3,<2023.0", "monty>=2021.3,<2023.0"`:

```
ERROR: Cannot install emmet-core==0.39.6, mp-api, pymatgen and pymatgen[dev,optional]==2023.1.9 because these package versions have conflicting dependencies.

The conflict is caused by:
    pymatgen[dev,optional] 2023.1.9 depends on pymatgen 2023.1.9 (from /home/runner/work/pymatgen/pymatgen)
    mp-api 0.27.3 depends on pymatgen>=2022.3.7
    emmet-core 0.39.6 depends on pymatgen<2023.0 and >=2021.3
    pymatgen[dev,optional] 2023.1.9 depends on pymatgen 2023.1.9 (from /home/runner/work/pymatgen/pymatgen)
    mp-api 0.27.3 depends on pymatgen>=2022.3.7
    emmet-core 0.39.5 depends on pymatgen<2023.0 and >=2021.3
    pymatgen[dev,optional] 2023.1.9 depends on pymatgen 2023.1.9 (from /home/runner/work/pymatgen/pymatgen)
    mp-api 0.27.3 depends on pymatgen>=2022.3.7
    emmet-core 0.39.4 depends on pymatgen<2023.0 and >=2021.3
    pymatgen[dev,optional] 2023.1.9 depends on pymatgen 2023.1.9 (from /home/runner/work/pymatgen/pymatgen)
```