### PR TITLE
Change default values in document model for TaskDocument.output.stress/forces

### DIFF
--- a/emmet-core/emmet/core/vasp/task_valid.py
+++ b/emmet-core/emmet/core/vasp/task_valid.py
@@ -68,10 +68,10 @@ class OutputSummary(BaseModel):
         None, description="The DFT bandgap for the last calculation"
     )
     forces: Optional[List[Vector3D]] = Field(
-        [], description="Forces on atoms from the last calculation"
+        None, description="Forces on atoms from the last calculation"
     )
     stress: Optional[Matrix3D] = Field(
-        [], description="Stress on the unitcell from the last calculation"
+        None, description="Stress on the unitcell from the last calculation"
     )
 
 


### PR DESCRIPTION
Pydantic will throw validation errors for older calculations where stress and forces were not calculated. An empty list as the default field causes pydantic to check the empty list for Matrix3D or Vector3D entries, which don't exist.
