### PR TITLE
correct import of EmmetSetting

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -5,8 +5,8 @@
 Example:
 ``` python
 from pydantic import Field
-from emmet.settings import EmmetSettings
-
+from emmet.core.settings import EmmetSettings
+    
 class MySettings(EmmetSettings):
     my_new_setting: int = Field(3,description = "A custom setting")
 ```


### PR DESCRIPTION
Simple PR to correct import of EmmetSetting in documentation

The previous import 
```from emmet.settings import EmmetSettings```
would lead to 
```ModuleNotFoundError: No module named 'emmet.settings'```

