### PR TITLE
Use `Literal` type hints for `CrystalSystem`

### DIFF
--- a/emmet-core/emmet/core/symmetry.py
+++ b/emmet-core/emmet/core/symmetry.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal, Optional
 
 from pydantic import BaseModel, Field
 from pymatgen.core import Structure
@@ -102,7 +102,7 @@ class SymmetryData(BaseModel):
     Defines a symmetry data set for materials documents
     """
 
-    crystal_system: Optional[CrystalSystem] = Field(
+    crystal_system: Optional[Literal["Triclinic", "Monoclinic", "Orthorhombic", "Tetragonal", "Trigonal", "Hexagonal", "Cubic"]] = Field(
         None, title="Crystal System", description="The crystal system for this lattice."
     )
 

--- a/emmet-core/emmet/core/symmetry.py
+++ b/emmet-core/emmet/core/symmetry.py
@@ -11,20 +11,6 @@ from emmet.core.utils import ValueEnum
 SETTINGS = EmmetSettings()
 
 
-class CrystalSystem(ValueEnum):
-    """
-    The crystal system of the lattice
-    """
-
-    tri = "Triclinic"
-    mono = "Monoclinic"
-    ortho = "Orthorhombic"
-    tet = "Tetragonal"
-    trig = "Trigonal"
-    hex_ = "Hexagonal"
-    cubic = "Cubic"
-
-
 class PointGroupData(BaseModel):
     """
     Defines symmetry for a molecule document


### PR DESCRIPTION
Switch from using a `ValueEnum` approach for `CrystalSystem` to `Literal` strings. Closes #914.

## Contributor Checklist

- [X] I have broken down my PR scope into the following TODO tasks
   -  [X] task 1
   -  [X] task 2
- [X] I have run the tests locally and they passed.
- [X] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR
