### PR TITLE
Fix `pymatgen` breaking change: `PotcarSingle.get_potcar_hash` renamed to `md5_header_hash`

### DIFF
--- a/emmet-builders/emmet/builders/vasp/task_validator.py
+++ b/emmet-builders/emmet/builders/vasp/task_validator.py
@@ -52,7 +52,7 @@ class TaskValidator(MapBuilder):
                         potcar = PotcarSingle.from_symbol_and_functional(
                             symbol=potcar_symbol, functional=functional
                         )
-                        hashes[calc_type][potcar_symbol] = potcar.get_potcar_hash()
+                        hashes[calc_type][potcar_symbol] = potcar.md5_header_hash
 
                 self.potcar_hashes = potcar_hashes
         else:

--- a/emmet-core/emmet/core/vasp/calculation.py
+++ b/emmet-core/emmet/core/vasp/calculation.py
@@ -81,8 +81,7 @@ class PotcarSpec(BaseModel):
         PotcarSpec
             A potcar spec.
         """
-        potcar_hash = potcar_single.get_potcar_hash()
-        return cls(titel=potcar_single.symbol, hash=potcar_hash)
+        return cls(titel=potcar_single.symbol, hash=potcar_single.md5_header_hash)
 
     @classmethod
     def from_potcar(cls, potcar: Potcar) -> List["PotcarSpec"]:

--- a/emmet-core/setup.py
+++ b/emmet-core/setup.py
@@ -15,7 +15,7 @@ setup(
     },
     include_package_data=True,
     install_requires=[
-        "pymatgen>=2023.10.3",
+        "pymatgen>=2023.10.4",
         "monty>=2021.3",
         "pydantic>=2.0",
         "pydantic-settings>=2.0",

--- a/emmet-core/setup.py
+++ b/emmet-core/setup.py
@@ -15,7 +15,7 @@ setup(
     },
     include_package_data=True,
     install_requires=[
-        "pymatgen<=2023.9.10",
+        "pymatgen>=2023.10.3",
         "monty>=2021.3",
         "pydantic>=2.0",
         "pydantic-settings>=2.0",


### PR DESCRIPTION
This PR addresses the breaking changes to PotcarSingle introduced in https://github.com/materialsproject/pymatgen/pull/3351. This should only be merged once a new `pymatgen` release is out at which point we need to down-pin the version to the latest release.

This should be merged before a new `emmet` release is made to unblock https://github.com/materialsproject/atomate2/pull/548.