### PR TITLE
setup.py fixes to include mp_potcar_stats in emmet-builders package

### DIFF
--- a/emmet-builders/MANIFEST.in
+++ b/emmet-builders/MANIFEST.in
@@ -1,0 +1,1 @@
+include emmet/builders/vasp/mp_potcar_stats.json.gz

--- a/emmet-builders/setup.py
+++ b/emmet-builders/setup.py
@@ -11,7 +11,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/materialsproject/emmet",
     packages=find_namespace_packages(include=["emmet.*"]),
-    package_data={"emmet.builders": ["*.json", "*.json.gz"]},
+    include_package_data=True,
     install_requires=[
         "emmet-core[all]",
         "emmet-core[ml]",


### PR DESCRIPTION
#972 added in `mp_potcar_stats.json.gz` to `emmet-builders/emmet/builders/vasp/` for use in the validation builder to enable validation of task documents without having a POTCAR library established. Due to what I am guessing is a pathing error in the `setup.py` for `emmet-builders`, this file was not being included in the package for `emmet-builders`.

Since there is actually just a single `.json.gz` file that we intend to include, explicitly including the file in `MANIFEST.in` gets us where we want to be.

Only concern is that by including the potcar stats file, the wheel for `emmet-builders` increases by roughly 3.3x (116kb -> 385kb, comparing [pypi](https://pypi.org/project/emmet-builders/#files) vs. [test-pypi](https://test.pypi.org/project/tsmathis-emmet-builders/#files)).

`sdist` size remains the same