### PR TITLE
Small fixes for `TaskDoc`

### DIFF
--- a/emmet-core/emmet/core/tasks.py
+++ b/emmet-core/emmet/core/tasks.py
@@ -96,8 +96,8 @@ class OutputDoc(BaseModel):
 
     @validator("density", pre=True, always=True)
     def set_density_from_structure(cls, v, values, **kwargs):
-        # Validator to automatically set density from structure if not already 
-        # specified. This might happen when importing an older atomate2-format 
+        # Validator to automatically set density from structure if not already
+        # specified. This might happen when importing an older atomate2-format
         # TaskDocument.
         return v or values["structure"].density
 
@@ -392,7 +392,7 @@ class TaskDoc(StructureMetadata):
     @validator("last_updated", pre=True)
     def last_updated_dict_ok(cls, v) -> datetime:
         return v if isinstance(v, datetime) else monty_decoder.process_decoded(v)
-    
+
     @validator("entry", pre=True)
     def set_entry(cls, v, values) -> datetime:
         return v or cls.get_entry(values["calcs_reversed"], values["task_id"])
@@ -541,7 +541,7 @@ class TaskDoc(StructureMetadata):
             },
         }
         return ComputedEntry.from_dict(entry_dict)
-    
+
     @property
     def structure_entry(self) -> ComputedStructureEntry:
         """
@@ -560,7 +560,7 @@ class TaskDoc(StructureMetadata):
             energy_adjustments=self.entry.energy_adjustments,
             parameters=self.entry.parameters,
             data=self.entry.data,
-            entry_id=self.entry.entry_id
+            entry_id=self.entry.entry_id,
         )
 
 


### PR DESCRIPTION
Hi friends, marking this as draft so not accidentally merged. This contains some small `TaskDoc` fixes for backwards compatibility:

* `density` is now set automatically, which is important when importing older atomate2 TaskDocument (i.e. TaskDocument generated prior to #676)
* `entry.entry_id` is now set from `task_id` (and `job_id` kwarg renamed to `task_id` for consistency)
* Adds a `structure_entry` convenience property
* Ensures that `entry.parameters["potcar_spec"]` is a dict, as expected by pymatgen. 

Probably ok to merge as-is, but I'm going to look around for other issues first.

I did have some questions:

1. The `potcar_ok` validator has an `if isinstance(v, list): return [i for i in v]` line, wasn't obvious why, and didn't have a comment?
2. I'd quite like to remove/replace `icsd_id` with something more general, like `external_database_ids: Dict[str, str]` (e.g. `external_database_ids={"icsd": 1234}`, but wasn't sure if this would break anything (@utf, any comment? I think this is your addition)
3. Were there any remaining issues why `emmet.core.vasp.task_valid.TaskDocument` could not be superseded by `emmet.core.tasks.TaskDoc`?