### PR TITLE
Split ml deps into new option

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     rev: v0.0.261
     hooks:
       - id: ruff
-        args: [--fix, --ignore, "D,E501,E741", --exclude, "__init__.py,emmet-cli,*_resources.py"]
+        args: [--fix, --ignore, "D,E501,E741,E402", --exclude, "__init__.py,emmet-cli,*_resources.py"]
 
   - repo: https://github.com/psf/black
     rev: 23.3.0

--- a/emmet-api/app.py
+++ b/emmet-api/app.py
@@ -1,4 +1,5 @@
 import time
+
 start = time.perf_counter()
 import logging
 

--- a/emmet-api/app.py
+++ b/emmet-api/app.py
@@ -2,6 +2,7 @@ import time
 
 start = time.perf_counter()
 import logging
+
 logging.getLogger("uvicorn.access").handlers = []
 from asgi_logger import AccessLoggerMiddleware
 
@@ -26,7 +27,7 @@ api = MAPI(
 app = api.app
 app.add_middleware(
     AccessLoggerMiddleware,
-    format='%(h)s %(t)s %(m)s %(U)s?%(q)s %(H)s %(s)s %(b)s "%(f)s" "%(a)s" %(D)s %(p)s %({x-consumer-id}i)s'
+    format='%(h)s %(t)s %(m)s %(U)s?%(q)s %(H)s %(s)s %(b)s "%(f)s" "%(a)s" %(D)s %(p)s %({x-consumer-id}i)s',
 )
 delta = time.perf_counter() - start
 logger.warning(f"Startup took {delta:.1f}s")

--- a/emmet-builders/setup.py
+++ b/emmet-builders/setup.py
@@ -11,6 +11,7 @@ setup(
     packages=find_namespace_packages(include=["emmet.*"]),
     install_requires=[
         "emmet-core[all]",
+        "emmet-core[ml]",
         "maggma>=0.57.0",
         "matminer>=0.7.3",
     ],

--- a/emmet-core/setup.py
+++ b/emmet-core/setup.py
@@ -24,12 +24,13 @@ setup(
     ],
     extras_require={
         "all": [
+            "matcalc",
             "seekpath>=2.0.1",
             "robocrys>=0.2.8",
             "pymatgen-analysis-diffusion>=2023.8.15",
             "pymatgen-analysis-alloys>=0.0.3",
         ],
-        "ml": ["matcalc", "chgnet", "matgl"],
+        "ml": ["chgnet", "matgl"],
         "test": [
             "pre-commit",
             "pytest",

--- a/emmet-core/setup.py
+++ b/emmet-core/setup.py
@@ -28,10 +28,8 @@ setup(
             "robocrys>=0.2.8",
             "pymatgen-analysis-diffusion>=2023.8.15",
             "pymatgen-analysis-alloys>=0.0.3",
-            "matcalc",
-            "chgnet",
-            "matgl",
         ],
+        "ml": ["matcalc", "chgnet", "matgl"],
         "test": [
             "pre-commit",
             "pytest",

--- a/emmet-core/setup.py
+++ b/emmet-core/setup.py
@@ -15,7 +15,7 @@ setup(
     },
     include_package_data=True,
     install_requires=[
-        "pymatgen>=2023.10.4",
+        "pymatgen>=2023.10.11",
         "monty>=2023.9.25",
         "pydantic>=2.0",
         "pydantic-settings>=2.0",


### PR DESCRIPTION
Splits `chgnet`, and `matgl` into a second optional dependency category.