### PR TITLE
Use calcs_reversed data when available for params

### DIFF
--- a/emmet-core/emmet/core/vasp/task_valid.py
+++ b/emmet-core/emmet/core/vasp/task_valid.py
@@ -139,10 +139,15 @@ class TaskDocument(BaseTaskDocument, StructureMetadata):
 
     @property
     def calc_type(self):
+        inputs = (
+            self.calcs_reversed[0].get("input", {})
+            if len(self.calcs_reversed) > 0
+            else self.orig_inputs
+        )
         params = self.calcs_reversed[0].get("input", {}).get("parameters", {})
         incar = self.calcs_reversed[0].get("input", {}).get("incar", {})
 
-        return calc_type(self.orig_inputs, {**params, **incar})
+        return calc_type(inputs, {**params, **incar})
 
     @property
     def entry(self) -> ComputedEntry:


### PR DESCRIPTION
This PR forces task validation to use parameters from `calcs_reversed` as much as possible. This accommodates schema differences in `orig_inputs` as it is not always populated with the same data when being parsed with `VaspDrone`. This appears to affect only output directories that contain a large number of chained VASP calculations.