### PR TITLE
Fix NSCF line mode task type iden

### DIFF
--- a/emmet-core/emmet/core/vasp/calc_types/utils.py
+++ b/emmet-core/emmet/core/vasp/calc_types/utils.py
@@ -40,13 +40,18 @@ def run_type(parameters: Dict) -> RunType:
     # This is to force an order of evaluation
     for functional_class in ["HF", "VDW", "METAGGA", "GGA"]:
         for special_type, params in _RUN_TYPE_DATA[functional_class].items():
-            if all(_variant_equal(parameters.get(param, None), value) for param, value in params.items()):
+            if all(
+                _variant_equal(parameters.get(param, None), value)
+                for param, value in params.items()
+            ):
                 return RunType(f"{special_type}{is_hubbard}")
 
     return RunType(f"LDA{is_hubbard}")
 
 
-def task_type(inputs: Dict[Literal["incar", "poscar", "kpoints", "potcar"], Dict]) -> TaskType:
+def task_type(
+    inputs: Dict[Literal["incar", "poscar", "kpoints", "potcar"], Dict]
+) -> TaskType:
     """
     Determine task type from vasp inputs.
 

--- a/emmet-core/emmet/core/vasp/calc_types/utils.py
+++ b/emmet-core/emmet/core/vasp/calc_types/utils.py
@@ -40,18 +40,13 @@ def run_type(parameters: Dict) -> RunType:
     # This is to force an order of evaluation
     for functional_class in ["HF", "VDW", "METAGGA", "GGA"]:
         for special_type, params in _RUN_TYPE_DATA[functional_class].items():
-            if all(
-                _variant_equal(parameters.get(param, None), value)
-                for param, value in params.items()
-            ):
+            if all(_variant_equal(parameters.get(param, None), value) for param, value in params.items()):
                 return RunType(f"{special_type}{is_hubbard}")
 
     return RunType(f"LDA{is_hubbard}")
 
 
-def task_type(
-    inputs: Dict[Literal["incar", "poscar", "kpoints", "potcar"], Dict]
-) -> TaskType:
+def task_type(inputs: Dict[Literal["incar", "poscar", "kpoints", "potcar"], Dict]) -> TaskType:
     """
     Determine task type from vasp inputs.
 
@@ -78,7 +73,7 @@ def task_type(
         else:
             calc_type.append("NSCF Uniform")
     elif len([x for x in kpts.get("labels") or [] if x is not None]) > 0:
-        calc_type.append("SCF Line")
+        calc_type.append("NSCF Line")
     elif incar.get("LEPSILON", False):
         if incar.get("IBRION", 0) > 6:
             calc_type.append("DFPT")


### PR DESCRIPTION
Fixes typo in task_type identification function when assigning an `NSCF Line` type.