### PR TITLE
bump matminer

### DIFF
--- a/emmet-builders/setup.py
+++ b/emmet-builders/setup.py
@@ -16,7 +16,7 @@ setup(
         "emmet-core[all]",
         "emmet-core[ml]",
         "maggma>=0.57.6",
-        "matminer>=0.7.3",
+        "matminer>=0.9.1",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
latest release of matminer (0.9.1) addresses issue raised by upgrades in pymatgen [matminer issue 920](https://github.com/hackingmaterials/matminer/issues/920). Affected robocrys builder