### PR TITLE
Cli updates

### DIFF
--- a/emmet-cli/emmet/cli/tasks.py
+++ b/emmet-cli/emmet/cli/tasks.py
@@ -611,7 +611,12 @@ def parse(task_ids, snl_metas, nproc, store_volumetric_data, runs):  # noqa: C90
             {"$group": {"_id": None, "num_max": {"$max": "$num_int"}}},
         ]
         result = list(target.collection.aggregate(pipeline))
-        next_tid = result[0]["num_max"] + 1
+
+        if not result:
+            next_tid = 1000001 # Only occurs when inserting into an empty task collection for testing
+        else:
+            next_tid = result[0]["num_max"] + 1
+
         lst = [f"mp-{next_tid + n}" for n in range(nmax)]
         task_ids = chunks(lst, chunk_size)
 

--- a/emmet-cli/emmet/cli/tasks.py
+++ b/emmet-cli/emmet/cli/tasks.py
@@ -613,7 +613,7 @@ def parse(task_ids, snl_metas, nproc, store_volumetric_data, runs):  # noqa: C90
         result = list(target.collection.aggregate(pipeline))
 
         if not result:
-            next_tid = 1 # Only occurs when inserting into an empty task collection for testing
+            next_tid = 1000001 # Only occurs when inserting into an empty task collection for testing
         else:
             next_tid = result[0]["num_max"] + 1
 

--- a/emmet-cli/emmet/cli/tasks.py
+++ b/emmet-cli/emmet/cli/tasks.py
@@ -611,12 +611,8 @@ def parse(task_ids, snl_metas, nproc, store_volumetric_data, runs):  # noqa: C90
             {"$group": {"_id": None, "num_max": {"$max": "$num_int"}}},
         ]
         result = list(target.collection.aggregate(pipeline))
-
-        if not result:
-            next_tid = 1000001 # Only occurs when inserting into an empty task collection for testing
-        else:
-            next_tid = result[0]["num_max"] + 1
-
+        # Manually set next_tid when parsing into an empty task collection for testing
+        next_tid = result[0]["num_max"] + 1 if result else 1000001
         lst = [f"mp-{next_tid + n}" for n in range(nmax)]
         task_ids = chunks(lst, chunk_size)
 

--- a/emmet-cli/emmet/cli/tasks.py
+++ b/emmet-cli/emmet/cli/tasks.py
@@ -613,7 +613,7 @@ def parse(task_ids, snl_metas, nproc, store_volumetric_data, runs):  # noqa: C90
         result = list(target.collection.aggregate(pipeline))
 
         if not result:
-            next_tid = 1000001 # Only occurs when inserting into an empty task collection for testing
+            next_tid = 1 # Only occurs when inserting into an empty task collection for testing
         else:
             next_tid = result[0]["num_max"] + 1
 

--- a/emmet-cli/emmet/cli/utils.py
+++ b/emmet-cli/emmet/cli/utils.py
@@ -55,7 +55,7 @@ def ensure_indexes(indexes, colls):
         for coll in colls:
             keys = [k.rsplit("_", 1)[0] for k in coll.index_information().keys()]
             if index not in keys:
-                coll.ensure_index(index)
+                coll.create_index(index)
                 created[coll.full_name].append(index)
 
     if created:


### PR DESCRIPTION
This PR addresses two bugs in the CLI that occur when trying to parse calculations into an empty task collection.

1. (utils.py) Starting with Pymongo4(Maggma currently requires pymongo>=4.2), the collection.ensure_index() function has been replaced with collection.create_index() [pymongo4 migration, ensure_index](https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html#collection-ensure-index-is-removed). This function is only called when trying to parse task documents into a collection that does not already have the required indexes.
2. (tasks.py) Trying to reserve `task_id`s in an empty collection results in an `IndexError: list index out of range` error. Specifying a `task_id` of 1000001 fixes this. The 7 digit default `task_id` also ensures any task documents in the test collection will not be overwritten