### PR TITLE
Ensure RunType enum variants are case insensitive

### DIFF
--- a/emmet-core/emmet/core/vasp/calc_types/enums.py
+++ b/emmet-core/emmet/core/vasp/calc_types/enums.py
@@ -76,6 +76,12 @@ class RunType(ValueEnum):
     LDA = "LDA"
     LDA_U = "LDA+U"
 
+    @classmethod
+    def _missing_(cls, value):
+        for member in cls:
+            if member.value.upper() == value.upper():
+                return member
+
 
 class TaskType(ValueEnum):
     """VASP calculation task types."""


### PR DESCRIPTION
Allows the `RunType` enum to have case insensitive variants. This fixes a validation bug related to parsing `TaskDoc` data.