### PR TITLE
Ensure run, calc, and task types are always refreshed in TaskDoc

### DIFF
--- a/emmet-core/emmet/core/tasks.py
+++ b/emmet-core/emmet/core/tasks.py
@@ -36,7 +36,6 @@ from pydantic import (
     Field,
     field_validator,
     model_validator,
-    PrivateAttr,
 )
 from pymatgen.analysis.structure_analyzer import oxide_type
 from pymatgen.core.structure import Structure
@@ -373,11 +372,10 @@ class TaskDoc(StructureMetadata, extra="allow"):
     run_type: Optional[RunType] = Field(
         None, description="The functional used in the calculation."
     )
-    
+
     calc_type: Optional[CalcType] = Field(
         None, description="The functional and task type used in the calculation."
     )
-
 
     task_id: Optional[Union[MPID, str]] = Field(
         None,
@@ -454,10 +452,9 @@ class TaskDoc(StructureMetadata, extra="allow"):
     # can't find them, throws an AttributeError. It does this before looking to see if the
     # class has that attr defined on it.
 
-    #_structure_entry: Optional[ComputedStructureEntry] = PrivateAttr(None)
+    # _structure_entry: Optional[ComputedStructureEntry] = PrivateAttr(None)
 
     def model_post_init(self, __context: Any) -> None:
-
         # Always refresh task_type, calc_type, run_type
         # See, e.g. https://github.com/materialsproject/emmet/issues/960
         # where run_type's were set incorrectly in older versions of TaskDoc
@@ -729,7 +726,9 @@ class TaskDoc(StructureMetadata, extra="allow"):
         return ComputedEntry.from_dict(entry_dict)
 
     @staticmethod
-    def _get_calc_type(calcs_reversed : list[Calculation], orig_inputs : OrigInputs) -> CalcType:
+    def _get_calc_type(
+        calcs_reversed: list[Calculation], orig_inputs: OrigInputs
+    ) -> CalcType:
         """Get the calc type from calcs_reversed.
 
         Returns
@@ -737,13 +736,17 @@ class TaskDoc(StructureMetadata, extra="allow"):
         CalcType
             The type of calculation.
         """
-        inputs = calcs_reversed[0].input.model_dump() if len(calcs_reversed) > 0 else orig_inputs
+        inputs = (
+            calcs_reversed[0].input.model_dump()
+            if len(calcs_reversed) > 0
+            else orig_inputs
+        )
         params = calcs_reversed[0].input.parameters
         incar = calcs_reversed[0].input.incar
         return calc_type(inputs, {**params, **incar})
 
     @staticmethod
-    def _get_run_type(calcs_reversed : list[Calculation]) -> RunType:
+    def _get_run_type(calcs_reversed: list[Calculation]) -> RunType:
         """Get the run type from calcs_reversed.
 
         Returns
@@ -775,6 +778,7 @@ class TaskDoc(StructureMetadata, extra="allow"):
             data=self.entry.data,
             entry_id=self.entry.entry_id,
         )
+
 
 class TrajectoryDoc(BaseModel):
     """Model for task trajectory data."""


### PR DESCRIPTION
Simple changes to `TaskDoc` structure: during post init, the `run_type`, `task_type` and `calc_type` (union of the previous two) are always updated to ensure that these are consistent with subsequent bug fixes. Previously, these were only updated if `task_type` was `None`.

This change is motivated by [#960](https://github.com/materialsproject/emmet/issues/960), where the `run_type` was incorrectly determined for any non-GGA run and some discussions with @mkhorton. By re-initializing a `TaskDoc` from a dict, these changes would correctly populate the three fields. 

The source of the bug in 960 is separately fixed in [#1026](https://github.com/materialsproject/emmet/pull/1026). This change would also ensure that 1026 also patches fields in legacy TaskDocs