### PR TITLE
fix custodian import

### DIFF
--- a/emmet-core/emmet/core/tasks.py
+++ b/emmet-core/emmet/core/tasks.py
@@ -222,7 +222,7 @@ class CustodianDoc(BaseModel):
         title="Custodian Corrections",
         description="List of custodian correction data for calculation.",
     )
-    job: Optional[Union[Any]] = Field(
+    job: Optional[Any] = Field(
         None,
         title="Cusotodian Job Data",
         description="Job data logged by custodian.",

--- a/emmet-core/emmet/core/tasks.py
+++ b/emmet-core/emmet/core/tasks.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
-from custodian.vasp.jobs import VaspJob
 import numpy as np
 from monty.json import MontyDecoder
 from monty.serialization import loadfn
@@ -223,7 +222,7 @@ class CustodianDoc(BaseModel):
         title="Custodian Corrections",
         description="List of custodian correction data for calculation.",
     )
-    job: Optional[Union[dict, VaspJob]] = Field(
+    job: Optional[Union[Any]] = Field(
         None,
         title="Cusotodian Job Data",
         description="Job data logged by custodian.",


### PR DESCRIPTION
@munrojm I somehow overlooked that custodian is not installed by emmet... Therefore, importing custodian fails. I would assume we do not want custodian as a dependency just for type checking.

Really sorry! I am currently using the mp-api and it is failing because of my latest change.