### PR TITLE
Add 3 missing `Optional`s for `EmmetMeta` fields

### DIFF
--- a/emmet-core/emmet/core/base.py
+++ b/emmet-core/emmet/core/base.py
@@ -19,10 +19,10 @@ monty_decoder = MontyDecoder()
 class EmmetMeta(BaseModel):
     """Default emmet metadata."""
 
-    emmet_version: str = Field(
+    emmet_version: Optional[str] = Field(
         __version__, description="The version of emmet this document was built with."
     )
-    pymatgen_version: str = Field(
+    pymatgen_version: Optional[str] = Field(
         pmg_version, description="The version of pymatgen this document was built with."
     )
 
@@ -34,7 +34,7 @@ class EmmetMeta(BaseModel):
         None, description="The database version for the built data."
     )
 
-    build_date: datetime = Field(
+    build_date: Optional[datetime] = Field(
         default_factory=datetime.utcnow,
         description="The build date for this document.",
     )
@@ -53,6 +53,6 @@ class EmmetMeta(BaseModel):
 class EmmetBaseModel(BaseModel):
     """Base Model for default emmet data."""
 
-    builder_meta: EmmetMeta = Field(
+    builder_meta: Optional[EmmetMeta] = Field(
         default_factory=EmmetMeta, description="Builder metadata."
     )


### PR DESCRIPTION
These 3 fields were not optional and raising validation errors from being `None` in `atomate2` tests.

1. `builder_meta.emmet_version`
1. `builder_meta.pymatgen_version`
1. `builder_meta.build_date`

Causing 32 tests to fail on the [`main` branch](https://github.com/materialsproject/atomate2/actions/runs/6533680977/job/17739343959) so new `emmet` release this week would be much appreciated @munrojm! 🙏 

@esoteric-ephemera @hrushikesh-s @Zhuoying