### PR TITLE
add default long description text for emmet-core

### DIFF
--- a/emmet-core/setup.py
+++ b/emmet-core/setup.py
@@ -1,4 +1,14 @@
+import os
+
 from setuptools import find_namespace_packages, setup
+
+readme_path = os.path.join(os.path.dirname(__file__), "..", "README.md")
+if os.path.exists(readme_path):
+    with open(readme_path) as f:
+        long_description = f.read()
+else:
+    long_description = "Core Emmet Library"
+
 
 setup(
     name="emmet-core",
@@ -7,7 +17,7 @@ setup(
     description="Core Emmet Library",
     author="The Materials Project",
     author_email="feedback@materialsproject.org",
-    long_description=open("../README.md").read(),  # noqa: SIM115
+    long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/materialsproject/emmet",
     packages=find_namespace_packages(include=["emmet.*"]),


### PR DESCRIPTION
Trying to pip install `emmet-core` in a container (Docker) context will throw the following error:

```
× python setup.py egg_info did not run successfully.
│ exit code: 1
╰─> [7 lines of output]
    Traceback (most recent call last):
      File "<string>", line 2, in <module>
      File "<pip-setuptools-caller>", line 34, in <module>
      File "/tmp/pip-install-hxr58vdl/emmet-core_4bad4006d3d442a6ae60dc59dcf5ac78/setup.py", line 10, in <module>
        long_description=open("../README.md").read(),  # noqa: SIM115
                         ^^^^^^^^^^^^^^^^^^^^
    FileNotFoundError: [Errno 2] No such file or directory: '../README.md'
    [end of output]
```

PR adds some default text for the long_description field to allow container builds to succeed.