### PR TITLE
Allow ULID for MPIDS

### DIFF
--- a/emmet-builders/emmet/builders/materials/electrodes.py
+++ b/emmet-builders/emmet/builders/materials/electrodes.py
@@ -14,7 +14,7 @@ from pymatgen.entries.compatibility import MaterialsProject2020Compatibility
 from pymatgen.analysis.phase_diagram import PhaseDiagram, Composition
 
 from emmet.core.electrode import InsertionElectrodeDoc, ConversionElectrodeDoc
-from emmet.core.structure_group import StructureGroupDoc, _get_id_num
+from emmet.core.structure_group import StructureGroupDoc, _get_id_lexi
 from emmet.core.utils import jsanitize
 from emmet.builders.settings import EmmetBuildSettings
 
@@ -571,7 +571,7 @@ class ConversionElectrodeBuilder(Builder):
                     for e in pd.entries
                 ]
                 material_ids = list(filter(None, material_ids))
-                lowest_id = min(material_ids, key=_get_id_num)
+                lowest_id = min(material_ids, key=_get_id_lexi)
                 conversion_electrode_doc = (
                     ConversionElectrodeDoc.from_composition_and_pd(
                         comp=v[1],

--- a/emmet-core/emmet/core/mpid.py
+++ b/emmet-core/emmet/core/mpid.py
@@ -14,6 +14,7 @@ mpculeid_regex = re.compile(
     r"^([A-Za-z]+-)?([A-Fa-f0-9]+)-([A-Za-z0-9]+)-(m?[0-9]+)-([0-9]+)$"
 )
 # matches capital letters and numbers of length 26 (ULID)
+# followed by and optional "-(Alphanumeric)"
 check_ulid = re.compile(r"^[A-Z0-9]{26}(-[A-Za-z0-9]+)*$")
 
 

--- a/emmet-core/emmet/core/mpid.py
+++ b/emmet-core/emmet/core/mpid.py
@@ -59,7 +59,7 @@ class MPID(str):
 
         else:
             raise ValueError(
-                "Must provide an MPID, int, or string of the format prefix-number"
+                "Must provide an MPID, int, or string of the format prefix-number or start with a valid ULID."
             )
 
     def __eq__(self, other: object):

--- a/emmet-core/emmet/core/mpid.py
+++ b/emmet-core/emmet/core/mpid.py
@@ -1,3 +1,4 @@
+# %%
 import re
 from typing import Union, Any, Callable
 
@@ -7,10 +8,13 @@ from pydantic import GetJsonSchemaHandler
 from pydantic.json_schema import JsonSchemaValue
 
 
+# matches "mp-1234" or "1234" followed by and optional "-(Alphanumeric)"
 mpid_regex = re.compile(r"^([A-Za-z]*-)?(\d+)(-[A-Za-z0-9]+)*$")
 mpculeid_regex = re.compile(
     r"^([A-Za-z]+-)?([A-Fa-f0-9]+)-([A-Za-z0-9]+)-(m?[0-9]+)-([0-9]+)$"
 )
+# matches capital letters and numbers of length 26 (ULID)
+check_ulid = re.compile(r"^[A-Z0-9]{26}(-[A-Za-z0-9]+)*$")
 
 
 class MPID(str):
@@ -39,9 +43,17 @@ class MPID(str):
             self.string = str(val)
 
         elif isinstance(val, str):
-            parts = val.split("-")
-            parts[1] = int(parts[1])  # type: ignore
-            self.parts = tuple(parts)
+            if mpid_regex.fullmatch(val):
+                parts = val.split("-")
+                parts[1] = int(parts[1])  # type: ignore
+                self.parts = tuple(parts)
+            elif check_ulid.fullmatch(val):
+                ulid = val.split("-")[0]
+                self.parts = (ulid, 0)
+            else:
+                raise ValueError(
+                    "MPID string representation must follow the format prefix-number or start with a valid ULID."
+                )
             self.string = val
 
         else:
@@ -106,10 +118,15 @@ class MPID(str):
             return __input_value
         elif isinstance(__input_value, str) and mpid_regex.fullmatch(__input_value):
             return MPID(__input_value)
+        elif isinstance(__input_value, str) and check_ulid.fullmatch(__input_value):
+            return MPID(__input_value)
         elif isinstance(__input_value, int):
             return MPID(__input_value)
 
         raise ValueError("Invalid MPID Format")
+
+
+# %%
 
 
 class MPculeID(str):

--- a/emmet-core/emmet/core/structure_group.py
+++ b/emmet-core/emmet/core/structure_group.py
@@ -1,6 +1,5 @@
 import logging
 import operator
-import re
 from datetime import datetime
 from itertools import groupby
 from typing import Iterable, List, Optional, Union
@@ -11,6 +10,7 @@ from pymatgen.analysis.structure_matcher import ElementComparator, StructureMatc
 from pymatgen.core.composition import Composition
 from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEntry
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+from emmet.core.mpid import MPID
 
 logger = logging.getLogger(__name__)
 
@@ -282,19 +282,8 @@ def group_entries_with_structure_matcher(
 def _get_id_lexi(task_id) -> Union[int, str]:
     """Get a lexicographic representation for a task ID"""
     # matches "mp-1234" or "1234" followed by and optional "-(Alphanumeric)"
-    mpid_regex = re.compile(r"^([A-Za-z]*-)?(\d+)(-[A-Za-z0-9]+)*$")
-    # matches capital letters and numbers of length 26 (ULID)
-    check_ulid = re.compile(r"^[A-Z0-9]{26}$")
-
-    if isinstance(task_id, int):
-        return task_id
-    if isinstance(task_id, str):
-        if mpid_regex.fullmatch(task_id):
-            return int(task_id.split("-")[-1])
-        elif check_ulid.fullmatch(task_id):
-            return task_id
-    else:
-        raise ValueError("TaskID needs to be either a number or of the form xxx-#####")
+    mpid = MPID(task_id)
+    return mpid.parts
 
 
 def _get_framework(formula, ignored_specie) -> str:

--- a/emmet-core/tests/test_mpid.py
+++ b/emmet-core/tests/test_mpid.py
@@ -1,4 +1,5 @@
 from emmet.core.mpid import MPID, MPculeID
+import pytest
 
 
 def test_mpid():
@@ -26,6 +27,8 @@ def test_mpid():
     MPID(3)
     ulid_mpid = MPID("01HMVV88CCQ6JQ2Y1N8F3ZTVWP-Li")
     assert ulid_mpid.parts == ("01HMVV88CCQ6JQ2Y1N8F3ZTVWP", 0)
+    with pytest.raises(ValueError, match="MPID string representation must follow"):
+        MPID("GGIRADF")
 
 
 def test_mpculeid():

--- a/emmet-core/tests/test_mpid.py
+++ b/emmet-core/tests/test_mpid.py
@@ -24,6 +24,7 @@ def test_mpid():
     )
 
     MPID(3)
+    MPID("01HMVV88CCQ6JQ2Y1N8F3ZTVWP")
 
 
 def test_mpculeid():

--- a/emmet-core/tests/test_mpid.py
+++ b/emmet-core/tests/test_mpid.py
@@ -24,7 +24,8 @@ def test_mpid():
     )
 
     MPID(3)
-    MPID("01HMVV88CCQ6JQ2Y1N8F3ZTVWP")
+    ulid_mpid = MPID("01HMVV88CCQ6JQ2Y1N8F3ZTVWP-Li")
+    assert ulid_mpid.parts == ("01HMVV88CCQ6JQ2Y1N8F3ZTVWP", 0)
 
 
 def test_mpculeid():

--- a/emmet-core/tests/test_structure_group.py
+++ b/emmet-core/tests/test_structure_group.py
@@ -58,6 +58,9 @@ def test_StructureGroupDoc_from_ungrouped_entries(entries_lfeo):
 
 
 def test_lexi_id():
-    assert _get_id_lexi("01HMVV88CCQ6JQ2Y1N8F3ZTVWP") == "01HMVV88CCQ6JQ2Y1N8F3ZTVWP"
-    assert _get_id_lexi("mp-123") == 123
-    assert _get_id_lexi("123") == 123
+    assert _get_id_lexi("01HMVV88CCQ6JQ2Y1N8F3ZTVWP") == (
+        "01HMVV88CCQ6JQ2Y1N8F3ZTVWP",
+        0,
+    )
+    assert _get_id_lexi("mp-123") == ("mp", 123)
+    assert _get_id_lexi("123") == ("", 123)

--- a/emmet-core/tests/test_structure_group.py
+++ b/emmet-core/tests/test_structure_group.py
@@ -2,7 +2,7 @@ import pytest
 from monty.serialization import loadfn
 from pymatgen.core import Composition
 
-from emmet.core.structure_group import StructureGroupDoc
+from emmet.core.structure_group import StructureGroupDoc, _get_id_lexi
 
 
 @pytest.fixture(scope="session")
@@ -55,3 +55,9 @@ def test_StructureGroupDoc_from_ungrouped_entries(entries_lfeo):
                 dd_.pop(ignored)
             framework = Composition.from_dict(dd_).reduced_formula
             assert framework == framework_ref
+
+
+def test_lexi_id():
+    assert _get_id_lexi("01HMVV88CCQ6JQ2Y1N8F3ZTVWP") == "01HMVV88CCQ6JQ2Y1N8F3ZTVWP"
+    assert _get_id_lexi("mp-123") == 123
+    assert _get_id_lexi("123") == 123


### PR DESCRIPTION
Following the discussion here:
https://github.com/materialsproject/jobflow/issues/519

Added support for ULID: Universally Unique Lexicographically Sortable Identifier

The idea is the UUIDs are random and they cannot be sorted for aggregate document creation.
Since atomate2 will call some `emmet.core` documents directly we might not always have a chance to parse the task docs and assign MPIDs to everyone.

This PR does the following:
1. Allows ULID to be used to as MPIDS
2. The `self.parts` used for sorting are `(ULID_ID, 0)` which should enough to help sort the documents.
3. Updated the logic in `StructureGroup` to allow for ULID comparison.