### PR TITLE
Conversion electrode builder query fix

### DIFF
--- a/emmet-builders/emmet/builders/materials/electrodes.py
+++ b/emmet-builders/emmet/builders/materials/electrodes.py
@@ -513,11 +513,23 @@ class ConversionElectrodeBuilder(Builder):
 
     def get_items(self):
         """
-        Get items. The phase diagrams are prefiltered by "thermo_type" or the functional.
+        Get items. Phase diagrams are filtered such that only PDs with chemical systems containing
+        the working ion and the specified "thermo_type", or functional, are chosen.
         """
-        q = dict(self.query)
-        q.update({"thermo_type": self.thermo_type})
-        for phase_diagram_doc in self.phase_diagram_store.query(q):
+
+        all_chemsys = self.phase_diagram_store.distinct("chemsys")
+
+        chemsys_w_wion = [c for c in all_chemsys if self.working_ion in c.split("-")]
+
+        q = {
+            "$and": [
+                dict(self.query),
+                {"thermo_type": self.thermo_type},
+                {"chemsys": {"$in": chemsys_w_wion}},
+            ]
+        }
+
+        for phase_diagram_doc in self.phase_diagram_store.query(criteria=q):
             yield phase_diagram_doc
 
     def process_item(self, item) -> Dict:

--- a/emmet-builders/emmet/builders/materials/electrodes.py
+++ b/emmet-builders/emmet/builders/materials/electrodes.py
@@ -519,7 +519,7 @@ class ConversionElectrodeBuilder(Builder):
 
         all_chemsys = self.phase_diagram_store.distinct("chemsys")
 
-        chemsys_w_wion = [c for c in all_chemsys if self.working_ion in c.split("-")]
+        chemsys_w_wion = [c for c in all_chemsys if self.working_ion in c]
 
         q = {
             "$and": [

--- a/emmet-core/setup.py
+++ b/emmet-core/setup.py
@@ -17,7 +17,7 @@ setup(
     },
     include_package_data=True,
     install_requires=[
-        "pymatgen>=2023.5.8",
+        "pymatgen>=2023.7.20",
         "monty>=2021.3",
         "pydantic>=1.10.2,<2.0",
         "pybtex~=0.24",


### PR DESCRIPTION
This PR introduces an additional query term in the get_items function for the `ConversionElectrodeBuilder`.

Namely, `{"chemsys": {"$in": chemsys_w_wion}}`, which ensures that the working ion is included in the chemical system of the phase diagram. The working ion is required to be in the chemical system of the phase diagram for the builder to run correctly (per advice of Jiyoon Kim)

The builder previously only queried based on `thermo_type`, or a given functional, which then retrieved phase diagrams for all chemical systems (with or without the working ion).