### PR TITLE
conditional check for existence of taskdoc.input.parameters in MaterialsDoc

### DIFF
--- a/emmet-core/emmet/core/vasp/material.py
+++ b/emmet-core/emmet/core/vasp/material.py
@@ -113,7 +113,12 @@ class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
             task_run_type = task.run_type
             _SPECIAL_TAGS = ["LASPH", "ISPIN"]
             special_tags = sum(
-                task.input.parameters.get(tag, False) for tag in _SPECIAL_TAGS
+                (
+                    task.input.parameters.get(tag, False)
+                    if task.input.parameters
+                    else False
+                )
+                for tag in _SPECIAL_TAGS
             )
 
             return (
@@ -165,7 +170,12 @@ class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
 
             _SPECIAL_TAGS = ["LASPH", "ISPIN"]
             special_tags = sum(
-                task.input.parameters.get(tag, False) for tag in _SPECIAL_TAGS
+                (
+                    task.input.parameters.get(tag, False)
+                    if task.input.parameters
+                    else False
+                )
+                for tag in _SPECIAL_TAGS
             )
 
             return (


### PR DESCRIPTION
Encountered some `TaskDoc`s without the presence of an `input.parameters` field, which causes these two comprehensions to fail. Quick fix by adding a ternary