### PR TITLE
Fix `TaskDoc.from_directory` when `dir_name != "."`

### DIFF
--- a/emmet-core/emmet/core/tasks.py
+++ b/emmet-core/emmet/core/tasks.py
@@ -951,16 +951,17 @@ def _find_vasp_files(
         vol_files = []
         elph_poscars = []
         for file in files:
+            file_no_path = file.relative_to(path)
             if file.match(f"*vasprun.xml{suffix}*"):
-                vasp_files["vasprun_file"] = file
+                vasp_files["vasprun_file"] = file_no_path
             elif file.match(f"*OUTCAR{suffix}*"):
-                vasp_files["outcar_file"] = file
+                vasp_files["outcar_file"] = file_no_path
             elif file.match(f"*CONTCAR{suffix}*"):
-                vasp_files["contcar_file"] = file
+                vasp_files["contcar_file"] = file_no_path
             elif any(file.match(f"*{f}{suffix}*") for f in volumetric_files):
-                vol_files.append(file)
+                vol_files.append(file_no_path)
             elif file.match(f"*POSCAR.T=*{suffix}*"):
-                elph_poscars.append(file)
+                elph_poscars.append(file_no_path)
 
         if len(vol_files) > 0:
             # add volumetric files if some were found or other vasp files were found

--- a/emmet-core/emmet/core/vasp/calculation.py
+++ b/emmet-core/emmet/core/vasp/calculation.py
@@ -675,9 +675,9 @@ class Calculation(BaseModel):
             A VASP calculation document.
         """
         dir_name = Path(dir_name)
-        vasprun_file = vasprun_file
-        outcar_file = outcar_file
-        contcar_file = contcar_file
+        vasprun_file = dir_name / vasprun_file
+        outcar_file = dir_name / outcar_file
+        contcar_file = dir_name / contcar_file
 
         vasprun_kwargs = vasprun_kwargs if vasprun_kwargs else {}
         volumetric_files = [] if volumetric_files is None else volumetric_files
@@ -688,7 +688,7 @@ class Calculation(BaseModel):
 
         output_file_paths = _get_output_file_paths(volumetric_files)
         vasp_objects: Dict[VaspObject, Any] = _get_volumetric_data(
-            output_file_paths, store_volumetric_data
+            dir_name, output_file_paths, store_volumetric_data
         )
 
         dos = _parse_dos(parse_dos, vasprun)
@@ -714,7 +714,7 @@ class Calculation(BaseModel):
                 locpot = vasp_objects[VaspObject.LOCPOT]  # type: ignore
             elif VaspObject.LOCPOT in output_file_paths:
                 locpot_file = output_file_paths[VaspObject.LOCPOT]  # type: ignore
-                locpot = Locpot.from_file(locpot_file)
+                locpot = Locpot.from_file(dir_name / locpot_file)
 
         input_doc = CalculationInput.from_vasprun(vasprun)
 
@@ -856,6 +856,7 @@ def _get_output_file_paths(volumetric_files: List[str]) -> Dict[VaspObject, str]
 
 
 def _get_volumetric_data(
+    dir_name: Path,
     output_file_paths: Dict[VaspObject, str],
     store_volumetric_data: Optional[Tuple[str]],
 ) -> Dict[VaspObject, VolumetricData]:
@@ -895,7 +896,7 @@ def _get_volumetric_data(
 
         try:
             # assume volumetric data is all in CHGCAR format
-            volumetric_data[file_type] = Chgcar.from_file(file)
+            volumetric_data[file_type] = Chgcar.from_file(dir_name / file)
         except Exception:
             raise ValueError(f"Failed to parse {file_type} at {file}.")
     return volumetric_data

--- a/emmet-core/emmet/core/vasp/calculation.py
+++ b/emmet-core/emmet/core/vasp/calculation.py
@@ -675,9 +675,9 @@ class Calculation(BaseModel):
             A VASP calculation document.
         """
         dir_name = Path(dir_name)
-        vasprun_file = dir_name / vasprun_file
-        outcar_file = dir_name / outcar_file
-        contcar_file = dir_name / contcar_file
+        vasprun_file = vasprun_file
+        outcar_file = outcar_file
+        contcar_file = contcar_file
 
         vasprun_kwargs = vasprun_kwargs if vasprun_kwargs else {}
         volumetric_files = [] if volumetric_files is None else volumetric_files
@@ -688,7 +688,7 @@ class Calculation(BaseModel):
 
         output_file_paths = _get_output_file_paths(volumetric_files)
         vasp_objects: Dict[VaspObject, Any] = _get_volumetric_data(
-            dir_name, output_file_paths, store_volumetric_data
+            output_file_paths, store_volumetric_data
         )
 
         dos = _parse_dos(parse_dos, vasprun)
@@ -714,7 +714,7 @@ class Calculation(BaseModel):
                 locpot = vasp_objects[VaspObject.LOCPOT]  # type: ignore
             elif VaspObject.LOCPOT in output_file_paths:
                 locpot_file = output_file_paths[VaspObject.LOCPOT]  # type: ignore
-                locpot = Locpot.from_file(dir_name / locpot_file)
+                locpot = Locpot.from_file(locpot_file)
 
         input_doc = CalculationInput.from_vasprun(vasprun)
 
@@ -856,7 +856,6 @@ def _get_output_file_paths(volumetric_files: List[str]) -> Dict[VaspObject, str]
 
 
 def _get_volumetric_data(
-    dir_name: Path,
     output_file_paths: Dict[VaspObject, str],
     store_volumetric_data: Optional[Tuple[str]],
 ) -> Dict[VaspObject, VolumetricData]:
@@ -896,7 +895,7 @@ def _get_volumetric_data(
 
         try:
             # assume volumetric data is all in CHGCAR format
-            volumetric_data[file_type] = Chgcar.from_file(dir_name / file)
+            volumetric_data[file_type] = Chgcar.from_file(file)
         except Exception:
             raise ValueError(f"Failed to parse {file_type} at {file}.")
     return volumetric_data


### PR DESCRIPTION
Minor bug with TaskDoc construction when `TaskDoc.from_directory` is called on a directory other than "." (`dir_name` arg).

In `emmet.core.tasks._find_vasp_files`, output files with the leading path are returned. When these files are fed to `emmet.core.vasp.Calculation.from_vasp_files(...)` (for example), `dir_name` will appear *twice*.

Ex: `_find_vasp_files` returns <dir_name>/OUTCAR, which `Calculation.from_vasp_files` turns into <dir_name>/<dir_name>/OUTCAR
