### PR TITLE
Transition wildcard chemsys queries to comp reduced

### DIFF
--- a/emmet-api/emmet/api/routes/materials/materials/utils.py
+++ b/emmet-api/emmet/api/routes/materials/materials/utils.py
@@ -128,10 +128,10 @@ def chemsys_to_criteria(chemsys: str) -> Dict:
             eles = chemsys_list[0].split("-")
 
             crit["nelements"] = len(eles)
-            crit["elements"] = {"$all": [ele for ele in eles if ele != "*"]}
 
-            if crit["elements"]["$all"] == []:
-                del crit["elements"]
+            for el in eles:
+                if el != "*":
+                    crit[f"composition_reduced.{el}"] = {"$exists": True}
 
             return crit
     else:

--- a/emmet-api/emmet/api/routes/materials/summary/hint_scheme.py
+++ b/emmet-api/emmet/api/routes/materials/summary/hint_scheme.py
@@ -11,7 +11,6 @@ class SummaryHintScheme(HintScheme):
         hints["agg_hint"] = hints["count_hint"]
 
         if list(query.get("criteria").keys()) != ["deprecated", "builder_meta.license"]:
-
             pure_params = []
             excluded_elements = False
             for param, val in query["criteria"].items():
@@ -20,14 +19,16 @@ class SummaryHintScheme(HintScheme):
                 if pure_param == "composition_reduced" and val == {"$exists": False}:
                     excluded_elements = True
 
-
             if "has_props" in pure_params:
                 hints["count_hint"] = {"has_props.$**": 1}
             elif "composition_reduced" in pure_params and not excluded_elements:
                 hints["count_hint"] = {"composition_reduced.$**": 1}
             else:
                 for param in query["criteria"]:
-                    if param not in ["deprecated", "builder_meta.license"] and "composition_reduced" not in param:
+                    if (
+                        param not in ["deprecated", "builder_meta.license"]
+                        and "composition_reduced" not in param
+                    ):
                         hints["count_hint"] = {
                             "deprecated": 1,
                             "builder_meta.license": 1,

--- a/emmet-api/tests/materials/materials/test_query_operators.py
+++ b/emmet-api/tests/materials/materials/test_query_operators.py
@@ -46,7 +46,7 @@ def test_chemsys_query():
     assert op.query("Si-O") == {"criteria": {"chemsys": "O-Si"}}
 
     assert op.query("Si-*") == {
-        "criteria": {"nelements": 2, "elements": {"$all": ["Si"]}}
+        "criteria": {"nelements": 2, "composition_reduced.Si": True}
     }
 
     with ScratchDir("."):

--- a/emmet-api/tests/materials/materials/test_query_operators.py
+++ b/emmet-api/tests/materials/materials/test_query_operators.py
@@ -46,7 +46,7 @@ def test_chemsys_query():
     assert op.query("Si-O") == {"criteria": {"chemsys": "O-Si"}}
 
     assert op.query("Si-*") == {
-        "criteria": {"nelements": 2, "composition_reduced.Si": True}
+        "criteria": {"nelements": 2, "composition_reduced.Si": {"$exists": True}}
     }
 
     with ScratchDir("."):

--- a/emmet-api/tests/materials/materials/test_utils.py
+++ b/emmet-api/tests/materials/materials/test_utils.py
@@ -31,7 +31,10 @@ def test_formula_to_criteria():
 def test_chemsys_to_criteria():
     # Chemsys
     assert chemsys_to_criteria("Si-O") == {"chemsys": "O-Si"}
-    assert chemsys_to_criteria("Si-*") == {"composition_reduced.Si": True, "nelements": 2}
+    assert chemsys_to_criteria("Si-*") == {
+        "composition_reduced.Si": True,
+        "nelements": 2,
+    }
     assert chemsys_to_criteria("*-*-*") == {"nelements": 3}
 
     assert chemsys_to_criteria("Si-O, P-Li-Fe") == {

--- a/emmet-api/tests/materials/materials/test_utils.py
+++ b/emmet-api/tests/materials/materials/test_utils.py
@@ -31,7 +31,7 @@ def test_formula_to_criteria():
 def test_chemsys_to_criteria():
     # Chemsys
     assert chemsys_to_criteria("Si-O") == {"chemsys": "O-Si"}
-    assert chemsys_to_criteria("Si-*") == {"elements": {"$all": ["Si"]}, "nelements": 2}
+    assert chemsys_to_criteria("Si-*") == {"composition_reduced.Si": True, "nelements": 2}
     assert chemsys_to_criteria("*-*-*") == {"nelements": 3}
 
     assert chemsys_to_criteria("Si-O, P-Li-Fe") == {

--- a/emmet-api/tests/materials/materials/test_utils.py
+++ b/emmet-api/tests/materials/materials/test_utils.py
@@ -32,7 +32,7 @@ def test_chemsys_to_criteria():
     # Chemsys
     assert chemsys_to_criteria("Si-O") == {"chemsys": "O-Si"}
     assert chemsys_to_criteria("Si-*") == {
-        "composition_reduced.Si": True,
+        "composition_reduced.Si": {"$exists": True},
         "nelements": 2,
     }
     assert chemsys_to_criteria("*-*-*") == {"nelements": 3}

--- a/emmet-api/tests/molecules/molecules/test_query_operators.py
+++ b/emmet-api/tests/molecules/molecules/test_query_operators.py
@@ -36,7 +36,7 @@ def test_chemsys_query():
     assert op.query("O-C") == {"criteria": {"chemsys": "C-O"}}
 
     assert op.query("C-*") == {
-        "criteria": {"nelements": 2, "elements": {"$all": ["C"]}}
+        "criteria": {"nelements": 2, "composition_reduced.C": {"$exists": True}}
     }
 
     with ScratchDir("."):


### PR DESCRIPTION
Ensure chemsys queries with `*` do not execute an `$all` query on `elements`