### PR TITLE
make ml dependencies optional for emmet-builders

### DIFF
--- a/emmet-builders/setup.py
+++ b/emmet-builders/setup.py
@@ -14,7 +14,6 @@ setup(
     include_package_data=True,
     install_requires=[
         "emmet-core[all]",
-        "emmet-core[ml]",
         "maggma>=0.57.6",
         "matminer>=0.9.1",
     ],
@@ -44,6 +43,7 @@ setup(
             "livereload",
             "jinja2",
         ],
+        "ml": ["emmet-core[ml]"],
     },
     python_requires=">=3.9",
     license="modified BSD",


### PR DESCRIPTION
The cuda toolchain installed with `emmet-core[ml]` is bloating the dependencies of `emmet-builders` currently. The ML builder needs a closer look for how we are going to run it on a regular basis, so it doesn't make sense to drag along all the dependencies at the moment