### PR TITLE
Add magnetic_moments field to `InputDoc`

### DIFF
--- a/emmet-core/emmet/core/tasks.py
+++ b/emmet-core/emmet/core/tasks.py
@@ -8,17 +8,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
 import numpy as np
-from monty.json import MontyDecoder
-from monty.serialization import loadfn
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
-from pymatgen.analysis.structure_analyzer import oxide_type
-from pymatgen.core.structure import Structure
-from pymatgen.core.trajectory import Trajectory
-from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEntry
-from pymatgen.io.vasp import Incar, Kpoints, Poscar
-from pymatgen.io.vasp import Potcar as VaspPotcar
 from emmet.core.common import convert_datetime
-
 from emmet.core.structure import StructureMetadata
 from emmet.core.vasp.calc_types import CalcType, TaskType
 from emmet.core.vasp.calculation import (
@@ -28,6 +18,15 @@ from emmet.core.vasp.calculation import (
     VaspObject,
 )
 from emmet.core.vasp.task_valid import TaskState
+from monty.json import MontyDecoder
+from monty.serialization import loadfn
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pymatgen.analysis.structure_analyzer import oxide_type
+from pymatgen.core.structure import Structure
+from pymatgen.core.trajectory import Trajectory
+from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEntry
+from pymatgen.io.vasp import Incar, Kpoints, Poscar
+from pymatgen.io.vasp import Potcar as VaspPotcar
 
 monty_decoder = MontyDecoder()
 logger = logging.getLogger(__name__)
@@ -182,6 +181,9 @@ class InputDoc(BaseModel):
         default=False, description="Is this a Hubbard +U calculation"
     )
     hubbards: Optional[dict] = Field(None, description="The hubbard parameters used")
+    magnetic_moments: Optional[List[float]] = Field(
+        None, description="Magnetic moments for each atom"
+    )
 
     @classmethod
     def from_vasp_calc_doc(cls, calc_doc: Calculation) -> "InputDoc":
@@ -210,10 +212,11 @@ class InputDoc(BaseModel):
             parameters=calc_doc.input.parameters,
             pseudo_potentials=pps,
             potcar_spec=calc_doc.input.potcar_spec,
-            is_hubbard=calc_doc.input.is_hubbard,
-            hubbards=calc_doc.input.hubbards,
             xc_override=xc,
             is_lasph=calc_doc.input.parameters.get("LASPH", False),
+            is_hubbard=calc_doc.input.is_hubbard,
+            hubbards=calc_doc.input.hubbards,
+            magnetic_moments=calc_doc.input.parameters.get("MAGMOM"),
         )
 
 


### PR DESCRIPTION
Added a `magnetic_moments` field to the `InputDoc` class. 

This is instantiated from `parameters["MAGMOM"]`.

This is a necessary change to support a common magnetic orderings workflow in atomate2. See discussion in the open PR: https://github.com/materialsproject/atomate2/pull/432 

Tagging @utf 

## Contributor Checklist

- [x] I have run the tests locally and they passed.
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR 
^ (no tests needed here)
