### PR TITLE
Update `MoleculeMetadata` to have additional fields

### DIFF
--- a/emmet-core/emmet/core/structure.py
+++ b/emmet-core/emmet/core/structure.py
@@ -196,6 +196,57 @@ class MoleculeMetadata(EmmetBaseModel):
     )
 
     @classmethod
+    def from_composition(
+        cls: Type[T],
+        comp: Composition,
+        fields: Optional[List[str]] = None,
+        **kwargs,
+    ) -> S:
+        """
+        Create a MoleculeMetadata model from a composition.
+
+        Parameters
+        ----------
+        comp : .Composition
+            A pymatgen composition.
+        fields : list of str or None
+            Composition fields to include.
+        **kwargs
+            Keyword arguments that are passed to the model constructor.
+
+        Returns
+        -------
+        T
+            A molecule metadata model.
+        """
+        fields = (
+            [
+                "elements",
+                "nelements",
+                "composition",
+                "composition_reduced",
+                "formula_alphabetical",
+                "formula_anonymous",
+                "chemsys",
+            ]
+            if fields is None
+            else fields
+        )
+        elsyms = sorted({e.symbol for e in comp.elements})
+
+        data = {
+            "elements": elsyms,
+            "nelements": len(elsyms),
+            "composition": comp,
+            "composition_reduced": comp.reduced_composition,
+            "formula_alphabetical": comp.alphabetical_formula,
+            "formula_anonymous": comp.anonymized_formula,
+            "chemsys": "-".join(elsyms),
+        }
+
+        return cls(**{k: v for k, v in data.items() if k in fields}, **kwargs)
+
+    @classmethod
     def from_molecule(
         cls: Type[S],
         meta_molecule: Molecule,

--- a/emmet-core/emmet/core/structure.py
+++ b/emmet-core/emmet/core/structure.py
@@ -1,4 +1,4 @@
-""" Core definition of Structure metadata """
+""" Core definition of Structure and Molecule metadata """
 from __future__ import annotations
 
 from typing import List, Optional, Type, TypeVar
@@ -22,9 +22,13 @@ class StructureMetadata(EmmetBaseModel):
 
     # Structure metadata
     nsites: int = Field(None, description="Total number of sites in the structure.")
-    elements: List[Element] = Field(None, description="List of elements in the material.")
+    elements: List[Element] = Field(
+        None, description="List of elements in the material."
+    )
     nelements: int = Field(None, description="Number of elements.")
-    composition: Composition = Field(None, description="Full composition for the material.")
+    composition: Composition = Field(
+        None, description="Full composition for the material."
+    )
     composition_reduced: Composition = Field(
         None,
         title="Reduced Composition",
@@ -51,7 +55,9 @@ class StructureMetadata(EmmetBaseModel):
         description="Total volume for this structure in Angstroms^3.",
     )
 
-    density: float = Field(None, title="Density", description="Density in grams per cm^3.")
+    density: float = Field(
+        None, title="Density", description="Density in grams per cm^3."
+    )
 
     density_atomic: float = Field(
         None,
@@ -68,7 +74,6 @@ class StructureMetadata(EmmetBaseModel):
         fields: Optional[List[str]] = None,
         **kwargs,
     ) -> T:
-
         fields = (
             [
                 "elements",
@@ -105,7 +110,6 @@ class StructureMetadata(EmmetBaseModel):
         fields: Optional[List[str]] = None,
         **kwargs,
     ) -> T:
-
         fields = (
             [
                 "nsites",
@@ -155,21 +159,41 @@ class MoleculeMetadata(EmmetBaseModel):
         None, description="Spin multiplicity of the molecule"
     )
     natoms: int = Field(None, description="Total number of atoms in the molecule")
-    elements: List[Element] = Field(None, description="List of elements in the molecule")
+    elements: List[Element] = Field(
+        None, description="List of elements in the molecule"
+    )
     nelements: int = Field(None, title="Number of Elements")
-    composition: Composition = Field(None, description="Full composition for the molecule")
+    nelectrons: int = Field(
+        None,
+        title="Number of electrons",
+        description="The total number of electrons for the molecule",
+    )
+    composition: Composition = Field(
+        None, description="Full composition for the molecule"
+    )
+    composition_reduced: Composition = Field(
+        None,
+        title="Reduced Composition",
+        description="Simplified representation of the composition",
+    )
     formula_alphabetical: str = Field(
         None,
         title="Alphabetical Formula",
         description="Alphabetical molecular formula",
+    )
+    formula_anonymous: str = Field(
+        None,
+        title="Anonymous Formula",
+        description="Anonymized representation of the formula",
     )
     chemsys: str = Field(
         None,
         title="Chemical System",
         description="dash-delimited string of elements in the molecule",
     )
-
-    symmetry: PointGroupData = Field(None, description="Symmetry data for this molecule")
+    symmetry: PointGroupData = Field(
+        None, description="Symmetry data for this molecule"
+    )
 
     @classmethod
     def from_molecule(
@@ -178,7 +202,6 @@ class MoleculeMetadata(EmmetBaseModel):
         fields: Optional[List[str]] = None,
         **kwargs,
     ) -> S:
-
         fields = (
             [
                 "charge",
@@ -186,8 +209,11 @@ class MoleculeMetadata(EmmetBaseModel):
                 "natoms",
                 "elements",
                 "nelements",
+                "nelectrons",
                 "composition",
+                "composition_reduced",
                 "formula_alphabetical",
+                "formula_anonymous",
                 "chemsys",
                 "symmetry",
             ]
@@ -204,8 +230,11 @@ class MoleculeMetadata(EmmetBaseModel):
             "natoms": len(meta_molecule),
             "elements": elsyms,
             "nelements": len(elsyms),
+            "nelectrons": int(meta_molecule.nelectrons),
             "composition": comp,
+            "composition_reduced": comp.reduced_composition,
             "formula_alphabetical": comp.alphabetical_formula,
+            "formula_anonymous": comp.anonymized_formula,
             "chemsys": "-".join(elsyms),
             "symmetry": symmetry,
         }

--- a/emmet-core/emmet/core/structure.py
+++ b/emmet-core/emmet/core/structure.py
@@ -181,6 +181,11 @@ class MoleculeMetadata(EmmetBaseModel):
         title="Alphabetical Formula",
         description="Alphabetical molecular formula",
     )
+    formula_pretty: str = Field(
+        None,
+        title="Pretty Formula",
+        description="Cleaned representation of the formula.",
+    )
     formula_anonymous: str = Field(
         None,
         title="Anonymous Formula",
@@ -226,6 +231,7 @@ class MoleculeMetadata(EmmetBaseModel):
                 "composition",
                 "composition_reduced",
                 "formula_alphabetical",
+                "formula_pretty",
                 "formula_anonymous",
                 "chemsys",
             ]
@@ -240,6 +246,7 @@ class MoleculeMetadata(EmmetBaseModel):
             "composition": comp,
             "composition_reduced": comp.reduced_composition,
             "formula_alphabetical": comp.alphabetical_formula,
+            "formula_pretty": comp.reduced_formula,
             "formula_anonymous": comp.anonymized_formula,
             "chemsys": "-".join(elsyms),
         }
@@ -264,6 +271,7 @@ class MoleculeMetadata(EmmetBaseModel):
                 "composition",
                 "composition_reduced",
                 "formula_alphabetical",
+                "formula_pretty",
                 "formula_anonymous",
                 "chemsys",
                 "symmetry",
@@ -285,6 +293,7 @@ class MoleculeMetadata(EmmetBaseModel):
             "composition": comp,
             "composition_reduced": comp.reduced_composition,
             "formula_alphabetical": comp.alphabetical_formula,
+            "formula_pretty": comp.reduced_formula,
             "formula_anonymous": comp.anonymized_formula,
             "chemsys": "-".join(elsyms),
             "symmetry": symmetry,

--- a/emmet-core/emmet/core/structure.py
+++ b/emmet-core/emmet/core/structure.py
@@ -197,7 +197,7 @@ class MoleculeMetadata(EmmetBaseModel):
 
     @classmethod
     def from_composition(
-        cls: Type[T],
+        cls: Type[S],
         comp: Composition,
         fields: Optional[List[str]] = None,
         **kwargs,

--- a/emmet-core/tests/test_moleculemetadata.py
+++ b/emmet-core/tests/test_moleculemetadata.py
@@ -2,7 +2,7 @@ from pymatgen.core import Molecule
 from pymatgen.core.composition import Composition
 from pymatgen.core.periodic_table import Element
 
-from atomate2.common.schemas.molecule import MoleculeMetadata
+from emmet.core.structure import MoleculeMetadata
 
 molecule = Molecule(
     species=["Mg", "O"],
@@ -17,7 +17,7 @@ def test_from_molecule(test_dir):
     assert metadata["nelements"] == 2
     assert metadata["composition"] == Composition("MgO")
     assert metadata["composition_reduced"] == Composition("MgO").reduced_composition
-    assert metadata["formula_pretty"] == "MgO"
+    assert metadata["formula_alphabetical"] == "MgO"
     assert metadata["formula_anonymous"] == "AB"
     assert metadata["chemsys"] == "Mg-O"
     assert metadata["point_group"] == "C*v"

--- a/emmet-core/tests/test_moleculemetadata.py
+++ b/emmet-core/tests/test_moleculemetadata.py
@@ -1,0 +1,37 @@
+from pymatgen.core import Molecule
+from pymatgen.core.composition import Composition
+from pymatgen.core.periodic_table import Element
+
+from atomate2.common.schemas.molecule import MoleculeMetadata
+
+molecule = Molecule(
+    species=["Mg", "O"],
+    coords=[[0, 0, 0], [0.5, 0.5, 0.5]],
+)
+
+
+def test_from_molecule(test_dir):
+    metadata = MoleculeMetadata.from_molecule(molecule).dict()
+    assert metadata["natoms"] == 2
+    assert metadata["elements"] == [Element("Mg"), Element("O")]
+    assert metadata["nelements"] == 2
+    assert metadata["composition"] == Composition("MgO")
+    assert metadata["composition_reduced"] == Composition("MgO").reduced_composition
+    assert metadata["formula_pretty"] == "MgO"
+    assert metadata["formula_anonymous"] == "AB"
+    assert metadata["chemsys"] == "Mg-O"
+    assert metadata["point_group"] == "C*v"
+    assert metadata["charge"] == 0
+    assert metadata["spin_multiplicity"] == 1
+    assert metadata["nelectrons"] == 20
+
+
+def test_from_comp(test_dir):
+    metadata = MoleculeMetadata.from_composition(molecule.composition).dict()
+    assert metadata["elements"] == [Element("Mg"), Element("O")]
+    assert metadata["nelements"] == 2
+    assert metadata["composition"] == Composition("MgO")
+    assert metadata["composition_reduced"] == Composition("MgO").reduced_composition
+    assert metadata["formula_pretty"] == "MgO"
+    assert metadata["formula_anonymous"] == "AB"
+    assert metadata["chemsys"] == "Mg-O"

--- a/emmet-core/tests/test_moleculemetadata.py
+++ b/emmet-core/tests/test_moleculemetadata.py
@@ -10,7 +10,7 @@ molecule = Molecule(
 )
 
 
-def test_from_molecule(test_dir):
+def test_from_molecule():
     metadata = MoleculeMetadata.from_molecule(molecule).dict()
     assert metadata["natoms"] == 2
     assert metadata["elements"] == [Element("Mg"), Element("O")]
@@ -26,7 +26,7 @@ def test_from_molecule(test_dir):
     assert metadata["nelectrons"] == 20
 
 
-def test_from_comp(test_dir):
+def test_from_comp():
     metadata = MoleculeMetadata.from_composition(molecule.composition).dict()
     assert metadata["elements"] == [Element("Mg"), Element("O")]
     assert metadata["nelements"] == 2

--- a/emmet-core/tests/test_moleculemetadata.py
+++ b/emmet-core/tests/test_moleculemetadata.py
@@ -17,9 +17,9 @@ def test_from_molecule():
     assert metadata["nelements"] == 2
     assert metadata["composition"] == Composition("MgO")
     assert metadata["composition_reduced"] == Composition("MgO").reduced_composition
-    assert metadata["formula_alphabetical"] == Composition("MgO").alphabetical_formula
-    assert metadata["formula_anonymous"] == Composition("MgO").anonymized_formula
-    assert metadata["chemsys"] == Composition("MgO").chemsys
+    assert metadata["formula_alphabetical"] == "MgO"
+    assert metadata["formula_anonymous"] == "AB"
+    assert metadata["chemsys"] == "Mg-O"
     assert metadata["point_group"] == "C*v"
     assert metadata["charge"] == 0
     assert metadata["spin_multiplicity"] == 1
@@ -32,6 +32,6 @@ def test_from_comp():
     assert metadata["nelements"] == 2
     assert metadata["composition"] == Composition("MgO")
     assert metadata["composition_reduced"] == Composition("MgO").reduced_composition
-    assert metadata["formula_alphabetical"] == Composition("MgO").alphabetical_formula
-    assert metadata["formula_anonymous"] == Composition("MgO").anonymized_formula
-    assert metadata["chemsys"] == Composition("MgO").chemsys
+    assert metadata["formula_alphabetical"] == "MgO"
+    assert metadata["formula_anonymous"] == "AB"
+    assert metadata["chemsys"] == "Mg-O"

--- a/emmet-core/tests/test_moleculemetadata.py
+++ b/emmet-core/tests/test_moleculemetadata.py
@@ -1,37 +1,43 @@
+import pytest
 from pymatgen.core import Molecule
 from pymatgen.core.composition import Composition
 from pymatgen.core.periodic_table import Element
 
 from emmet.core.structure import MoleculeMetadata
 
-molecule = Molecule(
-    species=["Mg", "O"],
-    coords=[[0, 0, 0], [0.5, 0.5, 0.5]],
-)
+
+@pytest.fixture
+def molecule():
+    test_mol = Molecule(
+        species=["Mg", "O"],
+        coords=[[0, 0, 0], [0.5, 0.5, 0.5]],
+    )
+    return test_mol
 
 
-def test_from_molecule():
-    metadata = MoleculeMetadata.from_molecule(molecule).dict()
-    assert metadata["natoms"] == 2
-    assert metadata["elements"] == [Element("Mg"), Element("O")]
-    assert metadata["nelements"] == 2
-    assert metadata["composition"] == Composition("MgO")
-    assert metadata["composition_reduced"] == Composition("MgO").reduced_composition
-    assert metadata["formula_alphabetical"] == "MgO"
-    assert metadata["formula_anonymous"] == "AB"
-    assert metadata["chemsys"] == "Mg-O"
-    assert metadata["point_group"] == "C*v"
-    assert metadata["charge"] == 0
-    assert metadata["spin_multiplicity"] == 1
-    assert metadata["nelectrons"] == 20
+def test_from_molecule(molecule):
+    metadata = MoleculeMetadata.from_molecule(molecule)
+    assert metadata.natoms == 2
+    assert metadata.elements == [Element("Mg"), Element("O")]
+    assert metadata.nelements == 2
+    assert metadata.composition == Composition("MgO")
+    assert metadata.composition_reduced == Composition("MgO").reduced_composition
+    assert metadata.formula_alphabetical == "Mg1 O1"
+    assert metadata.formula_pretty == "MgO"
+    assert metadata.formula_anonymous == "AB"
+    assert metadata.chemsys == "Mg-O"
+    assert metadata.symmetry.point_group == "C*v"
+    assert metadata.charge == 0
+    assert metadata.spin_multiplicity == 1
+    assert metadata.nelectrons == 20
 
 
-def test_from_comp():
-    metadata = MoleculeMetadata.from_composition(molecule.composition).dict()
-    assert metadata["elements"] == [Element("Mg"), Element("O")]
-    assert metadata["nelements"] == 2
-    assert metadata["composition"] == Composition("MgO")
-    assert metadata["composition_reduced"] == Composition("MgO").reduced_composition
-    assert metadata["formula_alphabetical"] == "MgO"
-    assert metadata["formula_anonymous"] == "AB"
-    assert metadata["chemsys"] == "Mg-O"
+def test_from_comp(molecule):
+    metadata = MoleculeMetadata.from_composition(molecule.composition)
+    assert metadata.elements == [Element("Mg"), Element("O")]
+    assert metadata.nelements == 2
+    assert metadata.composition == Composition("MgO")
+    assert metadata.composition_reduced == Composition("MgO").reduced_composition
+    assert metadata.formula_pretty == "MgO"
+    assert metadata.formula_anonymous == "AB"
+    assert metadata.chemsys == "Mg-O"

--- a/emmet-core/tests/test_moleculemetadata.py
+++ b/emmet-core/tests/test_moleculemetadata.py
@@ -17,9 +17,9 @@ def test_from_molecule():
     assert metadata["nelements"] == 2
     assert metadata["composition"] == Composition("MgO")
     assert metadata["composition_reduced"] == Composition("MgO").reduced_composition
-    assert metadata["formula_alphabetical"] == "MgO"
-    assert metadata["formula_anonymous"] == "AB"
-    assert metadata["chemsys"] == "Mg-O"
+    assert metadata["formula_alphabetical"] == Composition("MgO").alphabetical_formula
+    assert metadata["formula_anonymous"] == Composition("MgO").anonymized_formula
+    assert metadata["chemsys"] == Composition("MgO").chemsys
     assert metadata["point_group"] == "C*v"
     assert metadata["charge"] == 0
     assert metadata["spin_multiplicity"] == 1
@@ -32,6 +32,6 @@ def test_from_comp():
     assert metadata["nelements"] == 2
     assert metadata["composition"] == Composition("MgO")
     assert metadata["composition_reduced"] == Composition("MgO").reduced_composition
-    assert metadata["formula_pretty"] == "MgO"
-    assert metadata["formula_anonymous"] == "AB"
-    assert metadata["chemsys"] == "Mg-O"
+    assert metadata["formula_alphabetical"] == Composition("MgO").alphabetical_formula
+    assert metadata["formula_anonymous"] == Composition("MgO").anonymized_formula
+    assert metadata["chemsys"] == Composition("MgO").chemsys


### PR DESCRIPTION
This is an attempt to merge the `MoleculeMetadata` from Atomate2 and that in emmet. They are basically the same thing, except the one in Atomate2 has a few additional fields.

@espottesmith --- are you open to this update? I have not touched any of your existing fields; I have only added some new ones. These include `nelectrons`, `composition_reduced`, `formula_pretty`, `formula_anonymous` and a new `from_composition()` method. Sorry about the formatting change. I have `black` running by default.