### PR TITLE
Remove the pymatgen<=2023.9.10 version pin from `emmet-core`

### DIFF
--- a/emmet-core/setup.py
+++ b/emmet-core/setup.py
@@ -15,7 +15,7 @@ setup(
     },
     include_package_data=True,
     install_requires=[
-        "pymatgen>=2023.9.10",
+        "pymatgen>=2023.10.3",
         "monty>=2021.3",
         "pydantic>=2.0",
         "pydantic-settings>=2.0",

--- a/emmet-core/setup.py
+++ b/emmet-core/setup.py
@@ -15,7 +15,7 @@ setup(
     },
     include_package_data=True,
     install_requires=[
-        "pymatgen<=2023.9.10",
+        "pymatgen>=2023.9.10",
         "monty>=2021.3",
         "pydantic>=2.0",
         "pydantic-settings>=2.0",


### PR DESCRIPTION
See https://github.com/materialsproject/pymatgen/releases/tag/v2023.9.10, in which we removed the pydantic pin. So, given that emmet-core now supports pydantic 2, I have updated it to `pymatgen>=2023.9.10`.