### PR TITLE
Fix PyPI missing project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # ![Emmet](docs/images/logo_w_text.svg)
 
-
 [![Pytest Status](https://github.com/materialsproject/emmet/workflows/testing/badge.svg)](https://github.com/materialsproject/emmet/actions?query=workflow%3Atesting)
 [![Code Coverage](https://codecov.io/gh/materialsproject/emmet/branch/main/graph/badge.svg)](https://codecov.io/gh/materialsproject/emmet)
 

--- a/emmet-api/setup.py
+++ b/emmet-api/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from setuptools import find_namespace_packages, setup
 
 setup(
@@ -8,6 +7,8 @@ setup(
     description="Emmet API Library",
     author="The Materials Project",
     author_email="feedback@materialsproject.org",
+    long_description=open("../README.md").read(),  # noqa: SIM115
+    long_description_content_type="text/markdown",
     url="https://github.com/materialsproject/emmet",
     packages=find_namespace_packages(include=["emmet.*"]),
     install_requires=[

--- a/emmet-builders/setup.py
+++ b/emmet-builders/setup.py
@@ -7,6 +7,8 @@ setup(
     description="Builders for the Emmet Library",
     author="The Materials Project",
     author_email="feedback@materialsproject.org",
+    long_description=open("../README.md").read(),  # noqa: SIM115
+    long_description_content_type="text/markdown",
     url="https://github.com/materialsproject/emmet",
     packages=find_namespace_packages(include=["emmet.*"]),
     install_requires=[

--- a/emmet-cli/setup.py
+++ b/emmet-cli/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 
 from setuptools import setup
@@ -9,6 +8,8 @@ setup(
     description="command line interface for emmet",
     author="The Materials Project",
     author_email="feedback@materialsproject.org",
+    long_description=open("../README.md").read(),  # noqa: SIM115
+    long_description_content_type="text/markdown",
     url="https://github.com/materialsproject/emmet",
     packages=["emmet.cli"],
     install_requires=[

--- a/emmet-core/setup.py
+++ b/emmet-core/setup.py
@@ -7,6 +7,8 @@ setup(
     description="Core Emmet Library",
     author="The Materials Project",
     author_email="feedback@materialsproject.org",
+    long_description=open("../README.md").read(),  # noqa: SIM115
+    long_description_content_type="text/markdown",
     url="https://github.com/materialsproject/emmet",
     packages=find_namespace_packages(include=["emmet.*"]),
     package_data={


### PR DESCRIPTION
This PR will make the next release show the readme contents on the [PyPI project page](https://pypi.org/project/emmet-core) for `emmet-core` and siblings.

![Screenshot 2023-10-18 at 9 17 28 AM](https://github.com/materialsproject/emmet/assets/30958850/7d6d9fac-32f6-4f19-b7ea-232b837a74ee)
