### PR TITLE
Add `run_ddec6` option to `Calculation.from_vasp_files`

### DIFF
--- a/emmet-core/emmet/core/vasp/calculation.py
+++ b/emmet-core/emmet/core/vasp/calculation.py
@@ -661,7 +661,8 @@ class Calculation(BaseModel):
         run_ddec6 : bool | str = False
             Whether to run DDEC6 on the charge density. If a string, it's interpreted
             as the path to the atomic densities directory. Can also be set via the
-            DDEC6_ATOMIC_DENSITIES_DIR environment variable.
+            DDEC6_ATOMIC_DENSITIES_DIR environment variable. The files are available at
+            https://sourceforge.net/projects/ddec/files.
         strip_dos_projections
             Whether to strip the element and site projections from the density of
             states. This can help reduce the size of DOS objects in systems with many

--- a/emmet-core/emmet/core/vasp/calculation.py
+++ b/emmet-core/emmet/core/vasp/calculation.py
@@ -607,7 +607,7 @@ class Calculation(BaseModel):
         parse_bandstructure: Union[str, bool] = False,
         average_locpot: bool = True,
         run_bader: bool = False,
-        run_ddec6: bool = False,
+        run_ddec6: bool | str = False,
         strip_bandstructure_projections: bool = False,
         strip_dos_projections: bool = False,
         store_volumetric_data: Optional[Tuple[str]] = None,
@@ -658,8 +658,10 @@ class Calculation(BaseModel):
             Whether to store the average of the LOCPOT along the crystal axes.
         run_bader : bool = False
             Whether to run bader on the charge density.
-        run_ddec6 : bool = False
-            Whether to run DDEC6 on the charge density.
+        run_ddec6 : bool | str = False
+            Whether to run DDEC6 on the charge density. If a string, it's interpreted
+            as the path to the atomic densities directory. Can also be set via the
+            DDEC6_ATOMIC_DENSITIES_DIR environment variable.
         strip_dos_projections
             Whether to strip the element and site projections from the density of
             states. This can help reduce the size of DOS objects in systems with many
@@ -717,7 +719,8 @@ class Calculation(BaseModel):
 
         ddec6 = None
         if run_ddec6 and VaspObject.CHGCAR in output_file_paths:
-            ddec6 = ChargemolAnalysis(path=dir_name).summary
+            densities_path = run_ddec6 if isinstance(run_ddec6, (str, Path)) else None
+            ddec6 = ChargemolAnalysis(path=dir_name, atomic_densities_path=densities_path).summary
 
         locpot = None
         if average_locpot:

--- a/emmet-core/tests/test_calculation.py
+++ b/emmet-core/tests/test_calculation.py
@@ -152,7 +152,7 @@ def test_calculation(test_dir, object_name, task_name):
     assert_schemas_equal(test_doc, valid_doc)
     assert set(objects.keys()) == set(test_object.objects[task_name])
 
-    # check bader and ddec6 keys exist but are None
+    # check bader and ddec6 keys exist
     assert test_doc.bader is None
     assert test_doc.ddec6 is None
 

--- a/emmet-core/tests/test_calculation.py
+++ b/emmet-core/tests/test_calculation.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests.conftest import assert_schemas_equal, get_test_object
 
 
@@ -150,6 +151,10 @@ def test_calculation(test_dir, object_name, task_name):
     valid_doc = test_object.task_doc["calcs_reversed"][0]
     assert_schemas_equal(test_doc, valid_doc)
     assert set(objects.keys()) == set(test_object.objects[task_name])
+
+    # check bader and ddec6 keys exist but are None
+    assert test_doc.bader is None
+    assert test_doc.ddec6 is None
 
     # test document can be jsanitized
     d = jsanitize(test_doc, strict=True, enum_values=True, allow_bson=True)


### PR DESCRIPTION
This PR adds the functionality needed to automatically run a DDEC6 charge analysis after any VASP calculation with `atomate2`. See https://github.com/materialsproject/atomate2/pull/587.

@chiang-yuan Should the doc string contain some instructions on how to set `DDEC6_ATOMIC_DENSITIES_DIR` and where to get those densities?

