### PR TITLE
move undeform_structure function to core utils

### DIFF
--- a/emmet-builders/emmet/builders/vasp/materials.py
+++ b/emmet-builders/emmet/builders/vasp/materials.py
@@ -6,14 +6,9 @@ from typing import Dict, Iterable, Iterator, List, Optional, Union
 from maggma.builders import Builder
 from maggma.stores import Store
 from maggma.utils import grouper
-from pymatgen.analysis.elasticity.strain import Deformation
-from pymatgen.core.structure import Structure
-from pymatgen.transformations.standard_transformations import (
-    DeformStructureTransformation,
-)
 
 from emmet.builders.settings import EmmetBuildSettings
-from emmet.core.utils import group_structures, jsanitize
+from emmet.core.utils import group_structures, jsanitize, undeform_structure
 from emmet.core.vasp.calc_types import TaskType
 from emmet.core.vasp.material import MaterialsDoc
 from emmet.core.vasp.task_valid import TaskDocument
@@ -343,29 +338,3 @@ class MaterialsBuilder(Builder):
         for group in grouped_structures:
             grouped_tasks = [filtered_tasks[struct.index] for struct in group]  # type: ignore
             yield grouped_tasks
-
-
-def undeform_structure(structure: Structure, transformations: Dict) -> Structure:
-    """
-    Get the undeformed structure by applying the transformations in a reverse order.
-
-    Args:
-        structure: deformed structure
-        transformation: transformation that deforms the structure
-
-    Returns:
-        undeformed structure
-    """
-
-    for transformation in reversed(transformations.get("history", [])):
-        if transformation["@class"] == "DeformStructureTransformation":
-            deform = Deformation(transformation["deformation"])
-            dst = DeformStructureTransformation(deform.inv)
-            structure = dst.apply_transformation(structure)
-        else:
-            raise RuntimeError(
-                "Expect transformation to be `DeformStructureTransformation`; "
-                f"got {transformation['@class']}"
-            )
-
-    return structure

--- a/emmet-core/emmet/core/utils.py
+++ b/emmet-core/emmet/core/utils.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Iterator, List, Optional, Union
 import numpy as np
 from monty.json import MSONable
 from pydantic import BaseModel
+from pymatgen.analysis.elasticity.strain import Deformation
 from pymatgen.analysis.graphs import MoleculeGraph
 from pymatgen.analysis.local_env import OpenBabelNN, metal_edge_extender
 from pymatgen.analysis.molecule_matcher import MoleculeMatcher
@@ -16,6 +17,9 @@ from pymatgen.analysis.structure_matcher import (
     StructureMatcher,
 )
 from pymatgen.core.structure import Molecule, Structure
+from pymatgen.transformations.standard_transformations import (
+    DeformStructureTransformation,
+)
 from pymatgen.util.graph_hashing import weisfeiler_lehman_graph_hash
 
 from emmet.core.mpid import MPculeID
@@ -74,6 +78,32 @@ def group_structures(
     for _, pregroup in groupby(sorted(structures, key=_get_sg), key=_get_sg):
         for group in sm.group_structures(list(pregroup)):
             yield group
+
+
+def undeform_structure(structure: Structure, transformations: Dict) -> Structure:
+    """
+    Get an undeformed structure by applying transformations in a reverse order.
+
+    Args:
+        structure: deformed structure
+        transformation: transformation that deforms the structure
+
+    Returns:
+        undeformed structure
+    """
+
+    for transformation in reversed(transformations.get("history", [])):
+        if transformation["@class"] == "DeformStructureTransformation":
+            deform = Deformation(transformation["deformation"])
+            dst = DeformStructureTransformation(deform.inv)
+            structure = dst.apply_transformation(structure)
+        else:
+            raise RuntimeError(
+                "Expect transformation to be `DeformStructureTransformation`; "
+                f"got {transformation['@class']}"
+            )
+
+    return structure
 
 
 def group_molecules(molecules: List[Molecule]):


### PR DESCRIPTION
Small refactor to move the undeform_structures function out of the materials builder where it was floating outside the builder class as a helper function. 

Moved to emmet-core utils to live with the other util functions.
