### PR TITLE
`_parse_additional_json` ignore `FW.json(.gz)`

### DIFF
--- a/emmet-core/emmet/core/tasks.py
+++ b/emmet-core/emmet/core/tasks.py
@@ -831,7 +831,11 @@ def _parse_additional_json(dir_name: Path) -> Dict[str, Any]:
     additional_json = {}
     for filename in dir_name.glob("*.json*"):
         key = filename.name.split(".")[0]
-        if key not in ("custodian", "transformations"):
+        # ignore FW.json(.gz) so jobflow doesn't try to parse prev_vasp_dir OutputReferences
+        # was causing atomate2 MP workflows to fail with ValueError: Could not resolve reference
+        # 7f5a7f14-464c-4a5b-85f9-8d11b595be3b not in store or cache
+        # contact @janosh in case of questions
+        if key not in ("custodian", "transformations", "FW"):
             additional_json[key] = loadfn(filename, cls=None)
     return additional_json
 


### PR DESCRIPTION
Ignore `FW.json(.gz)` so `jobflow` doesn't try to parse `prev_vasp_dir` `OutputReferences` from it.

**Reason**
This was causing `atomate2` MP workflows (see https://github.com/materialsproject/atomate2/pull/504) to fail with 

```py
ValueError: Could not resolve reference 7f5a7f14-464c-4a5b-85f9-8d11b595be3b not in store or cache
```

if a `FW.json.gz` was present in the job's output directory.