### PR TITLE
Fix deprecated tasks in deprecated materials

### DIFF
--- a/emmet-builders/emmet/builders/vasp/materials.py
+++ b/emmet-builders/emmet/builders/vasp/materials.py
@@ -102,11 +102,17 @@ class MaterialsBuilder(Builder):
             temp_query["tags"] = {"$in": self.settings.BUILD_TAGS}
 
         self.logger.info("Finding tasks to process")
-        all_tasks = list(self.tasks.query(temp_query, [self.tasks.key, "formula_pretty"]))
+        all_tasks = list(
+            self.tasks.query(temp_query, [self.tasks.key, "formula_pretty"])
+        )
 
         processed_tasks = set(self.materials.distinct("task_ids"))
         to_process_tasks = {d[self.tasks.key] for d in all_tasks} - processed_tasks
-        to_process_forms = {d["formula_pretty"] for d in all_tasks if d[self.tasks.key] in to_process_tasks}
+        to_process_forms = {
+            d["formula_pretty"]
+            for d in all_tasks
+            if d[self.tasks.key] in to_process_tasks
+        }
 
         N = ceil(len(to_process_forms) / number_splits)
 
@@ -146,11 +152,17 @@ class MaterialsBuilder(Builder):
             temp_query["tags"] = {"$in": self.settings.BUILD_TAGS}
 
         self.logger.info("Finding tasks to process")
-        all_tasks = list(self.tasks.query(temp_query, [self.tasks.key, "formula_pretty"]))
+        all_tasks = list(
+            self.tasks.query(temp_query, [self.tasks.key, "formula_pretty"])
+        )
 
         processed_tasks = set(self.materials.distinct("task_ids"))
         to_process_tasks = {d[self.tasks.key] for d in all_tasks} - processed_tasks
-        to_process_forms = {d["formula_pretty"] for d in all_tasks if d[self.tasks.key] in to_process_tasks}
+        to_process_forms = {
+            d["formula_pretty"]
+            for d in all_tasks
+            if d[self.tasks.key] in to_process_tasks
+        }
 
         self.logger.info(f"Found {len(to_process_tasks)} unprocessed tasks")
         self.logger.info(f"Found {len(to_process_forms)} unprocessed formulas")
@@ -160,7 +172,10 @@ class MaterialsBuilder(Builder):
 
         if self.task_validation:
             invalid_ids = {
-                doc[self.tasks.key] for doc in self.task_validation.query({"valid": False}, [self.task_validation.key])
+                doc[self.tasks.key]
+                for doc in self.task_validation.query(
+                    {"valid": False}, [self.task_validation.key]
+                )
             }
         else:
             invalid_ids = set()
@@ -192,7 +207,9 @@ class MaterialsBuilder(Builder):
         for formula in to_process_forms:
             tasks_query = dict(temp_query)
             tasks_query["formula_pretty"] = formula
-            tasks = list(self.tasks.query(criteria=tasks_query, properties=projected_fields))
+            tasks = list(
+                self.tasks.query(criteria=tasks_query, properties=projected_fields)
+            )
             for t in tasks:
                 t["is_valid"] = t[self.tasks.key] not in invalid_ids
 
@@ -236,7 +253,8 @@ class MaterialsBuilder(Builder):
                 doc.warnings.append(str(e))
                 materials.append(doc)
                 self.logger.warn(
-                    f"Failed making material for {failed_ids}." f" Inserted as deprecated Material: {doc.material_id}"
+                    f"Failed making material for {failed_ids}."
+                    f" Inserted as deprecated Material: {doc.material_id}"
                 )
 
         self.logger.debug(f"Produced {len(materials)} materials for {formula}")
@@ -276,16 +294,25 @@ class MaterialsBuilder(Builder):
         filtered_tasks = []
         filtered_transmuters = []
         for task, transmuter in zip(tasks, transmuters):
-            if any(allowed_type == task.task_type for allowed_type in self.settings.VASP_ALLOWED_VASP_TYPES):
+            if any(
+                allowed_type == task.task_type
+                for allowed_type in self.settings.VASP_ALLOWED_VASP_TYPES
+            ):
                 filtered_tasks.append(task)
                 filtered_transmuters.append(transmuter)
 
         structures = []
-        for idx, (task, transmuter) in enumerate(zip(filtered_tasks, filtered_transmuters)):
+        for idx, (task, transmuter) in enumerate(
+            zip(filtered_tasks, filtered_transmuters)
+        ):
             if task.task_type == TaskType.Deformation:
-                if transmuter is None:  # Do not include deformed tasks without transmuter information
+                if (
+                    transmuter is None
+                ):  # Do not include deformed tasks without transmuter information
                     self.logger.debug(
-                        "Cannot find transmuter for deformation task {}. Excluding task.".format(task.task_id)
+                        "Cannot find transmuter for deformation task {}. Excluding task.".format(
+                            task.task_id
+                        )
                     )
                     continue
                 else:
@@ -319,7 +346,9 @@ def undeform_structure(structure: Structure, transmuter: Dict) -> Structure:
         undeformed structure
     """
 
-    for trans, params in reversed(list(zip(transmuter["transformations"], transmuter["transformation_params"]))):
+    for trans, params in reversed(
+        list(zip(transmuter["transformations"], transmuter["transformation_params"]))
+    ):
         # The transmuter only stores the transformation class and parameter, without
         # module info and such. Therefore, there is no general way to reconstruct it,
         # and has to do if else check.
@@ -328,6 +357,9 @@ def undeform_structure(structure: Structure, transmuter: Dict) -> Structure:
             dst = DeformStructureTransformation(deform.inv)
             structure = dst.apply_transformation(structure)
         else:
-            raise RuntimeError("Expect transformation to be `DeformStructureTransformation`; " f"got {trans}")
+            raise RuntimeError(
+                "Expect transformation to be `DeformStructureTransformation`; "
+                f"got {trans}"
+            )
 
     return structure

--- a/emmet-builders/emmet/builders/vasp/materials.py
+++ b/emmet-builders/emmet/builders/vasp/materials.py
@@ -102,17 +102,11 @@ class MaterialsBuilder(Builder):
             temp_query["tags"] = {"$in": self.settings.BUILD_TAGS}
 
         self.logger.info("Finding tasks to process")
-        all_tasks = list(
-            self.tasks.query(temp_query, [self.tasks.key, "formula_pretty"])
-        )
+        all_tasks = list(self.tasks.query(temp_query, [self.tasks.key, "formula_pretty"]))
 
         processed_tasks = set(self.materials.distinct("task_ids"))
         to_process_tasks = {d[self.tasks.key] for d in all_tasks} - processed_tasks
-        to_process_forms = {
-            d["formula_pretty"]
-            for d in all_tasks
-            if d[self.tasks.key] in to_process_tasks
-        }
+        to_process_forms = {d["formula_pretty"] for d in all_tasks if d[self.tasks.key] in to_process_tasks}
 
         N = ceil(len(to_process_forms) / number_splits)
 
@@ -152,17 +146,11 @@ class MaterialsBuilder(Builder):
             temp_query["tags"] = {"$in": self.settings.BUILD_TAGS}
 
         self.logger.info("Finding tasks to process")
-        all_tasks = list(
-            self.tasks.query(temp_query, [self.tasks.key, "formula_pretty"])
-        )
+        all_tasks = list(self.tasks.query(temp_query, [self.tasks.key, "formula_pretty"]))
 
         processed_tasks = set(self.materials.distinct("task_ids"))
         to_process_tasks = {d[self.tasks.key] for d in all_tasks} - processed_tasks
-        to_process_forms = {
-            d["formula_pretty"]
-            for d in all_tasks
-            if d[self.tasks.key] in to_process_tasks
-        }
+        to_process_forms = {d["formula_pretty"] for d in all_tasks if d[self.tasks.key] in to_process_tasks}
 
         self.logger.info(f"Found {len(to_process_tasks)} unprocessed tasks")
         self.logger.info(f"Found {len(to_process_forms)} unprocessed formulas")
@@ -172,10 +160,7 @@ class MaterialsBuilder(Builder):
 
         if self.task_validation:
             invalid_ids = {
-                doc[self.tasks.key]
-                for doc in self.task_validation.query(
-                    {"valid": False}, [self.task_validation.key]
-                )
+                doc[self.tasks.key] for doc in self.task_validation.query({"valid": False}, [self.task_validation.key])
             }
         else:
             invalid_ids = set()
@@ -207,9 +192,7 @@ class MaterialsBuilder(Builder):
         for formula in to_process_forms:
             tasks_query = dict(temp_query)
             tasks_query["formula_pretty"] = formula
-            tasks = list(
-                self.tasks.query(criteria=tasks_query, properties=projected_fields)
-            )
+            tasks = list(self.tasks.query(criteria=tasks_query, properties=projected_fields))
             for t in tasks:
                 t["is_valid"] = t[self.tasks.key] not in invalid_ids
 
@@ -249,12 +232,11 @@ class MaterialsBuilder(Builder):
                 )
             except Exception as e:
                 failed_ids = list({t_.task_id for t_ in group})
-                doc = MaterialsDoc.construct_deprecated_material(tasks)
+                doc = MaterialsDoc.construct_deprecated_material(group)
                 doc.warnings.append(str(e))
                 materials.append(doc)
                 self.logger.warn(
-                    f"Failed making material for {failed_ids}."
-                    f" Inserted as deprecated Material: {doc.material_id}"
+                    f"Failed making material for {failed_ids}." f" Inserted as deprecated Material: {doc.material_id}"
                 )
 
         self.logger.debug(f"Produced {len(materials)} materials for {formula}")
@@ -294,25 +276,16 @@ class MaterialsBuilder(Builder):
         filtered_tasks = []
         filtered_transmuters = []
         for task, transmuter in zip(tasks, transmuters):
-            if any(
-                allowed_type == task.task_type
-                for allowed_type in self.settings.VASP_ALLOWED_VASP_TYPES
-            ):
+            if any(allowed_type == task.task_type for allowed_type in self.settings.VASP_ALLOWED_VASP_TYPES):
                 filtered_tasks.append(task)
                 filtered_transmuters.append(transmuter)
 
         structures = []
-        for idx, (task, transmuter) in enumerate(
-            zip(filtered_tasks, filtered_transmuters)
-        ):
+        for idx, (task, transmuter) in enumerate(zip(filtered_tasks, filtered_transmuters)):
             if task.task_type == TaskType.Deformation:
-                if (
-                    transmuter is None
-                ):  # Do not include deformed tasks without transmuter information
+                if transmuter is None:  # Do not include deformed tasks without transmuter information
                     self.logger.debug(
-                        "Cannot find transmuter for deformation task {}. Excluding task.".format(
-                            task.task_id
-                        )
+                        "Cannot find transmuter for deformation task {}. Excluding task.".format(task.task_id)
                     )
                     continue
                 else:
@@ -346,9 +319,7 @@ def undeform_structure(structure: Structure, transmuter: Dict) -> Structure:
         undeformed structure
     """
 
-    for trans, params in reversed(
-        list(zip(transmuter["transformations"], transmuter["transformation_params"]))
-    ):
+    for trans, params in reversed(list(zip(transmuter["transformations"], transmuter["transformation_params"]))):
         # The transmuter only stores the transformation class and parameter, without
         # module info and such. Therefore, there is no general way to reconstruct it,
         # and has to do if else check.
@@ -357,9 +328,6 @@ def undeform_structure(structure: Structure, transmuter: Dict) -> Structure:
             dst = DeformStructureTransformation(deform.inv)
             structure = dst.apply_transformation(structure)
         else:
-            raise RuntimeError(
-                "Expect transformation to be `DeformStructureTransformation`; "
-                f"got {trans}"
-            )
+            raise RuntimeError("Expect transformation to be `DeformStructureTransformation`; " f"got {trans}")
 
     return structure


### PR DESCRIPTION
Ensures that `deprecated_tasks` contained proper data in material documents which are `deprecated`. Previously, every task was being put into this list.