### PR TITLE
Don't calculate band properties if LORBIT < 11

### DIFF
--- a/emmet-core/emmet/core/vasp/calculation.py
+++ b/emmet-core/emmet/core/vasp/calculation.py
@@ -493,8 +493,7 @@ class CalculationOutput(BaseModel):
         # Parse DOS properties
         dosprop_dict = (
             _get_band_props(vasprun.complete_dos, structure)
-            if hasattr(vasprun, "complete_dos")
-            and vasprun.parameters["LORBIT"] >= 11
+            if hasattr(vasprun, "complete_dos") and vasprun.parameters["LORBIT"] >= 11
             else {}
         )
 

--- a/emmet-core/emmet/core/vasp/calculation.py
+++ b/emmet-core/emmet/core/vasp/calculation.py
@@ -491,11 +491,12 @@ class CalculationOutput(BaseModel):
             structure.add_site_property("magmom", magmoms)
 
         # Parse DOS properties
-        dosprop_dict = (
-            _get_band_props(vasprun.complete_dos, structure)
-            if hasattr(vasprun, "complete_dos")
-            else {}
-        )
+        if vasprun.parameters["LORBIT"] >= 11:
+            dosprop_dict = (
+                _get_band_props(vasprun.complete_dos, structure)
+                if hasattr(vasprun, "complete_dos")
+                else {}
+            )
 
         elph_structures: Dict[str, List[Any]] = {}
         if elph_poscars is not None:

--- a/emmet-core/emmet/core/vasp/calculation.py
+++ b/emmet-core/emmet/core/vasp/calculation.py
@@ -491,12 +491,12 @@ class CalculationOutput(BaseModel):
             structure.add_site_property("magmom", magmoms)
 
         # Parse DOS properties
-        if vasprun.parameters["LORBIT"] >= 11:
-            dosprop_dict = (
-                _get_band_props(vasprun.complete_dos, structure)
-                if hasattr(vasprun, "complete_dos")
-                else {}
-            )
+        dosprop_dict = (
+            _get_band_props(vasprun.complete_dos, structure)
+            if hasattr(vasprun, "complete_dos")
+            and vasprun.parameters["LORBIT"] >= 11
+            else {}
+        )
 
         elph_structures: Dict[str, List[Any]] = {}
         if elph_poscars is not None:


### PR DESCRIPTION
I realized the `_get_band_properties` is always being called on the VASP output to populate the orbital-projected band properties (e.g. d-band center). However, this requires LORBIT >= 11, which is always true for MP calculations but not necessarily in general. I added a simple check so that emmet doesn't error out when LORBIT < 11.