### PR TITLE
`MoleculeMetadata` set model config `allow='extra'`

### DIFF
--- a/emmet-api/app.py
+++ b/emmet-api/app.py
@@ -30,9 +30,6 @@ app.add_middleware(
     AccessLoggerMiddleware,
     format='%(h)s %(t)s %(m)s %(U)s?%(q)s %(H)s %(s)s %(b)s "%(f)s" "%(a)s" %(D)s %(p)s %({x-consumer-id}i)s',
 )
-app.add_middleware(
-    CORSMiddleware,
-    expose_headers=["x-consumer-id"]
-)
+app.add_middleware(CORSMiddleware, expose_headers=["x-consumer-id"])
 delta = time.perf_counter() - start
 logger.warning(f"Startup took {delta:.1f}s")

--- a/emmet-core/emmet/core/base.py
+++ b/emmet-core/emmet/core/base.py
@@ -1,12 +1,13 @@
 # mypy: ignore-errors
 
-""" Base emmet model to add default metadata """
-from datetime import datetime
-from typing import TypeVar, Optional, Literal
+"""Base emmet model to add default metadata."""
 
-from pydantic import field_validator, BaseModel, Field
-from pymatgen.core import __version__ as pmg_version
+from datetime import datetime
+from typing import Literal, Optional, TypeVar
+
 from monty.json import MontyDecoder
+from pydantic import BaseModel, Field, field_validator
+from pymatgen.core import __version__ as pmg_version
 
 from emmet.core import __version__
 
@@ -16,9 +17,7 @@ monty_decoder = MontyDecoder()
 
 
 class EmmetMeta(BaseModel):
-    """
-    Default emmet metadata
-    """
+    """Default emmet metadata."""
 
     emmet_version: str = Field(
         __version__, description="The version of emmet this document was built with."
@@ -52,9 +51,7 @@ class EmmetMeta(BaseModel):
 
 
 class EmmetBaseModel(BaseModel):
-    """
-    Base Model for default emmet data
-    """
+    """Base Model for default emmet data."""
 
     builder_meta: EmmetMeta = Field(
         default_factory=EmmetMeta, description="Builder metadata."

--- a/emmet-core/emmet/core/structure.py
+++ b/emmet-core/emmet/core/structure.py
@@ -152,7 +152,7 @@ class StructureMetadata(EmmetBaseModel):
         return cls(**kwargs)
 
 
-class MoleculeMetadata(EmmetBaseModel, extra="allow"):
+class MoleculeMetadata(EmmetBaseModel):
     """Mix-in class for molecule metadata."""
 
     charge: Optional[int] = Field(None, description="Charge of the molecule")

--- a/emmet-core/emmet/core/structure.py
+++ b/emmet-core/emmet/core/structure.py
@@ -1,25 +1,22 @@
-""" Core definition of Structure and Molecule metadata """
+"""Core definition of Structure and Molecule metadata."""
 from __future__ import annotations
 
 from typing import List, Optional, Type, TypeVar
 
 from pydantic import Field
-
 from pymatgen.core.composition import Composition
 from pymatgen.core.periodic_table import Element
-from pymatgen.core.structure import Structure, Molecule
+from pymatgen.core.structure import Molecule, Structure
 
 from emmet.core.base import EmmetBaseModel
-from emmet.core.symmetry import SymmetryData, PointGroupData
+from emmet.core.symmetry import PointGroupData, SymmetryData
 
 T = TypeVar("T", bound="StructureMetadata")
 S = TypeVar("S", bound="MoleculeMetadata")
 
 
 class StructureMetadata(EmmetBaseModel):
-    """
-    Mix-in class for structure metadata
-    """
+    """Mix-in class for structure metadata."""
 
     # Structure metadata
     nsites: Optional[int] = Field(
@@ -94,7 +91,7 @@ class StructureMetadata(EmmetBaseModel):
         )
         composition = composition.remove_charges()
 
-        elsyms = sorted(set([e.symbol for e in composition.elements]))
+        elsyms = sorted({e.symbol for e in composition.elements})
 
         data = {
             "elements": elsyms,
@@ -134,7 +131,7 @@ class StructureMetadata(EmmetBaseModel):
             else fields
         )
         comp = meta_structure.composition.remove_charges()
-        elsyms = sorted(set([e.symbol for e in comp.elements]))
+        elsyms = sorted({e.symbol for e in comp.elements})
         symmetry = SymmetryData.from_structure(meta_structure)
 
         data = {
@@ -156,9 +153,7 @@ class StructureMetadata(EmmetBaseModel):
 
 
 class MoleculeMetadata(EmmetBaseModel):
-    """
-    Mix-in class for molecule metadata
-    """
+    """Mix-in class for molecule metadata."""
 
     charge: Optional[int] = Field(None, description="Charge of the molecule")
     spin_multiplicity: Optional[int] = Field(
@@ -288,7 +283,7 @@ class MoleculeMetadata(EmmetBaseModel):
             else fields
         )
         comp = meta_molecule.composition
-        elsyms = sorted(set([e.symbol for e in comp.elements]))
+        elsyms = sorted({e.symbol for e in comp.elements})
         symmetry = PointGroupData.from_molecule(meta_molecule)
 
         data = {

--- a/emmet-core/emmet/core/structure.py
+++ b/emmet-core/emmet/core/structure.py
@@ -152,7 +152,7 @@ class StructureMetadata(EmmetBaseModel):
         return cls(**kwargs)
 
 
-class MoleculeMetadata(EmmetBaseModel):
+class MoleculeMetadata(EmmetBaseModel, extra="allow"):
     """Mix-in class for molecule metadata."""
 
     charge: Optional[int] = Field(None, description="Charge of the molecule")

--- a/emmet-core/tests/test_molecule_metadata.py
+++ b/emmet-core/tests/test_molecule_metadata.py
@@ -1,7 +1,4 @@
 import pytest
-
-import numpy as np
-
 from pymatgen.core import Molecule
 from pymatgen.core.composition import Composition
 from pymatgen.core.periodic_table import Element
@@ -9,17 +6,13 @@ from pymatgen.core.periodic_table import Element
 from emmet.core.structure import MoleculeMetadata
 
 
-@pytest.fixture
+@pytest.fixture()
 def molecule():
-    test_mol = Molecule(
-        species=["O", "O"],
-        coords=np.asarray([[0, 0, 0], [0.0, 0.0, 1.16]]),
-    )
-    return test_mol
+    return Molecule(species=["O", "O"], coords=[[0, 0, 0], [0.0, 0.0, 1.16]])
 
 
 def test_from_molecule(molecule):
-    metadata = MoleculeMetadata.from_molecule(molecule)
+    metadata = MoleculeMetadata.from_molecule(molecule, extra_field="extra_value")
     assert metadata.natoms == 2
     assert metadata.elements == [Element("O")]
     assert metadata.nelements == 1
@@ -33,6 +26,9 @@ def test_from_molecule(molecule):
     assert metadata.charge == 0
     assert metadata.spin_multiplicity == 1
     assert metadata.nelectrons == 16
+
+    assert metadata.model_config.get("extra") == "allow"
+    assert metadata.model_dump().get("extra_field") == "extra_value"
 
 
 def test_from_comp(molecule):

--- a/emmet-core/tests/test_molecule_metadata.py
+++ b/emmet-core/tests/test_molecule_metadata.py
@@ -27,8 +27,11 @@ def test_from_molecule(molecule):
     assert metadata.spin_multiplicity == 1
     assert metadata.nelectrons == 16
 
-    assert metadata.model_config.get("extra") == "allow"
-    assert metadata.model_dump().get("extra_field") == "extra_value"
+    assert metadata.model_config.get("extra") is None, (
+        "Should not allow extra field to keep validation strict, if "
+        "extra fields are needed, set extra='allow' on a subclass"
+    )
+    assert metadata.model_dump().get("extra_field") is None
 
 
 def test_from_comp(molecule):


### PR DESCRIPTION
Fixes breaking `test_cclib_taskdoc` in https://github.com/materialsproject/atomate2/pull/548.

[Failing lines that require `allow='extra'`](https://github.com/materialsproject/atomate2/blob/302bed8b1e4fd68aec3ffbfa92302780c58b9902/tests/common/schemas/test_cclib.py#L91-L92).

2nd fix needed for `atomate2` tests following #853.