### PR TITLE
Pull initial keys from thermo in alloys

### DIFF
--- a/emmet-builders/emmet/builders/materials/alloys.py
+++ b/emmet-builders/emmet/builders/materials/alloys.py
@@ -52,9 +52,7 @@ class AlloyPairBuilder(Builder):
         t_type = thermo_type if isinstance(thermo_type, str) else thermo_type.value
         valid_types = {*map(str, ThermoType.__members__.values())}
         if invalid_types := {t_type} - valid_types:
-            raise ValueError(
-                f"Invalid thermo type(s) passed: {invalid_types}, valid types are: {valid_types}"
-            )
+            raise ValueError(f"Invalid thermo type(s) passed: {invalid_types}, valid types are: {valid_types}")
 
         self.thermo_type = t_type
 
@@ -78,34 +76,33 @@ class AlloyPairBuilder(Builder):
             # if af != "AB":
             #     continue
 
-            docs = self.materials.query(
-                criteria={
-                    "formula_anonymous": af,
-                    "deprecated": False,
-                },  # , "material_id": {"$in": ["mp-804", "mp-661"]}},
-                properties=["structure", "material_id", "symmetry.number"],
-            )
-            docs = {d["material_id"]: d for d in docs}
-
-            mpids = list(docs.keys())
-
             thermo_docs = self.thermo.query(
-                {"material_id": {"$in": mpids}, "thermo_type": self.thermo_type},
+                criteria={"formula_anonymous": af, "deprecated": False, "thermo_type": self.thermo_type},
                 properties=[
                     "material_id",
                     "energy_above_hull",
                     "formation_energy_per_atom",
                 ],
             )
+
             thermo_docs = {d["material_id"]: d for d in thermo_docs}
+
+            mpids = list(thermo_docs.keys())
+
+            docs = self.materials.query(
+                criteria={
+                    "material_id": {"$in": mpids},
+                    "deprecated": False,
+                },  # , "material_id": {"$in": ["mp-804", "mp-661"]}},
+                properties=["structure", "material_id", "symmetry.number"],
+            )
+            docs = {d["material_id"]: d for d in docs}
 
             electronic_structure_docs = self.electronic_structure.query(
                 {"material_id": {"$in": mpids}},
                 properties=["material_id", "band_gap", "is_gap_direct"],
             )
-            electronic_structure_docs = {
-                d["material_id"]: d for d in electronic_structure_docs
-            }
+            electronic_structure_docs = {d["material_id"]: d for d in electronic_structure_docs}
 
             provenance_docs = self.provenance.query(
                 {"material_id": {"$in": mpids}},
@@ -119,22 +116,18 @@ class AlloyPairBuilder(Builder):
             )
             oxi_states_docs = {d["material_id"]: d for d in oxi_states_docs}
 
-            for material_id in thermo_docs:
+            for material_id in mpids:
                 d = docs[material_id]
 
                 d["structure"] = Structure.from_dict(d["structure"])
 
                 if material_id in oxi_states_docs:
-                    d["structure_oxi"] = Structure.from_dict(
-                        oxi_states_docs[material_id]["structure"]
-                    )
+                    d["structure_oxi"] = Structure.from_dict(oxi_states_docs[material_id]["structure"])
                 else:
                     d["structure_oxi"] = d["structure"]
 
                 # calculate loose space group
-                d["spacegroup_loose"] = d["structure"].get_space_group_info(
-                    LOOSE_SPACEGROUP_SYMPREC
-                )[1]
+                d["spacegroup_loose"] = d["structure"].get_space_group_info(LOOSE_SPACEGROUP_SYMPREC)[1]
 
                 d["properties"] = {}
                 # patch in BoltzTraP data if present
@@ -145,9 +138,7 @@ class AlloyPairBuilder(Builder):
 
                 if material_id in electronic_structure_docs:
                     for key in ("band_gap", "is_gap_direct"):
-                        d["properties"][key] = electronic_structure_docs[material_id][
-                            key
-                        ]
+                        d["properties"][key] = electronic_structure_docs[material_id][key]
 
                 for key in ("energy_above_hull", "formation_energy_per_atom"):
                     d["properties"][key] = thermo_docs[material_id][key]
@@ -156,19 +147,14 @@ class AlloyPairBuilder(Builder):
                     for key in ("theoretical",):
                         d["properties"][key] = provenance_docs[material_id][key]
 
-            print(
-                f"Starting {af} with {len(docs)} materials, anonymous formula {idx} of {len(ANON_FORMULAS)}"
-            )
+            print(f"Starting {af} with {len(docs)} materials, anonymous formula {idx} of {len(ANON_FORMULAS)}")
 
             yield docs
 
     def process_item(self, item):
         pairs = []
         for mpids in tqdm(list(combinations(item.keys(), 2))):
-            if (
-                item[mpids[0]]["symmetry"]["number"]
-                == item[mpids[1]]["symmetry"]["number"]
-            ) or (
+            if (item[mpids[0]]["symmetry"]["number"] == item[mpids[1]]["symmetry"]["number"]) or (
                 item[mpids[0]]["spacegroup_loose"] == item[mpids[1]]["spacegroup_loose"]
             ):
                 # optionally, could restrict based on band gap too (e.g. at least one end-point semiconducting)
@@ -224,9 +210,7 @@ class AlloyPairMemberBuilder(Builder):
         self.snls = snls
         self.alloy_pair_members = alloy_pair_members
 
-        super().__init__(
-            sources=[alloy_pairs, materials, snls], targets=[alloy_pair_members]
-        )
+        super().__init__(sources=[alloy_pairs, materials, snls], targets=[alloy_pair_members])
 
     def ensure_indexes(self):
         self.alloy_pairs.ensure_index("pair_id")
@@ -238,9 +222,7 @@ class AlloyPairMemberBuilder(Builder):
 
     def get_items(self):
         all_alloy_chemsys = set(self.alloy_pairs.distinct("alloy_pair.chemsys"))
-        all_known_chemsys = set(self.materials.distinct("chemsys")) | set(
-            self.snls.distinct("chemsys")
-        )
+        all_known_chemsys = set(self.materials.distinct("chemsys")) | set(self.snls.distinct("chemsys"))
         possible_chemsys = all_known_chemsys.intersection(all_alloy_chemsys)
 
         print(
@@ -256,9 +238,7 @@ class AlloyPairMemberBuilder(Builder):
                 criteria={"chemsys": chemsys, "deprecated": False},
                 properties=["structure", "material_id"],
             )
-            mp_structures = {
-                d["material_id"]: Structure.from_dict(d["structure"]) for d in mp_docs
-            }
+            mp_structures = {d["material_id"]: Structure.from_dict(d["structure"]) for d in mp_docs}
 
             snl_docs = self.snls.query({"chemsys": chemsys})
             snl_structures = {d["snl_id"]: Structure.from_dict(d) for d in snl_docs}
@@ -308,9 +288,7 @@ class AlloySystemBuilder(Builder):
     It also builds AlloySystem.
     """
 
-    def __init__(
-        self, alloy_pairs, alloy_pair_members, alloy_pairs_merged, alloy_systems
-    ):
+    def __init__(self, alloy_pairs, alloy_pair_members, alloy_pairs_merged, alloy_systems):
         self.alloy_pairs = alloy_pairs
         self.alloy_pair_members = alloy_pair_members
         self.alloy_pairs_merged = alloy_pairs_merged
@@ -330,10 +308,7 @@ class AlloySystemBuilder(Builder):
 
             docs = list(self.alloy_pairs.query({"alloy_pair.anonymous_formula": af}))
             pair_ids = [d["pair_id"] for d in docs]
-            members = {
-                d["pair_id"]: d
-                for d in self.alloy_pair_members.query({"pair_id": {"$in": pair_ids}})
-            }
+            members = {d["pair_id"]: d for d in self.alloy_pair_members.query({"pair_id": {"$in": pair_ids}})}
 
             if docs:
                 yield docs, members
@@ -344,9 +319,7 @@ class AlloySystemBuilder(Builder):
         for doc in pair_docs:
             if doc["pair_id"] in members:
                 doc["alloy_pair"]["members"] = members[doc["pair_id"]]["members"]
-                doc["_search"]["member_ids"] = [
-                    m["id_"] for m in members[doc["pair_id"]]["members"]
-                ]
+                doc["_search"]["member_ids"] = [m["id_"] for m in members[doc["pair_id"]]["members"]]
             else:
                 doc["alloy_pair"]["members"] = []
                 doc["_search"]["member_ids"] = []

--- a/emmet-builders/emmet/builders/materials/alloys.py
+++ b/emmet-builders/emmet/builders/materials/alloys.py
@@ -52,7 +52,9 @@ class AlloyPairBuilder(Builder):
         t_type = thermo_type if isinstance(thermo_type, str) else thermo_type.value
         valid_types = {*map(str, ThermoType.__members__.values())}
         if invalid_types := {t_type} - valid_types:
-            raise ValueError(f"Invalid thermo type(s) passed: {invalid_types}, valid types are: {valid_types}")
+            raise ValueError(
+                f"Invalid thermo type(s) passed: {invalid_types}, valid types are: {valid_types}"
+            )
 
         self.thermo_type = t_type
 
@@ -77,7 +79,11 @@ class AlloyPairBuilder(Builder):
             #     continue
 
             thermo_docs = self.thermo.query(
-                criteria={"formula_anonymous": af, "deprecated": False, "thermo_type": self.thermo_type},
+                criteria={
+                    "formula_anonymous": af,
+                    "deprecated": False,
+                    "thermo_type": self.thermo_type,
+                },
                 properties=[
                     "material_id",
                     "energy_above_hull",
@@ -102,7 +108,9 @@ class AlloyPairBuilder(Builder):
                 {"material_id": {"$in": mpids}},
                 properties=["material_id", "band_gap", "is_gap_direct"],
             )
-            electronic_structure_docs = {d["material_id"]: d for d in electronic_structure_docs}
+            electronic_structure_docs = {
+                d["material_id"]: d for d in electronic_structure_docs
+            }
 
             provenance_docs = self.provenance.query(
                 {"material_id": {"$in": mpids}},
@@ -122,12 +130,16 @@ class AlloyPairBuilder(Builder):
                 d["structure"] = Structure.from_dict(d["structure"])
 
                 if material_id in oxi_states_docs:
-                    d["structure_oxi"] = Structure.from_dict(oxi_states_docs[material_id]["structure"])
+                    d["structure_oxi"] = Structure.from_dict(
+                        oxi_states_docs[material_id]["structure"]
+                    )
                 else:
                     d["structure_oxi"] = d["structure"]
 
                 # calculate loose space group
-                d["spacegroup_loose"] = d["structure"].get_space_group_info(LOOSE_SPACEGROUP_SYMPREC)[1]
+                d["spacegroup_loose"] = d["structure"].get_space_group_info(
+                    LOOSE_SPACEGROUP_SYMPREC
+                )[1]
 
                 d["properties"] = {}
                 # patch in BoltzTraP data if present
@@ -138,7 +150,9 @@ class AlloyPairBuilder(Builder):
 
                 if material_id in electronic_structure_docs:
                     for key in ("band_gap", "is_gap_direct"):
-                        d["properties"][key] = electronic_structure_docs[material_id][key]
+                        d["properties"][key] = electronic_structure_docs[material_id][
+                            key
+                        ]
 
                 for key in ("energy_above_hull", "formation_energy_per_atom"):
                     d["properties"][key] = thermo_docs[material_id][key]
@@ -147,14 +161,19 @@ class AlloyPairBuilder(Builder):
                     for key in ("theoretical",):
                         d["properties"][key] = provenance_docs[material_id][key]
 
-            print(f"Starting {af} with {len(docs)} materials, anonymous formula {idx} of {len(ANON_FORMULAS)}")
+            print(
+                f"Starting {af} with {len(docs)} materials, anonymous formula {idx} of {len(ANON_FORMULAS)}"
+            )
 
             yield docs
 
     def process_item(self, item):
         pairs = []
         for mpids in tqdm(list(combinations(item.keys(), 2))):
-            if (item[mpids[0]]["symmetry"]["number"] == item[mpids[1]]["symmetry"]["number"]) or (
+            if (
+                item[mpids[0]]["symmetry"]["number"]
+                == item[mpids[1]]["symmetry"]["number"]
+            ) or (
                 item[mpids[0]]["spacegroup_loose"] == item[mpids[1]]["spacegroup_loose"]
             ):
                 # optionally, could restrict based on band gap too (e.g. at least one end-point semiconducting)
@@ -210,7 +229,9 @@ class AlloyPairMemberBuilder(Builder):
         self.snls = snls
         self.alloy_pair_members = alloy_pair_members
 
-        super().__init__(sources=[alloy_pairs, materials, snls], targets=[alloy_pair_members])
+        super().__init__(
+            sources=[alloy_pairs, materials, snls], targets=[alloy_pair_members]
+        )
 
     def ensure_indexes(self):
         self.alloy_pairs.ensure_index("pair_id")
@@ -222,7 +243,9 @@ class AlloyPairMemberBuilder(Builder):
 
     def get_items(self):
         all_alloy_chemsys = set(self.alloy_pairs.distinct("alloy_pair.chemsys"))
-        all_known_chemsys = set(self.materials.distinct("chemsys")) | set(self.snls.distinct("chemsys"))
+        all_known_chemsys = set(self.materials.distinct("chemsys")) | set(
+            self.snls.distinct("chemsys")
+        )
         possible_chemsys = all_known_chemsys.intersection(all_alloy_chemsys)
 
         print(
@@ -238,7 +261,9 @@ class AlloyPairMemberBuilder(Builder):
                 criteria={"chemsys": chemsys, "deprecated": False},
                 properties=["structure", "material_id"],
             )
-            mp_structures = {d["material_id"]: Structure.from_dict(d["structure"]) for d in mp_docs}
+            mp_structures = {
+                d["material_id"]: Structure.from_dict(d["structure"]) for d in mp_docs
+            }
 
             snl_docs = self.snls.query({"chemsys": chemsys})
             snl_structures = {d["snl_id"]: Structure.from_dict(d) for d in snl_docs}
@@ -288,7 +313,9 @@ class AlloySystemBuilder(Builder):
     It also builds AlloySystem.
     """
 
-    def __init__(self, alloy_pairs, alloy_pair_members, alloy_pairs_merged, alloy_systems):
+    def __init__(
+        self, alloy_pairs, alloy_pair_members, alloy_pairs_merged, alloy_systems
+    ):
         self.alloy_pairs = alloy_pairs
         self.alloy_pair_members = alloy_pair_members
         self.alloy_pairs_merged = alloy_pairs_merged
@@ -308,7 +335,10 @@ class AlloySystemBuilder(Builder):
 
             docs = list(self.alloy_pairs.query({"alloy_pair.anonymous_formula": af}))
             pair_ids = [d["pair_id"] for d in docs]
-            members = {d["pair_id"]: d for d in self.alloy_pair_members.query({"pair_id": {"$in": pair_ids}})}
+            members = {
+                d["pair_id"]: d
+                for d in self.alloy_pair_members.query({"pair_id": {"$in": pair_ids}})
+            }
 
             if docs:
                 yield docs, members
@@ -319,7 +349,9 @@ class AlloySystemBuilder(Builder):
         for doc in pair_docs:
             if doc["pair_id"] in members:
                 doc["alloy_pair"]["members"] = members[doc["pair_id"]]["members"]
-                doc["_search"]["member_ids"] = [m["id_"] for m in members[doc["pair_id"]]["members"]]
+                doc["_search"]["member_ids"] = [
+                    m["id_"] for m in members[doc["pair_id"]]["members"]
+                ]
             else:
                 doc["alloy_pair"]["members"] = []
                 doc["_search"]["member_ids"] = []

--- a/emmet-core/emmet/core/chemenv.py
+++ b/emmet-core/emmet/core/chemenv.py
@@ -322,13 +322,9 @@ class ChemEnvDoc(PropertyDoc):
         description="The structure used in the generation of the chemical environment data",
     )
 
-    valences: List[int] = Field(
-        description="List of valences for each site in this material to determine cations"
-    )
+    valences: List[int] = Field(description="List of valences for each site in this material to determine cations")
 
-    species: List[str] = Field(
-        description="List of unique (cationic) species in structure."
-    )
+    species: List[str] = Field(description="List of unique (cationic) species in structure.")
 
     chemenv_symbol: List[COORDINATION_GEOMETRIES] = Field(
         description="List of ChemEnv symbols for unique (cationic) species in structure"
@@ -345,9 +341,7 @@ class ChemEnvDoc(PropertyDoc):
     chemenv_name: List[COORDINATION_GEOMETRIES_NAMES] = Field(
         description="List of text description of coordination environment for unique (cationic) species in structure."
     )
-    chemenv_name_with_alternatives: List[
-        COORDINATION_GEOMETRIES_NAMES_WITH_ALTERNATIVES
-    ] = Field(
+    chemenv_name_with_alternatives: List[COORDINATION_GEOMETRIES_NAMES_WITH_ALTERNATIVES] = Field(
         description="List of text description of coordination environment including alternative descriptions for unique (cationic) species in structure."  # noqa: E501
     )
 
@@ -355,9 +349,7 @@ class ChemEnvDoc(PropertyDoc):
         description="Saves the continous symmetry measures for unique (cationic) species in structure"
     )
 
-    method: Union[str, None] = Field(
-        description="Method used to compute chemical environments"
-    )
+    method: Union[str, None] = Field(description="Method used to compute chemical environments")
 
     mol_from_site_environments: List[Union[Molecule, None]] = Field(
         description="List of Molecule Objects describing the detected environment."
@@ -406,124 +398,112 @@ class ChemEnvDoc(PropertyDoc):
             # "structure_environment": None,
         }  # type: dict
 
-        try:
-            list_mol = []
-            list_chemenv = []
-            list_chemenv_iupac = []
-            list_chemenv_iucr = []
-            list_chemenv_text = []
-            list_chemenv_text_with_alternatives = []
-            list_csm = []
-            list_wyckoff = []
-            list_species = []
+        # try:
+        list_mol = []
+        list_chemenv = []
+        list_chemenv_iupac = []
+        list_chemenv_iucr = []
+        list_chemenv_text = []
+        list_chemenv_text_with_alternatives = []
+        list_csm = []
+        list_wyckoff = []
+        list_species = []
 
-            valences = [getattr(site.specie, "oxi_state", None) for site in structure]
-            valences = [v for v in valences if v is not None]
-            sga = SpacegroupAnalyzer(structure)
-            symm_struct = sga.get_symmetrized_structure()
-            # We still need the whole list of indices
-            inequivalent_indices = [
-                indices[0] for indices in symm_struct.equivalent_indices
+        valences = [getattr(site.specie, "oxi_state", None) for site in structure]
+        valences = [v for v in valences if v is not None]
+        sga = SpacegroupAnalyzer(structure)
+        symm_struct = sga.get_symmetrized_structure()
+        # We still need the whole list of indices
+        inequivalent_indices = [indices[0] for indices in symm_struct.equivalent_indices]
+        # if len(inequivalent_indices)>5:
+        #    print("Too many sites")
+        #    raise Exception
+        # wyckoff symbols for all inequivalent indices
+        wyckoffs_unique = symm_struct.wyckoff_symbols
+        # use the local geometry finder to get the important information
+        lgf = LocalGeometryFinder()
+        lgf.setup_structure(structure=structure)
+        all_ce = AllCoordinationGeometries()
+        if len(valences) == len(structure):
+            # Standard alorithm will only focus on cations and cation-anion bonds!
+            method_description = "DefaultSimplestChemenvStrategy"
+            method = AVAILABLE_METHODS[method_description]
+            # We will only focus on cations!
+            inequivalent_indices_cations = [
+                indices[0] for indices in symm_struct.equivalent_indices if valences[indices[0]] > 0.0
             ]
-            # if len(inequivalent_indices)>5:
-            #    print("Too many sites")
-            #    raise Exception
-            # wyckoff symbols for all inequivalent indices
-            wyckoffs_unique = symm_struct.wyckoff_symbols
-            # use the local geometry finder to get the important information
-            lgf = LocalGeometryFinder()
-            lgf.setup_structure(structure=structure)
-            all_ce = AllCoordinationGeometries()
-            if len(valences) == len(structure):
-                # Standard alorithm will only focus on cations and cation-anion bonds!
-                method_description = "DefaultSimplestChemenvStrategy"
-                method = AVAILABLE_METHODS[method_description]
-                # We will only focus on cations!
-                inequivalent_indices_cations = [
-                    indices[0]
-                    for indices in symm_struct.equivalent_indices
-                    if valences[indices[0]] > 0.0
-                ]
 
-                se = lgf.compute_structure_environments(
-                    only_indices=inequivalent_indices_cations,
-                    valences=valences,
-                    maximum_distance_factor=DEFAULT_DISTANCE_CUTOFF,
-                    minimum_angle_factor=DEFAULT_ANGLE_CUTOFF,
-                )
-                lse = LightStructureEnvironments.from_structure_environments(
-                    strategy=method, structure_environments=se
-                )
-                warnings = None
-            else:
-                d.update(
-                    {
-                        "warnings": "No oxidation states available. Cation-anion bonds cannot be identified."
-                    }
-                )
-                return super().from_structure(
-                    meta_structure=structure,
-                    material_id=material_id,
-                    structure=structure,
-                    **d,
-                    **kwargs,
-                )
-                # method_description = "DefaultSimplestChemenvStrategy_all_bonds"
-                # method = AVAILABLE_METHODS[method_description]
+            se = lgf.compute_structure_environments(
+                only_indices=inequivalent_indices_cations,
+                valences=valences,
+                maximum_distance_factor=DEFAULT_DISTANCE_CUTOFF,
+                minimum_angle_factor=DEFAULT_ANGLE_CUTOFF,
+            )
+            lse = LightStructureEnvironments.from_structure_environments(strategy=method, structure_environments=se)
+            warnings = None
+        else:
+            d.update({"warnings": "No oxidation states available. Cation-anion bonds cannot be identified."})
+            return super().from_structure(
+                meta_structure=structure,
+                material_id=material_id,
+                structure=structure,
+                **d,
+                **kwargs,
+            )
+            # method_description = "DefaultSimplestChemenvStrategy_all_bonds"
+            # method = AVAILABLE_METHODS[method_description]
 
-                # se = lgf.compute_structure_environments(
-                #     only_indices=inequivalent_indices,
-                # )
-                # lse = LightStructureEnvironments.from_structure_environments(strategy=method,
-                #     structure_environments=se)
-                # Trick to get rid of duplicate code
-                # inequivalent_indices_cations = inequivalent_indices
-                # warnings = "No oxidation states. Analysis will now include all bonds"
+            # se = lgf.compute_structure_environments(
+            #     only_indices=inequivalent_indices,
+            # )
+            # lse = LightStructureEnvironments.from_structure_environments(strategy=method,
+            #     structure_environments=se)
+            # Trick to get rid of duplicate code
+            # inequivalent_indices_cations = inequivalent_indices
+            # warnings = "No oxidation states. Analysis will now include all bonds"
 
-            for index, wyckoff in zip(inequivalent_indices, wyckoffs_unique):
-                # ONLY CATIONS
-                if index in inequivalent_indices_cations:
-                    # Coordinaton environment will be saved as a molecule!
-                    mol = Molecule.from_sites(
-                        [structure[index]] + lse.neighbors_sets[index][0].neighb_sites
-                    )
-                    mol = mol.get_centered_molecule()
-                    env = lse.coordination_environments[index]
-                    co = all_ce.get_geometry_from_mp_symbol(env[0]["ce_symbol"])
-                    name = co.name
-                    if co.alternative_names:
-                        name += f" (also known as {', '.join(co.alternative_names)})"
-                    # save everything in a list
-                    list_chemenv_text.append(co.name)
-                    list_chemenv_text_with_alternatives.append(name)
-                    list_chemenv.append(co.ce_symbol)
-                    list_chemenv_iucr.append(co.IUCr_symbol_str)
-                    list_chemenv_iupac.append(co.IUPAC_symbol_str)
-                    list_mol.append(mol)
-                    list_wyckoff.append(wyckoff)
-                    list_species.append(structure[index].species_string)
-                    list_csm.append(env[0]["csm"])
+        for index, wyckoff in zip(inequivalent_indices, wyckoffs_unique):
+            # ONLY CATIONS
+            if index in inequivalent_indices_cations:
+                # Coordinaton environment will be saved as a molecule!
+                mol = Molecule.from_sites([structure[index]] + lse.neighbors_sets[index][0].neighb_sites)
+                mol = mol.get_centered_molecule()
+                env = lse.coordination_environments[index]
+                co = all_ce.get_geometry_from_mp_symbol(env[0]["ce_symbol"])
+                name = co.name
+                if co.alternative_names:
+                    name += f" (also known as {', '.join(co.alternative_names)})"
+                # save everything in a list
+                list_chemenv_text.append(co.name)
+                list_chemenv_text_with_alternatives.append(name)
+                list_chemenv.append(co.ce_symbol)
+                list_chemenv_iucr.append(co.IUCr_symbol_str)
+                list_chemenv_iupac.append(co.IUPAC_symbol_str)
+                list_mol.append(mol)
+                list_wyckoff.append(wyckoff)
+                list_species.append(structure[index].species_string)
+                list_csm.append(env[0]["csm"])
 
-                d.update(
-                    {
-                        "valences": valences,
-                        "species": list_species,
-                        "chemenv_symbol": list_chemenv,
-                        "chemenv_iupac": list_chemenv_iupac,
-                        "chemenv_iucr": list_chemenv_iucr,
-                        "chemenv_name": list_chemenv_text,
-                        "chemenv_name_with_alternatives": list_chemenv_text_with_alternatives,
-                        "csm": list_csm,
-                        "mol_from_site_environments": list_mol,
-                        "wyckoff_positions": list_wyckoff,
-                        # "structure_environment": se.as_dict(),
-                        "method": METHODS_DESCRIPTION[method_description],
-                        "warnings": warnings,
-                    }
-                )
+            d.update(
+                {
+                    "valences": valences,
+                    "species": list_species,
+                    "chemenv_symbol": list_chemenv,
+                    "chemenv_iupac": list_chemenv_iupac,
+                    "chemenv_iucr": list_chemenv_iucr,
+                    "chemenv_name": list_chemenv_text,
+                    "chemenv_name_with_alternatives": list_chemenv_text_with_alternatives,
+                    "csm": list_csm,
+                    "mol_from_site_environments": list_mol,
+                    "wyckoff_positions": list_wyckoff,
+                    # "structure_environment": se.as_dict(),
+                    "method": METHODS_DESCRIPTION[method_description],
+                    "warnings": warnings,
+                }
+            )
 
-        except Exception:
-            d.update({"warnings": "ChemEnv algorithm failed."})
+        # except Exception:
+        #     d.update({"warnings": "ChemEnv algorithm failed."})
 
         return super().from_structure(
             meta_structure=structure,

--- a/emmet-core/emmet/core/chemenv.py
+++ b/emmet-core/emmet/core/chemenv.py
@@ -322,9 +322,13 @@ class ChemEnvDoc(PropertyDoc):
         description="The structure used in the generation of the chemical environment data",
     )
 
-    valences: List[int] = Field(description="List of valences for each site in this material to determine cations")
+    valences: List[int] = Field(
+        description="List of valences for each site in this material to determine cations"
+    )
 
-    species: List[str] = Field(description="List of unique (cationic) species in structure.")
+    species: List[str] = Field(
+        description="List of unique (cationic) species in structure."
+    )
 
     chemenv_symbol: List[COORDINATION_GEOMETRIES] = Field(
         description="List of ChemEnv symbols for unique (cationic) species in structure"
@@ -341,7 +345,9 @@ class ChemEnvDoc(PropertyDoc):
     chemenv_name: List[COORDINATION_GEOMETRIES_NAMES] = Field(
         description="List of text description of coordination environment for unique (cationic) species in structure."
     )
-    chemenv_name_with_alternatives: List[COORDINATION_GEOMETRIES_NAMES_WITH_ALTERNATIVES] = Field(
+    chemenv_name_with_alternatives: List[
+        COORDINATION_GEOMETRIES_NAMES_WITH_ALTERNATIVES
+    ] = Field(
         description="List of text description of coordination environment including alternative descriptions for unique (cationic) species in structure."  # noqa: E501
     )
 
@@ -349,7 +355,9 @@ class ChemEnvDoc(PropertyDoc):
         description="Saves the continous symmetry measures for unique (cationic) species in structure"
     )
 
-    method: Union[str, None] = Field(description="Method used to compute chemical environments")
+    method: Union[str, None] = Field(
+        description="Method used to compute chemical environments"
+    )
 
     mol_from_site_environments: List[Union[Molecule, None]] = Field(
         description="List of Molecule Objects describing the detected environment."
@@ -414,7 +422,9 @@ class ChemEnvDoc(PropertyDoc):
         sga = SpacegroupAnalyzer(structure)
         symm_struct = sga.get_symmetrized_structure()
         # We still need the whole list of indices
-        inequivalent_indices = [indices[0] for indices in symm_struct.equivalent_indices]
+        inequivalent_indices = [
+            indices[0] for indices in symm_struct.equivalent_indices
+        ]
         # if len(inequivalent_indices)>5:
         #    print("Too many sites")
         #    raise Exception
@@ -430,7 +440,9 @@ class ChemEnvDoc(PropertyDoc):
             method = AVAILABLE_METHODS[method_description]
             # We will only focus on cations!
             inequivalent_indices_cations = [
-                indices[0] for indices in symm_struct.equivalent_indices if valences[indices[0]] > 0.0
+                indices[0]
+                for indices in symm_struct.equivalent_indices
+                if valences[indices[0]] > 0.0
             ]
 
             se = lgf.compute_structure_environments(
@@ -439,10 +451,16 @@ class ChemEnvDoc(PropertyDoc):
                 maximum_distance_factor=DEFAULT_DISTANCE_CUTOFF,
                 minimum_angle_factor=DEFAULT_ANGLE_CUTOFF,
             )
-            lse = LightStructureEnvironments.from_structure_environments(strategy=method, structure_environments=se)
+            lse = LightStructureEnvironments.from_structure_environments(
+                strategy=method, structure_environments=se
+            )
             warnings = None
         else:
-            d.update({"warnings": "No oxidation states available. Cation-anion bonds cannot be identified."})
+            d.update(
+                {
+                    "warnings": "No oxidation states available. Cation-anion bonds cannot be identified."
+                }
+            )
             return super().from_structure(
                 meta_structure=structure,
                 material_id=material_id,
@@ -466,7 +484,9 @@ class ChemEnvDoc(PropertyDoc):
             # ONLY CATIONS
             if index in inequivalent_indices_cations:
                 # Coordinaton environment will be saved as a molecule!
-                mol = Molecule.from_sites([structure[index]] + lse.neighbors_sets[index][0].neighb_sites)
+                mol = Molecule.from_sites(
+                    [structure[index]] + lse.neighbors_sets[index][0].neighb_sites
+                )
                 mol = mol.get_centered_molecule()
                 env = lse.coordination_environments[index]
                 co = all_ce.get_geometry_from_mp_symbol(env[0]["ce_symbol"])

--- a/emmet-core/setup.py
+++ b/emmet-core/setup.py
@@ -17,7 +17,7 @@ setup(
     },
     include_package_data=True,
     install_requires=[
-        "pymatgen>=2023.5.8",
+        "pymatgen>=2023.7.20",
         "monty>=2021.3",
         "pydantic>=1.10.2,<2.0",
         "pybtex~=0.24",


### PR DESCRIPTION
Ensures material ID values are sourced initially from the thermo collection in `AlloyPairBuilder`. This fixes key coverage issues with different thermo types.