### PR TITLE
Add   `summary_stats` attr to `emmet.core.vasp.calculation.PotcarSpec`

### DIFF
--- a/emmet-core/emmet/core/vasp/calculation.py
+++ b/emmet-core/emmet/core/vasp/calculation.py
@@ -65,8 +65,8 @@ class PotcarSpec(BaseModel):
 
     titel: Optional[str] = Field(None, description="TITEL field from POTCAR header")
     hash: Optional[str] = Field(None, description="md5 hash of POTCAR file")
-    summary_stats: Optional[dict] = Field(None, 
-        description="summary statistics used to ID POTCARs without hashing"
+    summary_stats: Optional[dict] = Field(
+        None, description="summary statistics used to ID POTCARs without hashing"
     )
 
     @classmethod
@@ -84,9 +84,10 @@ class PotcarSpec(BaseModel):
         PotcarSpec
             A potcar spec.
         """
-        return cls(titel=potcar_single.symbol, 
+        return cls(
+            titel=potcar_single.symbol,
             hash=potcar_single.md5_header_hash,
-            summary_stats=potcar_single._summary_stats
+            summary_stats=potcar_single._summary_stats,
         )
 
     @classmethod

--- a/emmet-core/emmet/core/vasp/calculation.py
+++ b/emmet-core/emmet/core/vasp/calculation.py
@@ -65,6 +65,9 @@ class PotcarSpec(BaseModel):
 
     titel: Optional[str] = Field(None, description="TITEL field from POTCAR header")
     hash: Optional[str] = Field(None, description="md5 hash of POTCAR file")
+    summary_stats: Optional[dict] = Field(None, 
+        description="summary statistics used to ID POTCARs without hashing"
+    )
 
     @classmethod
     def from_potcar_single(cls, potcar_single: PotcarSingle) -> "PotcarSpec":
@@ -81,7 +84,10 @@ class PotcarSpec(BaseModel):
         PotcarSpec
             A potcar spec.
         """
-        return cls(titel=potcar_single.symbol, hash=potcar_single.md5_header_hash)
+        return cls(titel=potcar_single.symbol, 
+            hash=potcar_single.md5_header_hash,
+            summary_stats=potcar_single._summary_stats
+        )
 
     @classmethod
     def from_potcar(cls, potcar: Potcar) -> List["PotcarSpec"]:


### PR DESCRIPTION
For consistency with pymatgen, which now includes the ability to validate POTCARs without hashing (see [PMG PR #3351](https://github.com/materialsproject/pymatgen/pull/3351)), added a `summary_stats` attribute to `emmet.core.vasp.calculation.PotcarSpec`.

`summary_stats` is just a dict with structure
```py
self._summary_stats = {
    "keywords": {
        "header": list[str],
        "data": list[str]
    },
    "stats": {
        "header": dict[float],
        "data": dict[float]
    }
}
```

This will help in adding new the POTCAR validation scheme to emmet.
