### PR TITLE
Fix hydrogen element injection in anonymous formula queries

### DIFF
--- a/emmet-api/emmet/api/routes/materials/materials/utils.py
+++ b/emmet-api/emmet/api/routes/materials/materials/utils.py
@@ -14,7 +14,7 @@ def formula_to_criteria(formulas: str) -> Dict:
     Returns:
         Mongo style search criteria for this formula
     """
-    dummies = "ADEGJLMQRXZ"
+    dummies = "AEGJLMQRXZ"
 
     formula_list = [formula.strip() for formula in formulas.split(",")]
 

--- a/emmet-api/setup.py
+++ b/emmet-api/setup.py
@@ -22,6 +22,7 @@ setup(
         "shapely",
         "asgi-logger",
         "pymatgen-analysis-alloys>=0.0.3",
+        "pymatgen<=2023.12.18",
     ],
     extras_require={
         "test": [

--- a/emmet-api/setup.py
+++ b/emmet-api/setup.py
@@ -22,7 +22,6 @@ setup(
         "shapely",
         "asgi-logger",
         "pymatgen-analysis-alloys>=0.0.3",
-        "pymatgen<=2023.12.18",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
Pymatgen appears to have a bug (or now treats `D` as deuterium) when using `Composition` with anonymous formulas:

Pre 2024.1.26:
```
comp = Composition("A2D2O7")
comp.reduced_formula => "A2D2O7"
```

Post 2024.1.26:
```
comp = Composition("A2D2O7")
comp.reduced_formula => "A2H2O7"
```