### PR TITLE
Fix `MLDoc` broken schema

### DIFF
--- a/emmet-core/emmet/core/elasticity.py
+++ b/emmet-core/emmet/core/elasticity.py
@@ -42,7 +42,7 @@ class ComplianceTensorDoc(BaseModel):
 
 class BulkModulus(BaseModel):
     voigt: Optional[float] = Field(None, description="Bulk modulus Voigt average (GPa)")
-    reuss: Optional[float] = Field(None, description="Bulk modulus Reuss average (Gpa)")
+    reuss: Optional[float] = Field(None, description="Bulk modulus Reuss average (GPa)")
     vrh: Optional[float] = Field(
         None, description="Bulk modulus Voigt-Reuss-Hill average (GPa)"
     )

--- a/emmet-core/emmet/core/fermi.py
+++ b/emmet-core/emmet/core/fermi.py
@@ -1,7 +1,8 @@
-from typing import List, Optional
 from datetime import datetime
+from typing import List, Optional
+
 from monty.json import MontyDecoder
-from pydantic import field_validator, BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class FermiDoc(BaseModel):

--- a/emmet-core/emmet/core/ml.py
+++ b/emmet-core/emmet/core/ml.py
@@ -46,9 +46,9 @@ class MLDoc(ElasticityDoc):
         - heat_capacities (list[float]): heat capacities at constant volume in eV/K
     - elasticity
         - elastic_tensor (ElasticTensorDoc): pydantic model from emmet.core.elasticity
-        - shear_modulus (ShearModulus): Voigt-Reuss-Hill shear modulus (single float in GPa)
-        - bulk_modulus (BulkModulus): Voigt-Reuss-Hill bulk modulus (single float in GPa)
-        - youngs_modulus (float): Young's modulus (single float in GPa)
+        - shear_modulus (ShearModulus): Voigt-Reuss-Hill shear modulus (single float in eV/Angstrom^3)
+        - bulk_modulus (BulkModulus): Voigt-Reuss-Hill bulk modulus (single float in eV/Angstrom^3)
+        - youngs_modulus (float): Young's modulus (single float in eV/Angstrom^3)
     """
 
     property_name: str = "ml"


### PR DESCRIPTION
MLDoc tests started failing due to a breaking change to `matcalc.PhononCalc` in https://github.com/materialsvirtuallab/matcalc/commit/cf6251f3727ebc44ff6edb3ba2276d7944b325c2.