### PR TITLE
Fixed TaskDoc for vasp_ml MD calculations.

### DIFF
--- a/emmet-core/emmet/core/vasp/calculation.py
+++ b/emmet-core/emmet/core/vasp/calculation.py
@@ -801,7 +801,7 @@ class Calculation(BaseModel):
 
         # MD run
         if vasprun.parameters.get("IBRION", -1) == 0:
-            if vasprun.parameters.get("NSW", 0) == vasprun.nionic_steps:
+            if vasprun.parameters.get("NSW", 0) == vasprun.md_n_steps:
                 has_vasp_completed = TaskState.SUCCESS
             else:
                 has_vasp_completed = TaskState.FAILED


### PR DESCRIPTION
This PR solves a problem for calculations with Vasp ML. Indeed, the number of ionic_steps from the vasprun is not taking into account the steps performed with the ML model.

## Contributor Checklist

- [ ] I have run the tests locally and they passed.
- [ ] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR
