### PR TITLE
Revive `ValueEnum.as_dict` method

### DIFF
--- a/emmet-core/emmet/core/utils.py
+++ b/emmet-core/emmet/core/utils.py
@@ -311,8 +311,9 @@ class ValueEnum(Enum):
         return hash(str(self))
 
     def as_dict(self) -> str:
-        """ Deserialize in a kludgey way. """
+        """Deserialize in a kludgey way."""
         return self.__str__()
+
 
 class DocEnum(ValueEnum):
     """

--- a/emmet-core/emmet/core/utils.py
+++ b/emmet-core/emmet/core/utils.py
@@ -286,7 +286,13 @@ def jsanitize(obj, strict=False, allow_bson=False):
 
 class ValueEnum(Enum):
     """
-    Enum that serializes to string as the value
+    Enum that serializes to string as the value.
+
+    While this method has an `as_dict` method, this
+    returns a `str`. This is to ensure deserialization
+    to a `str` when functions like `monty.json.jsanitize`
+    are called on a ValueEnum with `strict = True` and
+    `enum_values = False` (occurs often in jobflow).
     """
 
     def __str__(self):
@@ -304,6 +310,9 @@ class ValueEnum(Enum):
         """Get a hash of the enum."""
         return hash(str(self))
 
+    def as_dict(self) -> str:
+        """ Deserialize in a kludgey way. """
+        return self.__str__()
 
 class DocEnum(ValueEnum):
     """

--- a/emmet-core/tests/test_utils.py
+++ b/emmet-core/tests/test_utils.py
@@ -82,8 +82,9 @@ def test_value_enum(monkeypatch, tmp_path):
     assert Path(tmp_path, "temp.json").is_file()
 
     # ensure that as_dict method yields str
-    assert hasattr(TempEnum,"as_dict")
-    assert all(isinstance(val.as_dict(),str) for val in TempEnum)
+    assert hasattr(TempEnum, "as_dict")
+    assert all(isinstance(val.as_dict(), str) for val in TempEnum)
+
 
 def test_doc_enum():
     class TestEnum(DocEnum):

--- a/emmet-core/tests/test_utils.py
+++ b/emmet-core/tests/test_utils.py
@@ -77,9 +77,13 @@ def test_value_enum(monkeypatch, tmp_path):
 
     assert str(TempEnum.A) == "A"
     assert str(TempEnum.B) == "B"
+
     dumpfn(TempEnum, tmp_path / "temp.json")
     assert Path(tmp_path, "temp.json").is_file()
 
+    # ensure that as_dict method yields str
+    assert hasattr(TempEnum,"as_dict")
+    assert all(isinstance(val.as_dict(),str) for val in TempEnum)
 
 def test_doc_enum():
     class TestEnum(DocEnum):


### PR DESCRIPTION
A bug [was reported in atomate2](https://github.com/materialsproject/atomate2/issues/781#issuecomment-2007435512) where during a call to `monty.json.jsanitize` (*specifically* with `strict=True` and `enum_values = False`), an error was thrown during deserialization of `VaspObject` because it lacks an `as_dict` method. I reproduced this with versions of emmet-core > 0.77.1

Since `VaspObject` inherits from `emmet.core.utils.ValueEnum`, and its `as_dict` method was removed in [PR #944](https://github.com/materialsproject/emmet/pull/944), this is the source of the error

**TL;DR**: This PR adds back the kludgey `as_dict -> str` method of `ValueEnum`. Explainer below, ***I think these points merit discussion***:

Discussion / resolution (???):
- @Andrew-S-Rosen has suggested not reviving the `as_dict` method because an `as_dict` should not return a `str` and because the correct deserialization of an `Enum` can occur with changing `enum_values = True` in jsanitize
  - I agree with these points, but this requires a PR in jobflow with many unknown downstream consequences
- Removing the `as_dict` from `ValueEnum` can have many downstream consequences because this method, while a kludge, has existed for a long time. @utf has raised the issue of downstream consequences from removing `as_dict` and I also agree with these
  -  Adding clear documentation to explain what and why this function does on `ValueEnum` should make it clear to users.