### PR TITLE
Remove 'model_' from ML doc field names

### DIFF
--- a/emmet-core/emmet/core/ml.py
+++ b/emmet-core/emmet/core/ml.py
@@ -58,10 +58,8 @@ class MLDoc(ElasticityDoc):
     matcalc_version: Optional[str] = Field(
         None, description="Version of matcalc used to generate this document"
     )
-    model_name: Optional[str] = Field(
-        None, description="Name of model used as ML potential."
-    )
-    model_version: Optional[str] = Field(
+    name: Optional[str] = Field(None, description="Name of model used as ML potential.")
+    version: Optional[str] = Field(
         None, description="Version of model used as ML potential"
     )
 


### PR DESCRIPTION
The fields `model_name` and `model_version` in the MLDoc clash with the protected namespace `model_` that exists in Pydantic 2. See [here](https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.protected_namespaces), where the warning arises to prevent collisions with `BaseModel`s methods.

 Proposed fix is to change `model_name` and `model_version` to just `name` and `model
