### PR TITLE
bump pymatgen to >=2023.5.8

### DIFF
--- a/emmet-core/setup.py
+++ b/emmet-core/setup.py
@@ -17,7 +17,7 @@ setup(
     },
     include_package_data=True,
     install_requires=[
-        "pymatgen>=2021.5",
+        "pymatgen>=2023.5.8",
         "monty>=2021.3",
         "pydantic>=1.10.2",
         "pybtex~=0.24",


### PR DESCRIPTION
In the following line, a new module that was introduced in pymatgen 2023.5.8 (https://github.com/materialsproject/pymatgen/commit/a553f378dc830dc1ed73b853af85791fa7fea9d0) is imported. So the pymatgen requirement should also be bumped, otherwise, there might be a `ModuleNotFoundError` error.
https://github.com/materialsproject/emmet/blob/88445cf5a31cdbb0ee49a61664eb8de1e4378660/emmet-core/emmet/core/utils.py#L22
