### PR TITLE
Limit corrected entries and thermo

### DIFF
--- a/emmet-builders/emmet/builders/materials/corrected_entries.py
+++ b/emmet-builders/emmet/builders/materials/corrected_entries.py
@@ -140,25 +140,30 @@ class CorrectedEntriesBuilder(Builder):
         corrected_entries = {}
 
         for compatability in self.compatibility:
-
             if compatability is not None:
-                if compatability.name == "MP DFT mixing scheme":
-                    thermo_type = ThermoType.GGA_GGA_U_R2SCAN
-                elif compatability.name == "MP2020":
-                    thermo_type = ThermoType.GGA_GGA_U
-                else:
-                    thermo_type = ThermoType.UNKNOWN
 
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore")
                     with HiddenPrints():
-                        if thermo_type == ThermoType.GGA_GGA_U_R2SCAN:
-                            only_scan_pd_entries = [e for e in entries if str(e.data["run_type"]) == "R2SCAN"]
-                            corrected_entries["R2SCAN"] = only_scan_pd_entries
+                        if compatability.name == "MP DFT mixing scheme":
+                            thermo_type = ThermoType.GGA_GGA_U_R2SCAN
 
+                            if "R2SCAN" in all_entry_types:
+
+                                only_scan_pd_entries = [e for e in entries if str(e.data["run_type"]) == "R2SCAN"]
+                                corrected_entries["R2SCAN"] = only_scan_pd_entries
+
+                                pd_entries = compatability.process_entries(copy.deepcopy(entries))
+
+                            else:
+                                corrected_entries["R2SCAN"] = None
+                                pd_entries = None
+
+                        elif compatability.name == "MP2020":
+                            thermo_type = ThermoType.GGA_GGA_U
                             pd_entries = compatability.process_entries(copy.deepcopy(entries))
-
                         else:
+                            thermo_type = ThermoType.UNKNOWN
                             pd_entries = compatability.process_entries(copy.deepcopy(entries))
 
                         corrected_entries[str(thermo_type)] = pd_entries

--- a/emmet-builders/emmet/builders/materials/thermo.py
+++ b/emmet-builders/emmet/builders/materials/thermo.py
@@ -148,17 +148,20 @@ class ThermoBuilder(Builder):
 
         for thermo_type, entry_list in item["entries"].items():
 
-            entries = [ComputedStructureEntry.from_dict(entry) for entry in entry_list]
-            chemsys = item["chemsys"]
-            elements = chemsys.split("-")
+            if entry_list is None:
+                pd_thermo_doc_pair_list.append((None, None))
+            else:
+                entries = [ComputedStructureEntry.from_dict(entry) for entry in entry_list]
+                chemsys = item["chemsys"]
+                elements = chemsys.split("-")
 
-            self.logger.debug(f"Processing {len(entries)} entries for {chemsys} and thermo type {thermo_type}")
+                self.logger.debug(f"Processing {len(entries)} entries for {chemsys} and thermo type {thermo_type}")
 
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                with HiddenPrints():
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    with HiddenPrints():
 
-                    pd_thermo_doc_pair_list.append(self._produce_pair(entries, thermo_type, elements))
+                        pd_thermo_doc_pair_list.append(self._produce_pair(entries, thermo_type, elements))
 
         return pd_thermo_doc_pair_list
 

--- a/emmet-builders/emmet/builders/materials/thermo.py
+++ b/emmet-builders/emmet/builders/materials/thermo.py
@@ -148,9 +148,7 @@ class ThermoBuilder(Builder):
 
         for thermo_type, entry_list in item["entries"].items():
 
-            if entry_list is None:
-                pd_thermo_doc_pair_list.append((None, None))
-            else:
+            if entry_list:
                 entries = [ComputedStructureEntry.from_dict(entry) for entry in entry_list]
                 chemsys = item["chemsys"]
                 elements = chemsys.split("-")

--- a/emmet-core/emmet/core/corrected_entries.py
+++ b/emmet-core/emmet/core/corrected_entries.py
@@ -1,6 +1,6 @@
 """ Core definition of a CorrectedEntriesDoc Document """
 
-from typing import Dict, Union, List
+from typing import Dict, Union, List, Optional
 from datetime import datetime
 
 from pydantic import Field
@@ -22,7 +22,7 @@ class CorrectedEntriesDoc(EmmetBaseModel):
         ..., title="Chemical System", description="Dash-delimited string of elements in the material.",
     )
 
-    entries: Dict[Union[ThermoType, RunType], List[Union[ComputedEntry, ComputedStructureEntry]]] = Field(
+    entries: Dict[Union[ThermoType, RunType], Optional[List[Union[ComputedEntry, ComputedStructureEntry]]]] = Field(
         ..., description="List of all corrected entries that are valid for the specified thermo type."
     )
 


### PR DESCRIPTION
Limit corrected entries to only build R2SCAN data if at least one R2SCAN calculation is present in the entry list.