### PR TITLE
Add `is_hubbard` and `hubbards` to entry.parameters

### DIFF
--- a/emmet-core/emmet/core/tasks.py
+++ b/emmet-core/emmet/core/tasks.py
@@ -607,6 +607,8 @@ class TaskDoc(StructureMetadata):
                 "potcar_spec": [dict(d) for d in calcs_reversed[0].input.potcar_spec],
                 # Required to be compatible with MontyEncoder for the ComputedEntry
                 "run_type": str(calcs_reversed[0].run_type),
+                "is_hubbard": calcs_reversed[0].input.is_hubbard,
+                "hubbards": calcs_reversed[0].input.hubbards,
             },
             "data": {
                 "oxide_type": oxide_type(calcs_reversed[0].output.structure),

--- a/emmet-core/emmet/core/vasp/calculation.py
+++ b/emmet-core/emmet/core/vasp/calculation.py
@@ -493,7 +493,9 @@ class CalculationOutput(BaseModel):
                 magmoms = [m["tot"] for m in outcar.magnetization]
                 structure.add_site_property("magmom", magmoms)
         else:
-            logger.warning("No OUTCAR/CONTCAR available, some information will be missing from TaskDoc.")
+            logger.warning(
+                "No OUTCAR/CONTCAR available, some information will be missing from TaskDoc."
+            )
             outcar_dict = {}
             structure = vasprun.final_structure
             mag_density = None


### PR DESCRIPTION
A small patch for backwards-compatibility with the new `TaskDoc`; this is required by the compatibility scheme. Not sure how we missed this before, I thought I'd added! Thanks to Robert Pinsler for notification.

Should be fine to merge/release as-is, however longer term a document model for the Entry itself might be useful that specifies these fields.