### PR TITLE
MaterialsDoc - add early check for validity of tasks for better error reporting

### DIFF
--- a/emmet-core/emmet/core/vasp/material.py
+++ b/emmet-core/emmet/core/vasp/material.py
@@ -90,6 +90,10 @@ class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
             else structure_optimizations
         )
 
+        validity_check = [doc for doc in structure_calcs if doc.is_valid]
+        if not validity_check:
+            raise ValueError("Group must contain at least one valid task")
+
         # Material ID
         possible_mat_ids = [task.task_id for task in structure_optimizations]
 


### PR DESCRIPTION
The current check for GGA and GGA+U run types in the entries for a material also checks if the tasks are valid.

https://github.com/materialsproject/emmet/blob/257e6639e066e7cfe298a7345b5844928227184c/emmet-core/emmet/core/vasp/material.py#L195

This can result in an empty entries list if all the tasks are invalid with log messages for the builder reading: `"Individual material entry must contain at least one GGA or GGA+U calculation"`. This will also appear in the `warnings` field for the deprecated material.

Finding the root of this error for data validation between builds can be convoluted if the task group does contain GGA/GGA+U run types and the only hint is the current error/log message. Adding an early check for the validity of task docs with an appropriate error message improves clarity.

example materials entry with current error reporting:
```
{
  _id: ObjectId("65304f293e1d94017ba6d1ed"),
  material_id: 'mp-1228539',
  deprecated: true,
  task_ids: [ 'mp-1228539', 'mp-1933576' ],
  calc_types: {
    'mp-1228539': 'GGA+U Structure Optimization',
    'mp-1933576': 'GGA+U Static'
  },
  warnings: [
    'Individual material entry must contain at least one GGA or GGA+U calculation'
  ],
  run_types: { 'mp-1228539': 'GGA+U', 'mp-1933576': 'GGA+U' }
}
```