### PR TITLE
Remove PyObject pydantic type from model type hints

### DIFF
--- a/emmet-core/emmet/core/settings.py
+++ b/emmet-core/emmet/core/settings.py
@@ -5,11 +5,11 @@ Settings for defaults in the core definitions of Materials Project Documents
 """
 import json
 from pathlib import Path
-from typing import Dict, List, Type, TypeVar, Union, Any
+from typing import Dict, List, Type, TypeVar, Union
 
 import requests
 from monty.json import MontyDecoder
-from pydantic import field_validator, model_validator, Field
+from pydantic import field_validator, model_validator, Field, ImportString
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 DEFAULT_CONFIG_FILE_PATH = str(Path.home().joinpath(".emmet.json"))
@@ -120,7 +120,7 @@ class EmmetSettings(BaseSettings):
         description="Relative tolerance for kspacing to still be a valid task document",
     )
 
-    VASP_DEFAULT_INPUT_SETS: Dict[str, Any] = Field(
+    VASP_DEFAULT_INPUT_SETS: Dict[str, ImportString] = Field(
         {
             "GGA Structure Optimization": "pymatgen.io.vasp.sets.MPRelaxSet",
             "GGA+U Structure Optimization": "pymatgen.io.vasp.sets.MPRelaxSet",

--- a/emmet-core/emmet/core/settings.py
+++ b/emmet-core/emmet/core/settings.py
@@ -5,12 +5,11 @@ Settings for defaults in the core definitions of Materials Project Documents
 """
 import json
 from pathlib import Path
-from typing import Dict, List, Type, TypeVar, Union
+from typing import Dict, List, Type, TypeVar, Union, Any
 
 import requests
 from monty.json import MontyDecoder
 from pydantic import field_validator, model_validator, Field
-from pydantic.types import PyObject
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 DEFAULT_CONFIG_FILE_PATH = str(Path.home().joinpath(".emmet.json"))
@@ -121,7 +120,7 @@ class EmmetSettings(BaseSettings):
         description="Relative tolerance for kspacing to still be a valid task document",
     )
 
-    VASP_DEFAULT_INPUT_SETS: Dict[str, PyObject] = Field(
+    VASP_DEFAULT_INPUT_SETS: Dict[str, Any] = Field(
         {
             "GGA Structure Optimization": "pymatgen.io.vasp.sets.MPRelaxSet",
             "GGA+U Structure Optimization": "pymatgen.io.vasp.sets.MPRelaxSet",

--- a/emmet-core/emmet/core/vasp/validation.py
+++ b/emmet-core/emmet/core/vasp/validation.py
@@ -1,8 +1,8 @@
 from datetime import datetime
-from typing import Dict, List, Union, Optional, Any
+from typing import Dict, List, Union, Optional
 
 import numpy as np
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, ImportString
 from pymatgen.core.structure import Structure
 from pymatgen.io.vasp.sets import VaspInputSet
 
@@ -63,7 +63,7 @@ class ValidationDoc(EmmetBaseModel):
         task_doc: TaskDocument,
         kpts_tolerance: float = SETTINGS.VASP_KPTS_TOLERANCE,
         kspacing_tolerance: float = SETTINGS.VASP_KSPACING_TOLERANCE,
-        input_sets: Dict[str, Any] = SETTINGS.VASP_DEFAULT_INPUT_SETS,
+        input_sets: Dict[str, ImportString] = SETTINGS.VASP_DEFAULT_INPUT_SETS,
         LDAU_fields: List[str] = SETTINGS.VASP_CHECKED_LDAU_FIELDS,
         max_allowed_scf_gradient: float = SETTINGS.VASP_MAX_SCF_GRADIENT,
         potcar_hashes: Optional[Dict[CalcType, Dict[str, str]]] = None,

--- a/emmet-core/tests/vasp/test_vasp.py
+++ b/emmet-core/tests/vasp/test_vasp.py
@@ -51,7 +51,7 @@ def test_validator(tasks):
     validation_docs = [ValidationDoc.from_task_doc(task) for task in tasks]
 
     assert len(validation_docs) == len(tasks)
-    assert all(doc.valid for doc in validation_docs)
+    assert all([doc.valid for doc in validation_docs])
 
 
 def test_computed_entry(tasks):


### PR DESCRIPTION
This type is deprecated and causing warnings.