### PR TITLE
Optimade builder

### DIFF
--- a/emmet-builders/emmet/builders/materials/optimade.py
+++ b/emmet-builders/emmet/builders/materials/optimade.py
@@ -77,9 +77,9 @@ class OptimadeMaterialsBuilder(Builder):
 
         mats = [mat for mat in mats_set]
 
-        self.logger.info(f"Processing {len(mats)} items")
-
         self.total = len(mats)
+
+        self.logger.info(f"Processing {self.total} items")
 
         for mat in mats:
             doc = self._get_processed_doc(mat)
@@ -94,17 +94,16 @@ class OptimadeMaterialsBuilder(Builder):
         structure = Structure.from_dict(item["mat_doc"]["structure"])
         last_updated_structure = item["mat_doc"]["last_updated"]
 
+        # Functional names must be lowercase to adhere to optimade spec for querying attributes
+        thermo_calcs = {}
         if item["thermo_doc"]:
-            thermo_calcs = {}
             for doc in item["thermo_doc"]:
-                thermo_calcs[doc["thermo_type"]] = {
-                    "_mp_thermo_id": doc["thermo_id"],
-                    "_mp_energy_above_hull": doc["energy_above_hull"],
-                    "_mp_formation_energy_per_atom": doc["formation_energy_per_atom"],
-                    "_mp_last_updated_thermo": doc["last_updated"],
+                thermo_calcs[doc["thermo_type"].lower()] = {
+                    "thermo_id": doc["thermo_id"],
+                    "energy_above_hull": doc["energy_above_hull"],
+                    "formation_energy_per_atom": doc["formation_energy_per_atom"],
+                    "last_updated_thermo": doc["last_updated"],
                 }
-        else:
-            thermo_calcs = None
 
         optimade_doc = OptimadeMaterialsDoc.from_structure(
             material_id=mpid,

--- a/emmet-builders/emmet/builders/materials/optimade.py
+++ b/emmet-builders/emmet/builders/materials/optimade.py
@@ -1,48 +1,168 @@
-from maggma.builders.map_builder import MapBuilder
+from math import ceil
+from typing import Dict, Iterator, Optional
+
+from maggma.builders import Builder
 from maggma.core import Store
+from maggma.utils import grouper
 from pymatgen.core.structure import Structure
 
 from emmet.core.optimade import OptimadeMaterialsDoc
 from emmet.core.utils import jsanitize
 
 
-class OptimadeMaterialsBuilder(MapBuilder):
+class OptimadeMaterialsBuilder(Builder):
     def __init__(
         self,
         materials: Store,
+        thermo: Store,
         optimade: Store,
+        query: Optional[Dict] = None,
         **kwargs,
     ):
         """
-        Creates Optimade compatible structure docs for the materials
+        Creates Optimade compatible docs containing structure and thermo data for materials
 
         Args:
             materials: Store of materials docs
+            thermo: Store of thermo docs
             optimade: Store to update with optimade document
             query : query on materials to limit search
         """
+
         self.materials = materials
+        self.thermo = thermo
         self.optimade = optimade
+        self.query = query or {}
         self.kwargs = kwargs
 
         # Enforce that we key on material_id
         self.materials.key = "material_id"
+        self.thermo.key = "material_id"
         self.optimade.key = "material_id"
-        super().__init__(
-            source=materials,
-            target=optimade,
-            projection=["structure"],
-            **kwargs,
-        )
 
-    def unary_function(self, item):
-        structure = Structure.from_dict(item["structure"])
-        mpid = item["material_id"]
-        last_updated = item["last_updated"]
+        super().__init__(sources=[materials, thermo], targets=optimade, **kwargs)
+
+    def prechunk(self, number_splits: int) -> Iterator[Dict]:  # pragma: no cover
+        """
+        Prechunk method to perform chunking by the key field
+        """
+        q = dict(self.query)
+
+        keys = self.optimade.newer_in(self.materials, criteria=q, exhaustive=True)
+
+        N = ceil(len(keys) / number_splits)
+        for split in grouper(keys, N):
+            yield {"query": {self.materials.key: {"$in": list(split)}}}
+
+    def get_items(self) -> Iterator:
+        """
+        Gets all items to process
+
+        Returns:
+            Generator or list of relevant materials
+        """
+
+        self.logger.info("Optimade Builder Started")
+
+        q = dict(self.query)
+
+        q.update({"deprecated": False})
+
+        mat_ids = self.materials.distinct(self.materials.key, criteria=q)
+        opti_ids = self.optimade.distinct(self.optimade.key)
+
+        mats_set = set(
+            self.optimade.newer_in(target=self.materials, criteria=q, exhaustive=True)
+        ) | (set(mat_ids) - set(opti_ids))
+
+        mats = [mat for mat in mats_set]
+
+        self.logger.info(f"Processing {len(mats)} items")
+
+        self.total = len(mats)
+
+        for mat in mats:
+            doc = self._get_processed_doc(mat)
+
+            if doc is not None:
+                yield doc
+            else:
+                pass
+
+    def process_item(self, item):
+        mpid = item["mat_doc"]["material_id"]
+        structure = Structure.from_dict(item["mat_doc"]["structure"])
+        last_updated_structure = item["mat_doc"]["last_updated"]
+
+        if item["thermo_doc"]:
+            thermo_calcs = {}
+            for doc in item["thermo_doc"]:
+                thermo_calcs[doc["thermo_type"]] = {
+                    "_mp_thermo_id": doc["thermo_id"],
+                    "_mp_energy_above_hull": doc["energy_above_hull"],
+                    "_mp_formation_energy_per_atom": doc["formation_energy_per_atom"],
+                    "_mp_last_updated_thermo": doc["last_updated"],
+                }
+        else:
+            thermo_calcs = None
 
         optimade_doc = OptimadeMaterialsDoc.from_structure(
-            structure=structure, material_id=mpid, last_updated=last_updated
+            material_id=mpid,
+            structure=structure,
+            last_updated_structure=last_updated_structure,
+            thermo_calcs=thermo_calcs,
         )
+
         doc = jsanitize(optimade_doc.dict(), allow_bson=True)
 
         return doc
+
+    def update_targets(self, items):
+        """
+        Inserts the new optimade docs into the optimade collection
+        """
+        docs = list(filter(None, items))
+
+        if len(docs) > 0:
+            self.logger.info(f"Found {len(docs)} optimade docs to update")
+            self.optimade.update(docs)
+        else:
+            self.logger.info("No items to update")
+
+    def _get_processed_doc(self, mat):
+        mat_doc = self.materials.query_one(
+            {self.materials.key: mat}, [self.materials.key, "last_updated", "structure"]
+        )
+
+        mat_doc.update(
+            {
+                self.materials.key: mat_doc[self.materials.key],
+            }
+        )
+
+        # Query thermo store for all docs matching material_id to catch
+        # multiple stability calculations for the same material_id
+        thermo_docs = self.thermo.query(
+            {self.thermo.key: mat},
+            [
+                self.thermo.key,
+                "thermo_type",
+                "thermo_id",
+                "energy_above_hull",
+                "formation_energy_per_atom",
+                "last_updated",
+            ],
+        )
+
+        thermo_list = [doc for doc in thermo_docs]
+
+        if thermo_list:
+            for doc in thermo_list:
+                doc.update({self.thermo.key: doc[self.thermo.key]})
+
+        combined_doc = {
+            "mat_doc": mat_doc,
+            "thermo_doc": None if not thermo_list else thermo_list,
+        }
+
+        return combined_doc

--- a/emmet-core/emmet/core/optimade.py
+++ b/emmet-core/emmet/core/optimade.py
@@ -84,8 +84,8 @@ class OptimadeMaterialsDoc(StructureResourceAttributes, EmmetBaseModel):
     """
 
     material_id: MPID
-    _mp_chemical_system: str
-    _mp_thermo_calculations: dict or None
+    chemical_system: str
+    stability: dict
 
     @classmethod
     def from_structure(
@@ -93,14 +93,14 @@ class OptimadeMaterialsDoc(StructureResourceAttributes, EmmetBaseModel):
         material_id: MPID,
         structure: Structure,
         last_updated_structure: datetime,
-        thermo_calcs: dict or None,
+        thermo_calcs: dict,
         **kwargs
     ) -> StructureResourceAttributes:
         structure.remove_oxidation_states()
         return OptimadeMaterialsDoc(
             material_id=material_id,
-            _mp_chemical_system=structure.composition.chemical_system,
-            _mp_thermo_calculations=thermo_calcs,
+            chemical_system=structure.composition.chemical_system,
+            stability=thermo_calcs,
             elements=sorted(set([e.symbol for e in structure.composition.elements])),
             nelements=len(structure.composition.elements),
             elements_ratios=list(structure.composition.fractional_composition.values()),

--- a/emmet-core/emmet/core/optimade.py
+++ b/emmet-core/emmet/core/optimade.py
@@ -13,7 +13,6 @@ letters = "ABCDEFGHIJKLMNOPQRSTUVXYZ"
 
 
 def optimade_form(comp: Composition):
-
     symbols = sorted([str(e) for e in comp.keys()])
     numbers = set([comp[s] for s in symbols if comp[s]])
 
@@ -27,7 +26,6 @@ def optimade_form(comp: Composition):
 
 
 def optimade_anonymous_form(comp: Composition):
-
     reduced = comp.element_composition
     if all(x == int(x) for x in comp.values()):
         reduced /= gcd(*(int(i) for i in comp.values()))
@@ -70,30 +68,46 @@ def hill_formula(comp: Composition) -> str:
     else:
         form_elements = elements
 
-    formula = ["%s%s" % (el, formula_double_format(c[el]) if c[el] != 1 else "") for el in form_elements]
+    formula = [
+        "%s%s" % (el, formula_double_format(c[el]) if c[el] != 1 else "")
+        for el in form_elements
+    ]
     return "".join(formula)
 
 
 class OptimadeMaterialsDoc(StructureResourceAttributes, EmmetBaseModel):
-    """Optimade Structure resource with a few extra MP specific fields for materials"""
+    """
+    Optimade Structure resource with a few extra MP specific fields for materials
+
+    Thermo calculations are stored as a nested dict, with keys corresponding to the functional
+    used to perform stability calc, i.e., R2SCAN, GGA_GGA+U_R2SCAN, or GGA_GGA+U
+    """
 
     material_id: MPID
     _mp_chemical_system: str
+    _mp_thermo_calculations: dict or None
 
     @classmethod
     def from_structure(
-        cls, structure: Structure, material_id: MPID, last_updated: datetime, **kwargs
+        cls,
+        material_id: MPID,
+        structure: Structure,
+        last_updated_structure: datetime,
+        thermo_calcs: dict or None,
+        **kwargs
     ) -> StructureResourceAttributes:
-
         structure.remove_oxidation_states()
         return OptimadeMaterialsDoc(
             material_id=material_id,
             _mp_chemical_system=structure.composition.chemical_system,
+            _mp_thermo_calculations=thermo_calcs,
             elements=sorted(set([e.symbol for e in structure.composition.elements])),
             nelements=len(structure.composition.elements),
             elements_ratios=list(structure.composition.fractional_composition.values()),
             chemical_formula_descriptive=optimade_form(structure.composition),
-            chemical_formula_reduced=optimade_form(structure.composition.get_reduced_composition_and_factor()[0]),
+            chemical_formula_reduced=optimade_form(
+                structure.composition.get_reduced_composition_and_factor()[0]
+            ),
             chemical_formula_anonymous=optimade_anonymous_form(structure.composition),
             chemical_formula_hill=hill_formula(structure.composition),
             dimension_types=[1, 1, 1],
@@ -112,7 +126,7 @@ class OptimadeMaterialsDoc(StructureResourceAttributes, EmmetBaseModel):
                 }.values()
             ),
             species_at_sites=[site.species_string for site in structure],
-            last_modified=last_updated,
+            last_modified=last_updated_structure,
             structure_features=[],
             **kwargs
         )


### PR DESCRIPTION
This PR reworks the optimade builder to expose formation energies and stability data via the optimade API. This PR resolves #375 

Major changes include changing the optimade builder to be standard Builder, rather than a MapBuilder, allowing for the optimade builder to pull data from multiple collections.