### PR TITLE
Refactor Taskdoc.orig_inputs.potcar and bug fix

### DIFF
--- a/emmet-builders/emmet/builders/vasp/task_validator.py
+++ b/emmet-builders/emmet/builders/vasp/task_validator.py
@@ -39,7 +39,7 @@ class TaskValidator(MapBuilder):
         # Set up potcar cache if appropriate
         if self.settings.VASP_VALIDATE_POTCAR_STATS:
             if not self.potcar_stats:
-                self.potcar_stats = get_potcar_stats(strict=False)
+                self.potcar_stats = get_potcar_stats(method="stored")
         else:
             self.potcar_stats = None
 

--- a/emmet-builders/requirements/ubuntu-latest_py3.10_extras.txt
+++ b/emmet-builders/requirements/ubuntu-latest_py3.10_extras.txt
@@ -435,7 +435,7 @@ pygments==2.18.0
     # via
     #   mkdocs-material
     #   rich
-pymatgen==2024.5.1
+pymatgen==2024.4.13
     # via
     #   chgnet
     #   emmet-core

--- a/emmet-builders/requirements/ubuntu-latest_py3.11_extras.txt
+++ b/emmet-builders/requirements/ubuntu-latest_py3.11_extras.txt
@@ -429,7 +429,7 @@ pygments==2.18.0
     # via
     #   mkdocs-material
     #   rich
-pymatgen==2024.5.1
+pymatgen==2024.4.13
     # via
     #   chgnet
     #   emmet-core

--- a/emmet-builders/requirements/ubuntu-latest_py3.9_extras.txt
+++ b/emmet-builders/requirements/ubuntu-latest_py3.9_extras.txt
@@ -447,7 +447,7 @@ pygments==2.18.0
     # via
     #   mkdocs-material
     #   rich
-pymatgen==2024.5.1
+pymatgen==2024.4.13
     # via
     #   chgnet
     #   emmet-core

--- a/emmet-core/emmet/core/tasks.py
+++ b/emmet-core/emmet/core/tasks.py
@@ -86,24 +86,20 @@ class OrigInputs(CalculationBaseModel):
     @field_validator("potcar", mode="before")
     @classmethod
     def potcar_ok(cls, v):
-        """ Check that the POTCAR meets type requirements. """
+        """Check that the POTCAR meets type requirements."""
         if isinstance(v, list):
             return list(v)
         return v
-    
+
     @field_validator("potcar", mode="after")
     @classmethod
     def parse_potcar(cls, v):
-        """ Check that potcar attribute is not a pymatgen POTCAR. """
+        """Check that potcar attribute is not a pymatgen POTCAR."""
         if isinstance(v, VaspPotcar):
             # The user should not mix potential types, but account for that here
             # Using multiple potential types will be caught in validation
             pot_typ = "_".join(set(p.potential_type for p in v))
-            return Potcar(
-                pot_type = pot_typ,
-                functional = v.functional,
-                symbols = v.symbols
-            )
+            return Potcar(pot_type=pot_typ, functional=v.functional, symbols=v.symbols)
         return v
 
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/emmet-core/emmet/core/tasks.py
+++ b/emmet-core/emmet/core/tasks.py
@@ -86,8 +86,24 @@ class OrigInputs(CalculationBaseModel):
     @field_validator("potcar", mode="before")
     @classmethod
     def potcar_ok(cls, v):
+        """ Check that the POTCAR meets type requirements. """
         if isinstance(v, list):
             return list(v)
+        return v
+    
+    @field_validator("potcar", mode="after")
+    @classmethod
+    def _prune_potcar(cls, v):
+        """ Check that potcar attr is not a pymatgen POTCAR. """
+        if isinstance(v, VaspPotcar):
+            # The user should not mix potential types, but account for that here
+            # Using multiple potential types will be caught in validation
+            pot_typ = "_".join(set(p.potential_type for p in v))
+            return Potcar(
+                pot_type = pot_typ,
+                functional = v.functional,
+                symbols = v.symbols
+            )
         return v
 
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/emmet-core/emmet/core/tasks.py
+++ b/emmet-core/emmet/core/tasks.py
@@ -93,8 +93,8 @@ class OrigInputs(CalculationBaseModel):
     
     @field_validator("potcar", mode="after")
     @classmethod
-    def _prune_potcar(cls, v):
-        """ Check that potcar attr is not a pymatgen POTCAR. """
+    def parse_potcar(cls, v):
+        """ Check that potcar attribute is not a pymatgen POTCAR. """
         if isinstance(v, VaspPotcar):
             # The user should not mix potential types, but account for that here
             # Using multiple potential types will be caught in validation


### PR DESCRIPTION
As part of the effort in refining the TaskDoc scheme with @tsmathis, we're restricting the `TaskDoc.orig_inputs.potcar` field to be an `emmet.core.tasks.Potcar` object. The user can still input a serialized pymatgen `Potcar` object to `TaskDoc.orig_inputs.potcar` (no breaking changes), however the `OrigInputs` class will change this to the emmet-core `Potcar` representation.

Also a small bug fix for the builder potcar library caching (wrong kwarg).