### PR TITLE
Several `TaskDoc` improvements

### DIFF
--- a/emmet-builders/emmet/builders/materials/corrected_entries.py
+++ b/emmet-builders/emmet/builders/materials/corrected_entries.py
@@ -49,10 +49,10 @@ class CorrectedEntriesBuilder(Builder):
         self.chunk_size = chunk_size
         self._entries_cache: Dict[str, List[ComputedStructureEntry]] = defaultdict(list)
 
-        if self.corrected_entries.key != "chemsys":
+        if self.corrected_entries.key != "thermo_id":
             warnings.warn(
                 "Key for the corrected_entries store is incorrect and has been changed "
-                f"from {self.corrected_entries.key} to chemsys!"
+                f"from {self.corrected_entries.key} to thermo_id!"
             )
             self.corrected_entries.key = "thermo_id"
 

--- a/emmet-builders/emmet/builders/materials/corrected_entries.py
+++ b/emmet-builders/emmet/builders/materials/corrected_entries.py
@@ -49,12 +49,12 @@ class CorrectedEntriesBuilder(Builder):
         self.chunk_size = chunk_size
         self._entries_cache: Dict[str, List[ComputedStructureEntry]] = defaultdict(list)
 
-        if self.corrected_entries.key != "thermo_id":
+        if self.corrected_entries.key != "chemsys":
             warnings.warn(
                 "Key for the corrected_entries store is incorrect and has been changed "
                 f"from {self.corrected_entries.key} to thermo_id!"
             )
-            self.corrected_entries.key = "thermo_id"
+            self.corrected_entries.key = "chemsys"
 
         if self.materials.key != "material_id":
             warnings.warn(

--- a/emmet-builders/emmet/builders/vasp/materials.py
+++ b/emmet-builders/emmet/builders/vasp/materials.py
@@ -249,7 +249,7 @@ class MaterialsBuilder(Builder):
                 )
             except Exception as e:
                 failed_ids = list({t_.task_id for t_ in group})
-                doc = MaterialsDoc.construct_deprecated_material(failed_ids)
+                doc = MaterialsDoc.construct_deprecated_material(group)
                 doc.warnings.append(str(e))
                 materials.append(doc)
                 self.logger.warn(

--- a/emmet-builders/emmet/builders/vasp/materials.py
+++ b/emmet-builders/emmet/builders/vasp/materials.py
@@ -249,7 +249,7 @@ class MaterialsBuilder(Builder):
                 )
             except Exception as e:
                 failed_ids = list({t_.task_id for t_ in group})
-                doc = MaterialsDoc.construct_deprecated_material(tasks)
+                doc = MaterialsDoc.construct_deprecated_material(failed_ids)
                 doc.warnings.append(str(e))
                 materials.append(doc)
                 self.logger.warn(

--- a/emmet-core/emmet/core/tasks.py
+++ b/emmet-core/emmet/core/tasks.py
@@ -429,7 +429,7 @@ class TaskDoc(StructureMetadata):
 
         Returns
         -------
-        VaspTaskDoc
+        TaskDoc
             A task document for the calculation.
         """
         logger.info(f"Getting task doc in: {dir_name}")
@@ -504,6 +504,80 @@ class TaskDoc(StructureMetadata):
         doc = doc.copy(update=additional_fields)
         return doc
 
+    @classmethod
+    def from_vasprun(
+        cls: Type[_T],
+        path: Union[str, Path],
+        additional_fields: Dict[str, Any] = None,
+        volume_change_warning_tol: float = 0.2,
+        **vasp_calculation_kwargs,
+    ) -> _T:
+        """
+        Create a task document from a vasprun.xml file.
+
+        This is not recommended and will raise warnings, since some necessary
+        information is absent from the vasprun.xml file, such as per-atom
+        magnetic moments. However, the majority of the TaskDoc will
+        be complete.
+
+        Parameters
+        ----------
+        path
+            The path to the vasprun.xml.
+        additional_fields: Dict[str, Any] = None,
+        volume_change_warning_tol
+            Maximum volume change allowed in VASP relaxations before the calculation is
+            tagged with a warning.
+        **vasp_calculation_kwargs
+            Additional parsing options that will be passed to the
+            :obj:`.Calculation.from_vasp_files` function.
+
+        Returns
+        -------
+        TaskDoc
+            A task document for the calculation.
+        """
+        logger.info(f"Getting vasprun.xml at: {path}")
+
+        path = Path(path)
+        dir_name = path.resolve().parent
+
+        calc = Calculation.from_vasprun(path, **vasp_calculation_kwargs)
+        calcs_reversed = [calc]
+
+        analysis = AnalysisDoc.from_vasp_calc_docs(
+            calcs_reversed, volume_change_warning_tol=volume_change_warning_tol
+        )
+
+        # assume orig_inputs are those stated in vasprun.xml
+        orig_inputs = OrigInputs(
+            incar=calc.input.incar,
+            poscar=Poscar(calc.input.structure),
+            kpoints=calc.input.kpoints,
+            potcar=calc.input.potcar,
+        )
+
+        doc = cls.from_structure(
+            structure=calcs_reversed[0].output.structure,
+            meta_structure=calcs_reversed[0].output.structure,
+            include_structure=True,
+            dir_name=get_uri(dir_name),
+            calcs_reversed=calcs_reversed,
+            analysis=analysis,
+            orig_inputs=orig_inputs,
+            completed_at=calcs_reversed[0].completed_at,
+            input=InputDoc.from_vasp_calc_doc(calcs_reversed[-1]),
+            output=OutputDoc.from_vasp_calc_doc(calcs_reversed[0]),
+            state=_get_state(calcs_reversed, analysis),
+            run_stats=None,
+            vasp_objects={},
+            included_objects=[],
+            task_type=calcs_reversed[0].task_type,
+        )
+        if additional_fields:
+            doc = doc.copy(update=additional_fields)
+        return doc
+
     @staticmethod
     def get_entry(
         calcs_reversed: List[Calculation], task_id: Optional[str] = None
@@ -533,9 +607,6 @@ class TaskDoc(StructureMetadata):
                 "potcar_spec": [dict(d) for d in calcs_reversed[0].input.potcar_spec],
                 # Required to be compatible with MontyEncoder for the ComputedEntry
                 "run_type": str(calcs_reversed[0].run_type),
-                # Hubbard terms
-                "is_hubbard": calcs_reversed[0].input.is_hubbard,
-                "hubbards": calcs_reversed[0].input.hubbards,
             },
             "data": {
                 "oxide_type": oxide_type(calcs_reversed[0].output.structure),

--- a/emmet-core/emmet/core/tasks.py
+++ b/emmet-core/emmet/core/tasks.py
@@ -533,6 +533,9 @@ class TaskDoc(StructureMetadata):
                 "potcar_spec": [dict(d) for d in calcs_reversed[0].input.potcar_spec],
                 # Required to be compatible with MontyEncoder for the ComputedEntry
                 "run_type": str(calcs_reversed[0].run_type),
+                # Hubbard terms
+                "is_hubbard": calcs_reversed[0].input.is_hubbard,
+                "hubbards": calcs_reversed[0].input.hubbards,
             },
             "data": {
                 "oxide_type": oxide_type(calcs_reversed[0].output.structure),

--- a/emmet-core/emmet/core/vasp/calculation.py
+++ b/emmet-core/emmet/core/vasp/calculation.py
@@ -394,8 +394,8 @@ class CalculationOutput(BaseModel):
     def from_vasp_outputs(
         cls,
         vasprun: Vasprun,
-        outcar: Outcar,
-        contcar: Poscar,
+        outcar: Optional[Outcar],
+        contcar: Optional[Poscar],
         locpot: Optional[Locpot] = None,
         elph_poscars: Optional[List[Path]] = None,
         store_trajectory: bool = False,
@@ -474,21 +474,29 @@ class CalculationOutput(BaseModel):
                 normalmode_eigenvecs=vasprun.normalmode_eigenvecs.tolist(),
             )
 
-        outcar_dict = outcar.as_dict()
-        outcar_dict.pop("run_stats")
+        if outcar and contcar:
+            outcar_dict = outcar.as_dict()
+            outcar_dict.pop("run_stats")
 
-        # use structure from CONTCAR as it is written to
-        # greater precision than in the vasprun
-        # but still need to copy the charge over
-        structure = contcar.structure
-        structure._charge = vasprun.final_structure._charge
+            # use structure from CONTCAR as it is written to
+            # greater precision than in the vasprun
+            # but still need to copy the charge over
+            structure = contcar.structure
+            structure._charge = vasprun.final_structure._charge
 
-        mag_density = outcar.total_mag / structure.volume if outcar.total_mag else None
+            mag_density = (
+                outcar.total_mag / structure.volume if outcar.total_mag else None
+            )
 
-        if len(outcar.magnetization) != 0:
-            # patch calculated magnetic moments into final structure
-            magmoms = [m["tot"] for m in outcar.magnetization]
-            structure.add_site_property("magmom", magmoms)
+            if len(outcar.magnetization) != 0:
+                # patch calculated magnetic moments into final structure
+                magmoms = [m["tot"] for m in outcar.magnetization]
+                structure.add_site_property("magmom", magmoms)
+        else:
+            logger.warning("No OUTCAR/CONTCAR available, some information will be missing from TaskDoc.")
+            outcar_dict = {}
+            structure = vasprun.final_structure
+            mag_density = None
 
         # Parse DOS properties
         dosprop_dict = (
@@ -519,7 +527,7 @@ class CalculationOutput(BaseModel):
             ionic_steps=vasprun.ionic_steps if not store_trajectory else None,
             locpot=locpot_avg,
             outcar=outcar_dict,
-            run_stats=RunStatistics.from_outcar(outcar),
+            run_stats=RunStatistics.from_outcar(outcar) if outcar else None,
             **electronic_output,
             **phonon_output,
         )
@@ -736,6 +744,70 @@ class Calculation(BaseModel):
                 calc_type=calc_type(input_doc.dict(), input_doc.parameters),
             ),
             vasp_objects,
+        )
+
+    @classmethod
+    def from_vasprun(
+        cls,
+        path: Union[Path, str],
+        task_name: str = "Unknown vapsrun.xml",
+        vasprun_kwargs: Optional[Dict] = None,
+    ) -> Tuple["Calculation", Dict[VaspObject, Dict]]:
+        """
+        Create a VASP calculation document from a directory and file paths.
+
+        Parameters
+        ----------
+        path
+            Path to the vasprun.xml file.
+        task_name
+            The task name.
+        vasprun_kwargs
+            Additional keyword arguments that will be passed to the Vasprun init.
+
+        Returns
+        -------
+        Calculation
+            A VASP calculation document.
+        """
+        path = Path(path)
+        vasprun_kwargs = vasprun_kwargs if vasprun_kwargs else {}
+        vasprun = Vasprun(path, **vasprun_kwargs)
+
+        completed_at = str(datetime.fromtimestamp(path.stat().st_mtime))
+
+        input_doc = CalculationInput.from_vasprun(vasprun)
+
+        output_doc = CalculationOutput.from_vasp_outputs(
+            vasprun,
+            outcar=None,
+            contcar=None,
+        )
+
+        # MD run
+        if vasprun.parameters.get("IBRION", -1) == 0:
+            if vasprun.parameters.get("NSW", 0) == vasprun.nionic_steps:
+                has_vasp_completed = TaskState.SUCCESS
+            else:
+                has_vasp_completed = TaskState.FAILED
+        # others
+        else:
+            has_vasp_completed = (
+                TaskState.SUCCESS if vasprun.converged else TaskState.FAILED
+            )
+
+        return cls(
+            dir_name=str(path.resolve().parent),
+            task_name=task_name,
+            vasp_version=vasprun.vasp_version,
+            has_vasp_completed=has_vasp_completed,
+            completed_at=completed_at,
+            input=input_doc,
+            output=output_doc,
+            output_file_paths={},
+            run_type=run_type(input_doc.parameters),
+            task_type=task_type(input_doc.dict()),
+            calc_type=calc_type(input_doc.dict(), input_doc.parameters),
         )
 
 


### PR DESCRIPTION
I noticed this was currently missing, so an important add for parity with the `task_valid.TaskDocument`.

If I have a minute, I may append to this PR to formalize the `Entry` model to ensure these fields are explicitly defined (since they're required for the compatibility scheme), otherwise the PR could be merged as-is.