### PR TITLE
Remove `ValueEnum.as_dict`

### DIFF
--- a/emmet-builders/tests/test_vasp.py
+++ b/emmet-builders/tests/test_vasp.py
@@ -25,4 +25,4 @@ def test_validator(tasks_store, validation_store):
     builder.run()
     assert validation_store.count() == tasks_store.count()
     assert validation_store.count({"valid": True}) == tasks_store.count()
-    assert all(list(d["run_type"] == "GGA" for d in validation_store.query()))
+    assert all(list(d["run_type"] == "GGA" for d in list(validation_store.query())))

--- a/emmet-core/emmet/core/utils.py
+++ b/emmet-core/emmet/core/utils.py
@@ -5,6 +5,8 @@ from itertools import groupby
 from typing import Any, Dict, Iterator, List, Optional, Union
 
 import numpy as np
+from emmet.core.mpid import MPculeID
+from emmet.core.settings import EmmetSettings
 from monty.json import MSONable
 from pydantic import BaseModel
 from pymatgen.analysis.elasticity.strain import Deformation
@@ -21,9 +23,6 @@ from pymatgen.transformations.standard_transformations import (
     DeformStructureTransformation,
 )
 from pymatgen.util.graph_hashing import weisfeiler_lehman_graph_hash
-
-from emmet.core.mpid import MPculeID
-from emmet.core.settings import EmmetSettings
 
 try:
     import bson
@@ -339,10 +338,6 @@ class ValueEnum(Enum):
     def __hash__(self):
         """Get a hash of the enum."""
         return hash(str(self))
-
-    def as_dict(self) -> str:
-        """Deserialize in a kludgey way."""
-        return self.__str__()
 
 
 class DocEnum(ValueEnum):

--- a/emmet-core/tests/test_utils.py
+++ b/emmet-core/tests/test_utils.py
@@ -5,10 +5,9 @@ from pathlib import Path
 import numpy as np
 import pytest
 from bson.objectid import ObjectId
+from emmet.core.utils import DocEnum, ValueEnum, jsanitize
 from monty.json import MSONable
 from monty.serialization import dumpfn
-
-from emmet.core.utils import DocEnum, ValueEnum, jsanitize
 
 
 def test_jsanitize():
@@ -80,10 +79,6 @@ def test_value_enum(monkeypatch, tmp_path):
 
     dumpfn(TempEnum, tmp_path / "temp.json")
     assert Path(tmp_path, "temp.json").is_file()
-
-    # ensure that as_dict method yields str
-    assert hasattr(TempEnum, "as_dict")
-    assert all(isinstance(val.as_dict(), str) for val in TempEnum)
 
 
 def test_doc_enum():


### PR DESCRIPTION
since `ValueEnums` [have out-of-the-box support in `monty.json.MontyEncoder`](https://github.com/materialsvirtuallab/monty/blob/074804827ca438aa3749552b26fd3152f75dd974/src/monty/json.py#L657-L658)

fixes #1050

