### PR TITLE
Fix thermo material_id treatment in alloys

### DIFF
--- a/emmet-builders/emmet/builders/materials/alloys.py
+++ b/emmet-builders/emmet/builders/materials/alloys.py
@@ -119,7 +119,9 @@ class AlloyPairBuilder(Builder):
             )
             oxi_states_docs = {d["material_id"]: d for d in oxi_states_docs}
 
-            for material_id, d in docs.items():
+            for material_id in thermo_docs:
+                d = docs[material_id]
+
                 d["structure"] = Structure.from_dict(d["structure"])
 
                 if material_id in oxi_states_docs:


### PR DESCRIPTION
Small fix to account for missing material_ids in thermo for the full GGA/GGA+U/R2SCAN mixing scheme.