### PR TITLE
Enable querying based on license data in builder meta

### DIFF
--- a/emmet-api/emmet/api/routes/materials/materials/query_operators.py
+++ b/emmet-api/emmet/api/routes/materials/materials/query_operators.py
@@ -1,5 +1,5 @@
 from itertools import permutations
-from typing import Optional
+from typing import Literal, Optional
 
 from emmet.core.symmetry import CrystalSystem
 from fastapi import Body, HTTPException, Query
@@ -400,3 +400,20 @@ class FormulaAutoCompleteQuery(QueryOperator):
 
     def ensure_indexes(self):  # pragma: no cover
         return [("formula_pretty", False)]
+    
+    
+class LicenseQuery(QueryOperator):
+    """
+    Factory method to generate a dependency for querying by
+        license information in builder meta
+    """
+
+    def query(
+        self,
+        license: Optional[Literal["BY-C", "BY-NC"]] = Query(
+            "BY-C",
+            description="Query by license. Either commercial or non-commercial CC-BY",
+        ),
+    ) -> STORE_PARAMS:
+
+        return {"criteria": {"builder.meta.license": license}}

--- a/emmet-api/emmet/api/routes/materials/materials/query_operators.py
+++ b/emmet-api/emmet/api/routes/materials/materials/query_operators.py
@@ -416,4 +416,4 @@ class LicenseQuery(QueryOperator):
         ),
     ) -> STORE_PARAMS:
 
-        return {"criteria": {"builder.meta.license": license}}
+        return {"criteria": {"builder_meta.license": license}}

--- a/emmet-api/emmet/api/routes/materials/materials/query_operators.py
+++ b/emmet-api/emmet/api/routes/materials/materials/query_operators.py
@@ -400,8 +400,8 @@ class FormulaAutoCompleteQuery(QueryOperator):
 
     def ensure_indexes(self):  # pragma: no cover
         return [("formula_pretty", False)]
-    
-    
+
+
 class LicenseQuery(QueryOperator):
     """
     Factory method to generate a dependency for querying by
@@ -415,5 +415,4 @@ class LicenseQuery(QueryOperator):
             description="Query by license. Either commercial or non-commercial CC-BY",
         ),
     ) -> STORE_PARAMS:
-
         return {"criteria": {"builder_meta.license": license}}

--- a/emmet-api/emmet/api/routes/materials/materials/resources.py
+++ b/emmet-api/emmet/api/routes/materials/materials/resources.py
@@ -25,7 +25,7 @@ from emmet.api.routes.materials.materials.query_operators import (
     FindStructureQuery,
     FormulaAutoCompleteQuery,
     MultiMaterialIDQuery,
-    LicenseQuery
+    LicenseQuery,
 )
 from emmet.api.core.global_header import GlobalHeaderProcessor
 from emmet.api.core.settings import MAPISettings

--- a/emmet-api/emmet/api/routes/materials/materials/resources.py
+++ b/emmet-api/emmet/api/routes/materials/materials/resources.py
@@ -25,6 +25,7 @@ from emmet.api.routes.materials.materials.query_operators import (
     FindStructureQuery,
     FormulaAutoCompleteQuery,
     MultiMaterialIDQuery,
+    LicenseQuery
 )
 from emmet.api.core.global_header import GlobalHeaderProcessor
 from emmet.api.core.settings import MAPISettings
@@ -79,6 +80,7 @@ def materials_resource(materials_store):
                 MaterialsDoc,
                 default_fields=["material_id", "formula_pretty", "last_updated"],
             ),
+            LicenseQuery(),
         ],
         header_processor=GlobalHeaderProcessor(),
         hint_scheme=MaterialsHintScheme(),

--- a/emmet-api/emmet/api/routes/materials/oxidation_states/resources.py
+++ b/emmet-api/emmet/api/routes/materials/oxidation_states/resources.py
@@ -11,7 +11,7 @@ from emmet.api.routes.materials.materials.query_operators import (
     FormulaQuery,
     ChemsysQuery,
     MultiMaterialIDQuery,
-    LicenseQuery
+    LicenseQuery,
 )
 from emmet.api.routes.materials.oxidation_states.query_operators import (
     PossibleOxiStateQuery,

--- a/emmet-api/emmet/api/routes/materials/oxidation_states/resources.py
+++ b/emmet-api/emmet/api/routes/materials/oxidation_states/resources.py
@@ -11,6 +11,7 @@ from emmet.api.routes.materials.materials.query_operators import (
     FormulaQuery,
     ChemsysQuery,
     MultiMaterialIDQuery,
+    LicenseQuery
 )
 from emmet.api.routes.materials.oxidation_states.query_operators import (
     PossibleOxiStateQuery,
@@ -33,6 +34,7 @@ def oxi_states_resource(oxi_states_store):
             SparseFieldsQuery(
                 OxidationStateDoc, default_fields=["material_id", "last_updated"]
             ),
+            LicenseQuery(),
         ],
         header_processor=GlobalHeaderProcessor(),
         tags=["Materials Oxidation States"],

--- a/emmet-api/emmet/api/routes/materials/thermo/resources.py
+++ b/emmet-api/emmet/api/routes/materials/thermo/resources.py
@@ -18,6 +18,7 @@ from emmet.api.routes.materials.materials.query_operators import (
     MultiMaterialIDQuery,
     FormulaQuery,
     ChemsysQuery,
+    LicenseQuery,
 )
 from emmet.api.core.settings import MAPISettings
 
@@ -54,6 +55,7 @@ def thermo_resource(thermo_store):
             SparseFieldsQuery(
                 ThermoDoc, default_fields=["thermo_id", "material_id", "last_updated"]
             ),
+            LicenseQuery(),
         ],
         header_processor=GlobalHeaderProcessor(),
         tags=["Materials Thermo"],

--- a/emmet-builders/emmet/builders/materials/thermo.py
+++ b/emmet-builders/emmet/builders/materials/thermo.py
@@ -2,6 +2,7 @@ from math import ceil
 import warnings
 from itertools import chain
 from typing import Dict, Iterator, List, Optional, Set
+from datetime import datetime
 
 from maggma.core import Builder, Store
 from maggma.stores import S3Store
@@ -284,7 +285,8 @@ class ThermoBuilder(Builder):
             for chemsys in corrected_entries_chemsys_dates
             if (chemsys not in thermo_chemsys_dates)
             or (
-                thermo_chemsys_dates[chemsys] < corrected_entries_chemsys_dates[chemsys]
+                thermo_chemsys_dates[chemsys]
+                < datetime.fromisoformat(corrected_entries_chemsys_dates[chemsys])
             )
         ]
 


### PR DESCRIPTION
This PR adds a license query (CC-BY-C or CC-BY-NC) option for `materials`, `thermo`, `oxi_states`, and `summary`.