### PR TITLE
Handle data license

### DIFF
--- a/emmet-builders/emmet/builders/materials/corrected_entries.py
+++ b/emmet-builders/emmet/builders/materials/corrected_entries.py
@@ -242,7 +242,8 @@ class CorrectedEntriesBuilder(Builder):
 
         materials_docs = list(
             self.materials.query(
-                criteria=new_q, properties=["material_id", "entries", "deprecated"]
+                criteria=new_q,
+                properties=["material_id", "entries", "deprecated", "builder_meta"],
             )
         )
 
@@ -253,7 +254,10 @@ class CorrectedEntriesBuilder(Builder):
             oxi_states_data = {
                 d["material_id"]: d.get("average_oxidation_states", {})
                 for d in self.oxidation_states.query(
-                    properties=["material_id", "average_oxidation_states"],
+                    properties=[
+                        "material_id",
+                        "average_oxidation_states",
+                    ],
                     criteria={
                         "material_id": {"$in": material_ids},
                         "state": "successful",
@@ -272,6 +276,7 @@ class CorrectedEntriesBuilder(Builder):
                     entry_dict["data"]["oxidation_states"] = oxi_states_data.get(
                         entry_dict["data"]["material_id"], {}
                     )
+                    entry_dict["data"]["license"] = doc["builder_meta"].get("license")
                     entry_dict["data"]["run_type"] = r_type
                     elsyms = sorted(set([el for el in entry_dict["composition"]]))
                     self._entries_cache["-".join(elsyms)].append(entry_dict)

--- a/emmet-builders/emmet/builders/materials/oxidation_states.py
+++ b/emmet-builders/emmet/builders/materials/oxidation_states.py
@@ -33,7 +33,7 @@ class OxidationStatesBuilder(MapBuilder):
         super().__init__(
             source=materials,
             target=oxidation_states,
-            projection=["structure", "deprecated"],
+            projection=["structure", "deprecated", "builder_meta"],
             query=query,
             **kwargs,
         )

--- a/emmet-builders/emmet/builders/materials/oxidation_states.py
+++ b/emmet-builders/emmet/builders/materials/oxidation_states.py
@@ -42,9 +42,13 @@ class OxidationStatesBuilder(MapBuilder):
         structure = Structure.from_dict(item["structure"])
         mpid = item["material_id"]
         deprecated = item["deprecated"]
+        builder_meta = item["builder_meta"]
 
         oxi_doc = OxidationStateDoc.from_structure(
-            structure=structure, material_id=mpid, deprecated=deprecated
+            structure=structure,
+            material_id=mpid,
+            deprecated=deprecated,
+            builder_meta=builder_meta,
         )
         doc = jsanitize(oxi_doc.model_dump(), allow_bson=True)
 

--- a/emmet-builders/emmet/builders/settings.py
+++ b/emmet-builders/emmet/builders/settings.py
@@ -30,6 +30,10 @@ class EmmetBuildSettings(EmmetSettings):
         [], description="Tags for calculations to deprecate"
     )
 
+    NON_COMMERCIAL_TAGS: List[str] = Field(
+        [], description="Tages for which to add BY-NC as license data in builder_meta"
+    )
+
     VASP_ALLOWED_VASP_TYPES: List[VaspTaskType] = Field(
         [t.value for t in VaspTaskType],
         description="Allowed task_types to build materials from",

--- a/emmet-builders/emmet/builders/vasp/materials.py
+++ b/emmet-builders/emmet/builders/vasp/materials.py
@@ -241,7 +241,7 @@ class MaterialsBuilder(Builder):
         for group in grouped_tasks:
             commercial_license = True
             for task_doc in group:
-                if set(task_doc["tags"]).intersection(
+                if set(task_doc.tags).intersection(
                     set(self.settings.NON_COMMERCIAL_TAGS)
                 ):
                     commercial_license = False

--- a/emmet-builders/tests/test_chemenv.py
+++ b/emmet-builders/tests/test_chemenv.py
@@ -1,3 +1,4 @@
+from emmet.core.base import EmmetMeta
 import pytest
 from maggma.stores import JSONStore, MemoryStore
 
@@ -14,11 +15,13 @@ def fake_materials(test_dir):
     materials_store.connect()
 
     for doc in entries.query():
+        builder_meta = EmmetMeta(license="BY-C").model_dump()
         materials_store.update(
             {
                 "material_id": doc["entry_id"],
                 "structure": doc["structure"],
                 "deprecated": False,
+                "builder_meta": builder_meta,
             }
         )
     return materials_store

--- a/emmet-builders/tests/test_oxidation.py
+++ b/emmet-builders/tests/test_oxidation.py
@@ -1,6 +1,7 @@
 import pytest
 from maggma.stores import JSONStore, MemoryStore
 
+from emmet.core.base import EmmetMeta
 from emmet.builders.materials.oxidation_states import OxidationStatesBuilder
 
 
@@ -13,12 +14,14 @@ def fake_materials(test_dir):
     materials_store.connect()
 
     for doc in entries.query():
+        builder_meta = EmmetMeta(license="BY-C").model_dump()
         materials_store.update(
             {
                 "material_id": doc["entry_id"],
                 "structure": doc["structure"],
                 "deprecated": False,
-            }
+                "builder_meta": builder_meta,
+            },
         )
     return materials_store
 

--- a/emmet-core/emmet/core/summary.py
+++ b/emmet-core/emmet/core/summary.py
@@ -469,6 +469,7 @@ summary_fields: Dict[str, list] = {
         "structure",
         "deprecated",
         "task_ids",
+        "builder_meta",
     ],
     HasProps.thermo.value: [
         "uncorrected_energy_per_atom",

--- a/emmet-core/emmet/core/thermo.py
+++ b/emmet-core/emmet/core/thermo.py
@@ -2,6 +2,7 @@
 from collections import defaultdict
 from typing import Dict, List, Optional, Union
 from datetime import datetime
+from emmet.core.base import EmmetMeta
 from emmet.core.utils import ValueEnum
 
 from pydantic import BaseModel, Field
@@ -178,6 +179,8 @@ class ThermoDoc(PropertyDoc):
 
             (decomp, ehull) = pd.get_decomp_and_e_above_hull(blessed_entry)
 
+            builder_meta = EmmetMeta(license=blessed_entry.data.get("license"))
+
             d = {
                 "thermo_id": "{}_{}".format(material_id, str(thermo_type)),
                 "material_id": material_id,
@@ -189,6 +192,7 @@ class ThermoDoc(PropertyDoc):
                 "formation_energy_per_atom": pd.get_form_energy_per_atom(blessed_entry),
                 "energy_above_hull": ehull,
                 "is_stable": blessed_entry in pd.stable_entries,
+                "builder_meta": builder_meta.model_dump(),
             }
 
             # Uncomment to make last_updated line up with materials.

--- a/emmet-core/emmet/core/vasp/material.py
+++ b/emmet-core/emmet/core/vasp/material.py
@@ -1,5 +1,6 @@
 """ Core definition of a Materials Document """
 from typing import Dict, List, Mapping, Optional
+from emmet.core.base import EmmetMeta
 
 from pydantic import Field, BaseModel
 from pymatgen.analysis.structure_analyzer import SpacegroupAnalyzer
@@ -55,6 +56,7 @@ class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
             str, int
         ] = SETTINGS.VASP_STRUCTURE_QUALITY_SCORES,
         use_statics: bool = SETTINGS.VASP_USE_STATICS,
+        commercial_license: bool = True,
     ) -> "MaterialsDoc":
         """
         Converts a group of tasks into one material
@@ -63,6 +65,7 @@ class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
             task_group: List of task document
             structure_quality_scores: quality scores for various calculation types
             use_statics: Use statics to define a material
+            commercial_license: Whether the data should be licensed with BY-C (otherwise BY-NC).
         """
         if len(task_group) == 0:
             raise Exception("Must have more than one task in the group.")
@@ -196,6 +199,9 @@ class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
                 "Individual material entry must contain at least one GGA or GGA+U calculation"
             )
 
+        # Builder meta and license
+        builder_meta = EmmetMeta(license="BY-C" if commercial_license else "BY-NC")
+
         return cls.from_structure(
             structure=structure,
             material_id=material_id,
@@ -210,17 +216,21 @@ class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
             deprecated_tasks=deprecated_tasks,
             origins=origins,
             entries=entries,
+            builder_meta=builder_meta,
         )
 
     @classmethod
     def construct_deprecated_material(
-        cls, task_group: List[TaskDocument]
+        cls,
+        task_group: List[TaskDocument],
+        commercial_license: bool = True,
     ) -> "MaterialsDoc":
         """
         Converts a group of tasks into a deprecated material
 
         Args:
             task_group: List of task document
+            commercial_license: Whether the data should be licensed with BY-C (otherwise BY-NC).
         """
         if len(task_group) == 0:
             raise Exception("Must have more than one task in the group.")
@@ -246,6 +256,9 @@ class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
         # Deprecated
         deprecated = True
 
+        # Builder meta and license
+        builder_meta = EmmetMeta(license="BY-C" if commercial_license else "BY-NC")
+
         return cls.from_structure(
             structure=structure,
             material_id=material_id,
@@ -257,4 +270,5 @@ class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
             task_types=task_types,
             deprecated=deprecated,
             deprecated_tasks=deprecated_tasks,
+            builder_meta=builder_meta,
         )

--- a/emmet-core/emmet/core/vasp/task_valid.py
+++ b/emmet-core/emmet/core/vasp/task_valid.py
@@ -67,10 +67,10 @@ class OutputSummary(BaseModel):
     bandgap: Optional[float] = Field(
         None, description="The DFT bandgap for the last calculation"
     )
-    forces: List[Vector3D] = Field(
+    forces: Optional[List[Vector3D]] = Field(
         [], description="Forces on atoms from the last calculation"
     )
-    stress: Matrix3D = Field(
+    stress: Optional[Matrix3D] = Field(
         [], description="Stress on the unitcell from the last calculation"
     )
 


### PR DESCRIPTION
Added ability to handle data license information in `builder_meta` to the `materials`, `corrected_entries`, `thermo`, `oxi_states`, and `summary` builders.