### PR TITLE
Replace deprecated `pkg_resources` with `importlib.metadata.version`

### DIFF
--- a/emmet-core/emmet/core/__init__.py
+++ b/emmet-core/emmet/core/__init__.py
@@ -1,11 +1,12 @@
 """
 Core module exposes the document interfaces
-These will be ingested via Drones, built by Builders, and served via the API
+These will be ingested via Drones, built by Builders, and served via the API.
 """
-from pkg_resources import DistributionNotFound, get_distribution
+
+from importlib.metadata import PackageNotFoundError, version
 
 try:
-    __version__ = get_distribution("emmet-core").version
-except DistributionNotFound:  # pragma: no cover
+    __version__ = version("emmet-core")
+except PackageNotFoundError:  # pragma: no cover
     # package is not installed
     pass


### PR DESCRIPTION
From [https://setuptools.pypa.io](https://setuptools.pypa.io/en/latest/pkg_resources.html):

> Use of pkg_resources is deprecated in favor of [importlib.resources](https://docs.python.org/3.11/library/importlib.resources.html#module-importlib.resources), [importlib.metadata](https://docs.python.org/3.11/library/importlib.metadata.html#module-importlib.metadata) and their backports ([importlib_resources](https://pypi.org/project/importlib_resources), [importlib_metadata](https://pypi.org/project/importlib_metadata)). Some useful APIs are also provided by [packaging](https://pypi.org/project/packaging) (e.g. requirements and version parsing). Users should refrain from new usage of pkg_resources and should work to port to importlib-based solutions.