### PR TITLE
Improve trajectory handling for MD

### DIFF
--- a/emmet-core/emmet/core/tasks.py
+++ b/emmet-core/emmet/core/tasks.py
@@ -963,6 +963,8 @@ def _find_vasp_files(
                 vol_files.append(file_no_path)
             elif file.match(f"*POSCAR.T=*{suffix}*"):
                 elph_poscars.append(file_no_path)
+            elif file.match(f"*OSZICAR{suffix}*"):
+                vasp_files["oszicar_file"] = file_no_path
 
         if len(vol_files) > 0:
             # add volumetric files if some were found or other vasp files were found


### PR DESCRIPTION
Following what discussed in #872, I have tried to implement an additional option for `store_trajectory` and to add the temperature parsed from the OSZICAR. 

For the temperature, the code will attempt to parse it if `store_trajectory` is not False, but there are different ways of doing this. For example the temperature could have been stored in a different location in the model, or its parsing could have been activated by a new option. I preferred to keep it as minimal as possible and see if there are specific requests for emmet or atomate2 compatibility (@utf and @mjwen).