### PR TITLE
Add max chemsys option to thermo

### DIFF
--- a/emmet-builders/emmet/builders/materials/thermo.py
+++ b/emmet-builders/emmet/builders/materials/thermo.py
@@ -1,9 +1,11 @@
+from math import ceil
 import warnings
 from itertools import chain
 from typing import Dict, Iterator, List, Optional, Set
 
 from maggma.core import Builder, Store
 from maggma.stores import S3Store
+from maggma.utils import grouper
 from monty.json import MontyDecoder
 from pymatgen.analysis.phase_diagram import PhaseDiagramError
 from pymatgen.entries.computed_entries import ComputedStructureEntry
@@ -106,6 +108,15 @@ class ThermoBuilder(Builder):
 
             coll.ensure_index("chemsys")
             coll.ensure_index("phase_diagram_id")
+
+    def prechunk(self, number_splits: int) -> Iterator[Dict]:  # pragma: no cover
+        to_process_chemsys = self._get_chemsys_to_process()
+
+        N = ceil(len(to_process_chemsys) / number_splits)
+
+        for chemsys_chunk in grouper(to_process_chemsys, N):
+
+            yield {"query": {"chemsys": {"$in": list(chemsys_chunk)}}}
 
     def get_items(self) -> Iterator[List[Dict]]:
         """

--- a/emmet-core/emmet/core/thermo.py
+++ b/emmet-core/emmet/core/thermo.py
@@ -107,10 +107,25 @@ class ThermoDoc(PropertyDoc):
         entries: List[Union[ComputedEntry, ComputedStructureEntry]],
         thermo_type: Union[ThermoType, RunType],
         phase_diagram: Optional[PhaseDiagram] = None,
+        use_max_chemsys: bool = False,
         **kwargs
     ):
+        """Produce a list of ThermoDocs from a list of Entry objects
+
+        Args:
+            entries (List[Union[ComputedEntry, ComputedStructureEntry]]): List of Entry objects
+            thermo_type (Union[ThermoType, RunType]): Thermo type
+            phase_diagram (Optional[PhaseDiagram], optional): Already built phase diagram. Defaults to None.
+            use_max_chemsys (bool, optional): Whether to only produce thermo docs for materials
+                that match the largest chemsys represented in the list. Defaults to False.
+
+        Returns:
+            List[ThermoDoc]: List of built thermo doc objects.
+        """
 
         pd = phase_diagram or cls.construct_phase_diagram(entries)
+
+        chemsys = "-".join(sorted([str(e) for e in pd.elements]))
 
         docs = []
 
@@ -135,6 +150,9 @@ class ThermoDoc(PropertyDoc):
             )
 
         for material_id, entry_group in entries_by_mpid.items():
+
+            if use_max_chemsys and entry_group[0].composition.chemical_system != chemsys:
+                continue
 
             sorted_entries = sorted(entry_group, key=_energy_eval)
 


### PR DESCRIPTION
Add option to only produce ThermoDoc objects for materials which match the largest chemical system in the list of entries provided. This allows for the thermo builder to be order agnostic with respect to the chemical system order. In turn, it can be distributed more efficiently.