### PR TITLE
Fix molecules and materials route nesting

### DIFF
--- a/emmet-api/emmet/api/routes/materials/electrodes/resources.py
+++ b/emmet-api/emmet/api/routes/materials/electrodes/resources.py
@@ -10,7 +10,7 @@ from emmet.api.routes.materials.electrodes.query_operators import (
     ElectrodesChemsysQuery,
     WorkingIonQuery,
     ElectrodeMultiMaterialIDQuery,
-    MultiBatteryIDQuery
+    MultiBatteryIDQuery,
 )
 
 from emmet.api.core.settings import MAPISettings
@@ -31,14 +31,15 @@ def insertion_electrodes_resource(insertion_electrodes_store):
             SortQuery(),
             PaginationQuery(),
             SparseFieldsQuery(
-                InsertionElectrodeDoc, default_fields=["battery_id", "last_updated"],
+                InsertionElectrodeDoc,
+                default_fields=["battery_id", "last_updated"],
             ),
         ],
         header_processor=GlobalHeaderProcessor(),
-        tags=["Electrodes"],
+        tags=["Materials Electrodes"],
         sub_path="/insertion_electrodes/",
         disable_validation=True,
-        timeout=MAPISettings().TIMEOUT
+        timeout=MAPISettings().TIMEOUT,
     )
 
     return resource

--- a/emmet-api/emmet/api/routes/materials/materials/resources.py
+++ b/emmet-api/emmet/api/routes/materials/materials/resources.py
@@ -39,7 +39,7 @@ def find_structure_resource(materials_store):
         key_fields=["structure", "task_id"],
         query_operators=[FindStructureQuery()],
         tags=["Materials"],
-        sub_path="/find_structure/",
+        sub_path="/core/find_structure/",
         timeout=timeout,
     )
 
@@ -52,7 +52,7 @@ def formula_autocomplete_resource(formula_autocomplete_store):
         FormulaAutocomplete,
         pipeline_query_operator=FormulaAutoCompleteQuery(),
         tags=["Materials"],
-        sub_path="/formula_autocomplete/",
+        sub_path="/core/formula_autocomplete/",
         header_processor=GlobalHeaderProcessor(),
         timeout=timeout,
     )
@@ -83,6 +83,7 @@ def materials_resource(materials_store):
         header_processor=GlobalHeaderProcessor(),
         hint_scheme=MaterialsHintScheme(),
         tags=["Materials"],
+        sub_path="/core/",
         disable_validation=True,
         timeout=MAPISettings().TIMEOUT,
     )

--- a/emmet-api/emmet/api/routes/materials/materials/resources.py
+++ b/emmet-api/emmet/api/routes/materials/materials/resources.py
@@ -39,7 +39,7 @@ def find_structure_resource(materials_store):
         key_fields=["structure", "task_id"],
         query_operators=[FindStructureQuery()],
         tags=["Materials"],
-        sub_path="/materials/find_structure/",
+        sub_path="/find_structure/",
         timeout=timeout,
     )
 
@@ -52,7 +52,7 @@ def formula_autocomplete_resource(formula_autocomplete_store):
         FormulaAutocomplete,
         pipeline_query_operator=FormulaAutoCompleteQuery(),
         tags=["Materials"],
-        sub_path="/materials/formula_autocomplete/",
+        sub_path="/formula_autocomplete/",
         header_processor=GlobalHeaderProcessor(),
         timeout=timeout,
     )
@@ -61,7 +61,6 @@ def formula_autocomplete_resource(formula_autocomplete_store):
 
 
 def materials_resource(materials_store):
-
     resource = ReadOnlyResource(
         materials_store,
         MaterialsDoc,
@@ -76,12 +75,14 @@ def materials_resource(materials_store):
             NumericQuery(model=MaterialsDoc),
             SortQuery(),
             PaginationQuery(),
-            SparseFieldsQuery(MaterialsDoc, default_fields=["material_id", "formula_pretty", "last_updated"],),
+            SparseFieldsQuery(
+                MaterialsDoc,
+                default_fields=["material_id", "formula_pretty", "last_updated"],
+            ),
         ],
         header_processor=GlobalHeaderProcessor(),
         hint_scheme=MaterialsHintScheme(),
         tags=["Materials"],
-        sub_path="/materials/",
         disable_validation=True,
         timeout=MAPISettings().TIMEOUT,
     )

--- a/emmet-api/emmet/api/routes/materials/robocrys/resources.py
+++ b/emmet-api/emmet/api/routes/materials/robocrys/resources.py
@@ -23,7 +23,7 @@ def robo_resource(robo_store):
             ),
         ],
         header_processor=GlobalHeaderProcessor(),
-        tags=["Robocrystallographer"],
+        tags=["Materials Robocrystallographer"],
         sub_path="/robocrys/",
         disable_validation=True,
         timeout=timeout,

--- a/emmet-api/emmet/api/routes/molecules/molecules/resources.py
+++ b/emmet-api/emmet/api/routes/molecules/molecules/resources.py
@@ -38,7 +38,7 @@ def find_molecule_resource(molecules_store):
         key_fields=["molecule", "molecule_id"],
         query_operators=[FindMoleculeQuery()],
         tags=["Core Molecules"],
-        sub_path="/molecules/find_molecule/",
+        sub_path="/core/find_molecule/",
         timeout=timeout,
     )
 
@@ -69,7 +69,7 @@ def molecules_resource(molecules_store):
         ],
         header_processor=GlobalHeaderProcessor(),
         tags=["Core Molecules"],
-        sub_path="/molecules/",
+        sub_path="/core/",
         disable_validation=True,
         hint_scheme=MoleculesHintScheme(),
         timeout=MAPISettings().TIMEOUT,

--- a/emmet-api/emmet/api/routes/molecules/molecules/resources.py
+++ b/emmet-api/emmet/api/routes/molecules/molecules/resources.py
@@ -22,7 +22,7 @@ from emmet.api.routes.molecules.molecules.query_operators import (
     MultiMPculeIDQuery,
     FindMoleculeQuery,
     CalcMethodQuery,
-    HashQuery
+    HashQuery,
 )
 
 from emmet.api.core.global_header import GlobalHeaderProcessor
@@ -62,7 +62,10 @@ def molecules_resource(molecules_store):
             NumericQuery(model=MoleculeDoc),
             SortQuery(),
             PaginationQuery(),
-            SparseFieldsQuery(MoleculeDoc, default_fields=["molecule_id", "formula_alphabetical", "last_updated"],),
+            SparseFieldsQuery(
+                MoleculeDoc,
+                default_fields=["molecule_id", "formula_alphabetical", "last_updated"],
+            ),
         ],
         header_processor=GlobalHeaderProcessor(),
         tags=["Core Molecules"],

--- a/emmet-api/material_resources.py
+++ b/emmet-api/material_resources.py
@@ -13,36 +13,62 @@ db_version = default_settings.DB_VERSION
 db_suffix = os.environ["MAPI_DB_NAME_SUFFIX"]
 
 if db_uri:
-
     # allow db_uri to be set with a different protocol scheme
     # but prepend with mongodb+srv:// if not otherwise specified
     if len(db_uri.split("://", 1)) < 2:
         db_uri = "mongodb+srv://" + db_uri
 
     materials_store = MongoURIStore(
-        uri=db_uri, database=f"mp_core_{db_suffix}", key="material_id", collection_name="materials"
+        uri=db_uri,
+        database=f"mp_core_{db_suffix}",
+        key="material_id",
+        collection_name="materials",
     )
 
     absorption_store = MongoURIStore(
-        uri=db_uri, database=f"mp_core_{db_suffix}", key="material_id", collection_name="absorption"
+        uri=db_uri,
+        database=f"mp_core_{db_suffix}",
+        key="material_id",
+        collection_name="absorption",
     )
 
-    bonds_store = MongoURIStore(uri=db_uri, database=f"mp_core_{db_suffix}", key="material_id", collection_name="bonds")
+    bonds_store = MongoURIStore(
+        uri=db_uri,
+        database=f"mp_core_{db_suffix}",
+        key="material_id",
+        collection_name="bonds",
+    )
 
     chemenv_store = MongoURIStore(
-        uri=db_uri, database=f"mp_core_{db_suffix}", key="material_id", collection_name="chemenv"
+        uri=db_uri,
+        database=f"mp_core_{db_suffix}",
+        key="material_id",
+        collection_name="chemenv",
     )
 
     formula_autocomplete_store = MongoURIStore(
-        uri=db_uri, database="mp_core", key="_id", collection_name="formula_autocomplete"
+        uri=db_uri,
+        database="mp_core",
+        key="_id",
+        collection_name="formula_autocomplete",
     )
 
-    task_store = MongoURIStore(uri=db_uri, database="mp_core", key="task_id", collection_name="tasks")
+    task_store = MongoURIStore(
+        uri=db_uri, database="mp_core", key="task_id", collection_name="tasks"
+    )
 
-    thermo_store = MongoURIStore(uri=db_uri, database=f"mp_core_{db_suffix}", key="thermo_id", collection_name="thermo")
+    thermo_store = MongoURIStore(
+        uri=db_uri,
+        database=f"mp_core_{db_suffix}",
+        key="thermo_id",
+        collection_name="thermo",
+    )
 
     s3_phase_diagram_index = MongoURIStore(
-        uri=db_uri, database="mp_core", key="phase_diagram_id", collection_name="s3_phase_diagram_index"
+        uri=db_uri,
+        database="mp_core",
+        key="phase_diagram_id",
+        collection_name="s3_phase_diagram_index",
     )
 
     phase_diagram_store = S3Store(
@@ -55,72 +81,135 @@ if db_uri:
     )
 
     dielectric_store = MongoURIStore(
-        uri=db_uri, database=f"mp_core_{db_suffix}", key="material_id", collection_name="dielectric"
+        uri=db_uri,
+        database=f"mp_core_{db_suffix}",
+        key="material_id",
+        collection_name="dielectric",
     )
 
     piezoelectric_store = MongoURIStore(
-        uri=db_uri, database=f"mp_core_{db_suffix}", key="material_id", collection_name="piezoelectric"
+        uri=db_uri,
+        database=f"mp_core_{db_suffix}",
+        key="material_id",
+        collection_name="piezoelectric",
     )
 
     magnetism_store = MongoURIStore(
-        uri=db_uri, database=f"mp_core_{db_suffix}", key="material_id", collection_name="magnetism"
+        uri=db_uri,
+        database=f"mp_core_{db_suffix}",
+        key="material_id",
+        collection_name="magnetism",
     )
 
-    phonon_bs_store = MongoURIStore(uri=db_uri, database="mp_core", key="material_id", collection_name="pmg_ph_bs")
+    phonon_bs_store = MongoURIStore(
+        uri=db_uri, database="mp_core", key="material_id", collection_name="pmg_ph_bs"
+    )
 
-    eos_store = MongoURIStore(uri=db_uri, database="mp_core", key="task_id", collection_name="eos")
+    eos_store = MongoURIStore(
+        uri=db_uri, database="mp_core", key="task_id", collection_name="eos"
+    )
 
-    similarity_store = MongoURIStore(uri=db_uri, database="mp_core", key="material_id", collection_name="similarity")
+    similarity_store = MongoURIStore(
+        uri=db_uri, database="mp_core", key="material_id", collection_name="similarity"
+    )
 
-    xas_store = MongoURIStore(uri=db_uri, database="mp_core", key="spectrum_id", collection_name="xas")
+    xas_store = MongoURIStore(
+        uri=db_uri, database="mp_core", key="spectrum_id", collection_name="xas"
+    )
 
-    gb_store = MongoURIStore(uri=db_uri, database="mp_core", key="task_id", collection_name="grain_boundaries")
+    gb_store = MongoURIStore(
+        uri=db_uri,
+        database="mp_core",
+        key="task_id",
+        collection_name="grain_boundaries",
+    )
 
-    fermi_store = MongoURIStore(uri=db_uri, database="mp_core", key="task_id", collection_name="fermi_surface")
+    fermi_store = MongoURIStore(
+        uri=db_uri, database="mp_core", key="task_id", collection_name="fermi_surface"
+    )
 
-    elasticity_store = MongoURIStore(uri=db_uri, database="mp_core", key="task_id", collection_name="elasticity")
+    elasticity_store = MongoURIStore(
+        uri=db_uri, database="mp_core", key="task_id", collection_name="elasticity"
+    )
 
-    doi_store = MongoURIStore(uri=db_uri, database="mp_core", key="task_id", collection_name="dois")
+    doi_store = MongoURIStore(
+        uri=db_uri, database="mp_core", key="task_id", collection_name="dois"
+    )
 
-    substrates_store = MongoURIStore(uri=db_uri, database="mp_core", key="film_id", collection_name="substrates")
+    substrates_store = MongoURIStore(
+        uri=db_uri, database="mp_core", key="film_id", collection_name="substrates"
+    )
 
     surface_props_store = MongoURIStore(
-        uri=db_uri, database="mp_core", key="task_id", collection_name="surface_properties"
+        uri=db_uri,
+        database="mp_core",
+        key="task_id",
+        collection_name="surface_properties",
     )
 
     robo_store = MongoURIStore(
-        uri=db_uri, database=f"mp_core_{db_suffix}", key="material_id", collection_name="robocrys"
+        uri=db_uri,
+        database=f"mp_core_{db_suffix}",
+        key="material_id",
+        collection_name="robocrys",
     )
 
-    synth_store = MongoURIStore(uri=db_uri, database="mp_core", key="_id", collection_name="synth_descriptions")
+    synth_store = MongoURIStore(
+        uri=db_uri, database="mp_core", key="_id", collection_name="synth_descriptions"
+    )
 
     insertion_electrodes_store = MongoURIStore(
-        uri=db_uri, database=f"mp_core_{db_suffix}", key="battery_id", collection_name="insertion_electrodes"
+        uri=db_uri,
+        database=f"mp_core_{db_suffix}",
+        key="battery_id",
+        collection_name="insertion_electrodes",
     )
 
     oxi_states_store = MongoURIStore(
-        uri=db_uri, database=f"mp_core_{db_suffix}", key="material_id", collection_name="oxi_states"
+        uri=db_uri,
+        database=f"mp_core_{db_suffix}",
+        key="material_id",
+        collection_name="oxi_states",
     )
 
     provenance_store = MongoURIStore(
-        uri=db_uri, database=f"mp_core_{db_suffix}", key="material_id", collection_name="provenance"
+        uri=db_uri,
+        database=f"mp_core_{db_suffix}",
+        key="material_id",
+        collection_name="provenance",
     )
 
     alloy_pairs_store = MongoURIStore(
-        uri=db_uri, database=f"mp_core_{db_suffix}", key="pair_id", collection_name="alloy_pairs"
+        uri=db_uri,
+        database=f"mp_core_{db_suffix}",
+        key="pair_id",
+        collection_name="alloy_pairs",
     )
 
     summary_store = MongoURIStore(
-        uri=db_uri, database=f"mp_core_{db_suffix}", key="material_id", collection_name="summary"
+        uri=db_uri,
+        database=f"mp_core_{db_suffix}",
+        key="material_id",
+        collection_name="summary",
     )
 
     es_store = MongoURIStore(
-        uri=db_uri, database=f"mp_core_{db_suffix}", key="material_id", collection_name="electronic_structure"
+        uri=db_uri,
+        database=f"mp_core_{db_suffix}",
+        key="material_id",
+        collection_name="electronic_structure",
     )
 
-    s3_bs_index = MongoURIStore(uri=db_uri, database="mp_core", key="fs_id", collection_name="s3_bandstructure_index")
+    s3_bs_index = MongoURIStore(
+        uri=db_uri,
+        database="mp_core",
+        key="fs_id",
+        collection_name="s3_bandstructure_index",
+    )
 
-    s3_dos_index = MongoURIStore(uri=db_uri, database="mp_core", key="fs_id", collection_name="s3_dos_index")
+    s3_dos_index = MongoURIStore(
+        uri=db_uri, database="mp_core", key="fs_id", collection_name="s3_dos_index"
+    )
 
     s3_bs = S3Store(
         index=s3_bs_index,
@@ -141,7 +230,10 @@ if db_uri:
     )
 
     s3_chgcar_index = MongoURIStore(
-        uri=db_uri, database="mp_core", key="fs_id", collection_name="atomate_chgcar_fs_index"
+        uri=db_uri,
+        database="mp_core",
+        key="fs_id",
+        collection_name="atomate_chgcar_fs_index",
     )
 
     s3_chgcar = S3Store(
@@ -154,18 +246,29 @@ if db_uri:
         searchable_fields=["task_id", "fs_id"],
     )
 
-    chgcar_url = MongoURIStore(uri=db_uri, database="mp_core", key="fs_id", collection_name="chgcar_s3_urls")
+    chgcar_url = MongoURIStore(
+        uri=db_uri, database="mp_core", key="fs_id", collection_name="chgcar_s3_urls"
+    )
 
     mpcomplete_store = MongoURIStore(
-        uri=db_uri, database="mp_consumers", key="submission_id", collection_name="mpcomplete"
+        uri=db_uri,
+        database="mp_consumers",
+        key="submission_id",
+        collection_name="mpcomplete",
     )
 
     consumer_settings_store = MongoURIStore(
-        uri=db_uri, database="mp_consumers", key="consumer_id", collection_name="settings"
+        uri=db_uri,
+        database="mp_consumers",
+        key="consumer_id",
+        collection_name="settings",
     )
 
     general_store = MongoURIStore(
-        uri=db_uri, database="mp_consumers", key="submission_id", collection_name="general_store"
+        uri=db_uri,
+        database="mp_consumers",
+        key="submission_id",
+        collection_name="general_store",
     )
 else:
     raise RuntimeError("Must specify MongoDB URI containing inputs.")
@@ -220,9 +323,14 @@ materials_resources.extend(
 )
 
 # Thermo
-from emmet.api.routes.materials.thermo.resources import phase_diagram_resource, thermo_resource
+from emmet.api.routes.materials.thermo.resources import (
+    phase_diagram_resource,
+    thermo_resource,
+)
 
-materials_resources.extend([phase_diagram_resource(phase_diagram_store), thermo_resource(thermo_store)])
+materials_resources.extend(
+    [phase_diagram_resource(phase_diagram_store), thermo_resource(thermo_store)]
+)
 
 # Dielectric
 from emmet.api.routes.materials.dielectric.resources import dielectric_resource
@@ -280,15 +388,22 @@ from emmet.api.routes.materials.substrates.resources import substrates_resource
 materials_resources.extend([substrates_resource(substrates_store)])
 
 # Surface Properties
-from emmet.api.routes.materials.surface_properties.resources import surface_props_resource
+from emmet.api.routes.materials.surface_properties.resources import (
+    surface_props_resource,
+)
 
 materials_resources.extend([surface_props_resource(surface_props_store)])
 
 
 # Robocrystallographer
-from emmet.api.routes.materials.robocrys.resources import robo_resource, robo_search_resource
+from emmet.api.routes.materials.robocrys.resources import (
+    robo_resource,
+    robo_search_resource,
+)
 
-materials_resources.extend([robo_search_resource(robo_store), robo_resource(robo_store)])
+materials_resources.extend(
+    [robo_search_resource(robo_store), robo_resource(robo_store)]
+)
 
 # Synthesis
 from emmet.api.routes.materials.synthesis.resources import synth_resource
@@ -296,7 +411,9 @@ from emmet.api.routes.materials.synthesis.resources import synth_resource
 materials_resources.extend([synth_resource(synth_store)])
 
 # Electrodes
-from emmet.api.routes.materials.electrodes.resources import insertion_electrodes_resource
+from emmet.api.routes.materials.electrodes.resources import (
+    insertion_electrodes_resource,
+)
 
 materials_resources.extend([insertion_electrodes_resource(insertion_electrodes_store)])
 
@@ -316,14 +433,24 @@ from emmet.api.routes.materials.provenance.resources import provenance_resource
 materials_resources.extend([provenance_resource(provenance_store)])
 
 # Charge Density
-from emmet.api.routes.materials.charge_density.resources import charge_density_resource, charge_density_url_resource
+from emmet.api.routes.materials.charge_density.resources import (
+    charge_density_resource,
+    charge_density_url_resource,
+)
 
-materials_resources.extend([charge_density_resource(s3_chgcar), charge_density_url_resource(chgcar_url)])
+materials_resources.extend(
+    [charge_density_resource(s3_chgcar), charge_density_url_resource(chgcar_url)]
+)
 
 # Summary
-from emmet.api.routes.materials.summary.resources import summary_resource, summary_stats_resource
+from emmet.api.routes.materials.summary.resources import (
+    summary_resource,
+    summary_stats_resource,
+)
 
-materials_resources.extend([summary_stats_resource(summary_store), summary_resource(summary_store)])
+materials_resources.extend(
+    [summary_stats_resource(summary_store), summary_resource(summary_store)]
+)
 
 # Electronic Structure
 from emmet.api.routes.materials.electronic_structure.resources import (
@@ -352,7 +479,7 @@ resources.update({"mpcomplete": [mpcomplete_resource(mpcomplete_store)]})
 # DOIs
 from emmet.api.routes.dois.resources import dois_resource
 
-resources.update({"dois": [dois_resource(doi_store)]})
+resources.update({"doi": [dois_resource(doi_store)]})
 
 # Consumers
 from emmet.api.routes._consumer.resources import settings_resource

--- a/emmet-core/emmet/core/summary.py
+++ b/emmet-core/emmet/core/summary.py
@@ -7,11 +7,10 @@ from pymatgen.core.structure import Structure
 
 from emmet.core.electronic_structure import BandstructureData, DosData
 from emmet.core.material_property import PropertyDoc
-
 from emmet.core.mpid import MPID
+from emmet.core.provenance import Database
 from emmet.core.thermo import DecompositionProduct
 from emmet.core.xas import Edge, Type
-from emmet.core.provenance import Database
 
 T = TypeVar("T", bound="SummaryDoc")
 
@@ -61,14 +60,20 @@ class SummaryStats(BaseModel):
     min: float = Field(
         None,
         title="Minimum",
-        description="The minimum value " "of the specified field used to " "generate statistics.",
+        description="The minimum value "
+        "of the specified field used to "
+        "generate statistics.",
     )
     max: float = Field(
         None,
         title="Maximum",
-        description="The maximum value " "of the specified field used to " "generate statistics.",
+        description="The maximum value "
+        "of the specified field used to "
+        "generate statistics.",
     )
-    median: float = Field(None, title="Median", description="The median of the field values.")
+    median: float = Field(
+        None, title="Median", description="The median of the field values."
+    )
     mean: float = Field(None, title="Mean", description="The mean of the field values.")
     distribution: List[float] = Field(
         None,
@@ -90,7 +95,9 @@ class XASSearchData(BaseModel):
         description="The interaction edge for XAS",
         source="xas",
     )
-    absorbing_element: Element = Field(None, description="Absorbing element.", source="xas")
+    absorbing_element: Element = Field(
+        None, description="Absorbing element.", source="xas"
+    )
 
     spectrum_type: Type = Field(None, description="Type of XAS spectrum.", source="xas")
 
@@ -100,13 +107,19 @@ class GBSearchData(BaseModel):
     Fields in grain boundary sub docs in summary
     """
 
-    sigma: int = Field(None, description="Sigma value of the boundary.", source="grain_boundary")
+    sigma: int = Field(
+        None, description="Sigma value of the boundary.", source="grain_boundary"
+    )
 
     type: str = Field(None, description="Grain boundary type.", source="grain_boundary")
 
-    gb_energy: float = Field(None, description="Grain boundary energy in J/m^2.", source="grain_boundary")
+    gb_energy: float = Field(
+        None, description="Grain boundary energy in J/m^2.", source="grain_boundary"
+    )
 
-    rotation_angle: float = Field(None, description="Rotation angle in degrees.", source="grain_boundary")
+    rotation_angle: float = Field(
+        None, description="Rotation angle in degrees.", source="grain_boundary"
+    )
 
 
 class SummaryDoc(PropertyDoc):
@@ -179,7 +192,9 @@ class SummaryDoc(PropertyDoc):
 
     # XAS
 
-    xas: List[XASSearchData] = Field(None, description="List of xas documents.", source="xas")
+    xas: List[XASSearchData] = Field(
+        None, description="List of xas documents.", source="xas"
+    )
 
     # GB
 
@@ -191,13 +206,21 @@ class SummaryDoc(PropertyDoc):
 
     # Electronic Structure
 
-    band_gap: float = Field(None, description="Band gap energy in eV.", source="electronic_structure")
+    band_gap: float = Field(
+        None, description="Band gap energy in eV.", source="electronic_structure"
+    )
 
-    cbm: Union[float, Dict] = Field(None, description="Conduction band minimum data.", source="electronic_structure")
+    cbm: Union[float, Dict] = Field(
+        None, description="Conduction band minimum data.", source="electronic_structure"
+    )
 
-    vbm: Union[float, Dict] = Field(None, description="Valence band maximum data.", source="electronic_structure")
+    vbm: Union[float, Dict] = Field(
+        None, description="Valence band maximum data.", source="electronic_structure"
+    )
 
-    efermi: float = Field(None, description="Fermi energy in eV.", source="electronic_structure")
+    efermi: float = Field(
+        None, description="Fermi energy in eV.", source="electronic_structure"
+    )
 
     is_gap_direct: bool = Field(
         None,
@@ -231,17 +254,27 @@ class SummaryDoc(PropertyDoc):
 
     # DOS
 
-    dos_energy_up: float = Field(None, description="Spin-up DOS band gap in eV.", source="electronic_structure")
+    dos_energy_up: float = Field(
+        None, description="Spin-up DOS band gap in eV.", source="electronic_structure"
+    )
 
-    dos_energy_down: float = Field(None, description="Spin-down DOS band gap in eV.", source="electronic_structure")
+    dos_energy_down: float = Field(
+        None, description="Spin-down DOS band gap in eV.", source="electronic_structure"
+    )
 
     # Magnetism
 
-    is_magnetic: bool = Field(None, description="Whether the material is magnetic.", source="magnetism")
+    is_magnetic: bool = Field(
+        None, description="Whether the material is magnetic.", source="magnetism"
+    )
 
-    ordering: str = Field(None, description="Type of magnetic ordering.", source="magnetism")
+    ordering: str = Field(
+        None, description="Type of magnetic ordering.", source="magnetism"
+    )
 
-    total_magnetization: float = Field(None, description="Total magnetization in μB.", source="magnetism")
+    total_magnetization: float = Field(
+        None, description="Total magnetization in μB.", source="magnetism"
+    )
 
     total_magnetization_normalized_vol: float = Field(
         None,
@@ -255,25 +288,41 @@ class SummaryDoc(PropertyDoc):
         source="magnetism",
     )
 
-    num_magnetic_sites: int = Field(None, description="The number of magnetic sites.", source="magnetism")
+    num_magnetic_sites: int = Field(
+        None, description="The number of magnetic sites.", source="magnetism"
+    )
 
-    num_unique_magnetic_sites: int = Field(None, description="The number of unique magnetic sites.", source="magnetism")
+    num_unique_magnetic_sites: int = Field(
+        None, description="The number of unique magnetic sites.", source="magnetism"
+    )
 
-    types_of_magnetic_species: List[Element] = Field(None, description="Magnetic specie elements.", source="magnetism")
+    types_of_magnetic_species: List[Element] = Field(
+        None, description="Magnetic specie elements.", source="magnetism"
+    )
 
     # Elasticity
 
     k_voigt: float = Field(None, description="Voigt average of the bulk modulus.")
 
-    k_reuss: float = Field(None, description="Reuss average of the bulk modulus in GPa.")
+    k_reuss: float = Field(
+        None, description="Reuss average of the bulk modulus in GPa."
+    )
 
-    k_vrh: float = Field(None, description="Voigt-Reuss-Hill average of the bulk modulus in GPa.")
+    k_vrh: float = Field(
+        None, description="Voigt-Reuss-Hill average of the bulk modulus in GPa."
+    )
 
-    g_voigt: float = Field(None, description="Voigt average of the shear modulus in GPa.")
+    g_voigt: float = Field(
+        None, description="Voigt average of the shear modulus in GPa."
+    )
 
-    g_reuss: float = Field(None, description="Reuss average of the shear modulus in GPa.")
+    g_reuss: float = Field(
+        None, description="Reuss average of the shear modulus in GPa."
+    )
 
-    g_vrh: float = Field(None, description="Voigt-Reuss-Hill average of the shear modulus in GPa.")
+    g_vrh: float = Field(
+        None, description="Voigt-Reuss-Hill average of the shear modulus in GPa."
+    )
 
     universal_anisotropy: float = Field(None, description="Elastic anisotropy.")
 
@@ -281,7 +330,9 @@ class SummaryDoc(PropertyDoc):
 
     # Dielectric and Piezo
 
-    e_total: float = Field(None, description="Total dielectric constant.", source="dielectric")
+    e_total: float = Field(
+        None, description="Total dielectric constant.", source="dielectric"
+    )
 
     e_ionic: float = Field(
         None,
@@ -297,7 +348,9 @@ class SummaryDoc(PropertyDoc):
 
     n: float = Field(None, description="Refractive index.", source="dielectric")
 
-    e_ij_max: float = Field(None, description="Piezoelectric modulus.", source="piezoelectric")
+    e_ij_max: float = Field(
+        None, description="Piezoelectric modulus.", source="piezoelectric"
+    )
 
     # Surface Properties
 
@@ -317,9 +370,13 @@ class SummaryDoc(PropertyDoc):
         None, description="Weighted work function in eV.", source="surface_properties"
     )
 
-    surface_anisotropy: float = Field(None, description="Surface energy anisotropy.", source="surface_properties")
+    surface_anisotropy: float = Field(
+        None, description="Surface energy anisotropy.", source="surface_properties"
+    )
 
-    shape_factor: float = Field(None, description="Shape factor.", source="surface_properties")
+    shape_factor: float = Field(
+        None, description="Shape factor.", source="surface_properties"
+    )
 
     has_reconstructed: bool = Field(
         None,
@@ -345,11 +402,13 @@ class SummaryDoc(PropertyDoc):
 
     # Theoretical
 
-    theoretical: bool = Field(True, description="Whether the material is theoretical.", source="provenance")
+    theoretical: bool = Field(
+        True, description="Whether the material is theoretical.", source="provenance"
+    )
 
     # External Database IDs
 
-    database_IDs: Dict[Database, List[str]] = Field(
+    database_IDs: Dict[str, List[str]] = Field(
         {}, description="External database IDs corresponding to this material."
     )
 
@@ -368,7 +427,9 @@ class SummaryDoc(PropertyDoc):
             else:
                 del doc["bandstructure"]
         if "dos" in doc:
-            if doc["dos"] is not None and list(filter(lambda x: x is not None, doc["dos"].values())):
+            if doc["dos"] is not None and list(
+                filter(lambda x: x is not None, doc["dos"].values())
+            ):
                 doc["has_props"].append(HasProps.dos.value)
             else:
                 del doc["dos"]
@@ -480,12 +541,20 @@ def _copy_from_doc(doc):
             d[doc_key] = []
             for sub_item in sub_doc:
                 temp_doc = {
-                    copy_key: sub_item[copy_key] for copy_key in summary_fields[doc_key] if copy_key in sub_item
+                    copy_key: sub_item[copy_key]
+                    for copy_key in summary_fields[doc_key]
+                    if copy_key in sub_item
                 }
                 d[doc_key].append(temp_doc)
         elif isinstance(sub_doc, dict):
             d["has_props"].append(doc_key)
             if sub_doc["origins"]:
                 d["origins"].extend(sub_doc["origins"])
-            d.update({copy_key: sub_doc[copy_key] for copy_key in summary_fields[doc_key] if copy_key in sub_doc})
+            d.update(
+                {
+                    copy_key: sub_doc[copy_key]
+                    for copy_key in summary_fields[doc_key]
+                    if copy_key in sub_doc
+                }
+            )
     return d

--- a/emmet-core/emmet/core/summary.py
+++ b/emmet-core/emmet/core/summary.py
@@ -8,7 +8,6 @@ from pymatgen.core.structure import Structure
 from emmet.core.electronic_structure import BandstructureData, DosData
 from emmet.core.material_property import PropertyDoc
 from emmet.core.mpid import MPID
-from emmet.core.provenance import Database
 from emmet.core.thermo import DecompositionProduct
 from emmet.core.xas import Edge, Type
 


### PR DESCRIPTION
This PR fixes some remaining issues with having `materials/` and `molecules/` prefixes for all routes. 