### PR TITLE
Further bug fix for legacy task documents with no `calcs_reversed` field

### DIFF
--- a/emmet-core/emmet/core/tasks.py
+++ b/emmet-core/emmet/core/tasks.py
@@ -456,13 +456,17 @@ class TaskDoc(StructureMetadata, extra="allow"):
         # To determine task and run type, we search for input sets in this order
         # of precedence: calcs_reversed, inputs, orig_inputs
         inp_set = None
-        for inp_set in [self.calcs_reversed[0].input, self.input, self.orig_inputs]:
+        inp_sets_to_check = [self.input, self.orig_inputs]
+        if (calcs_reversed := getattr(self,"calcs_reversed", None)) is not None:
+            inp_sets_to_check = [calcs_reversed[0].input] + inp_sets_to_check
+            
+        for inp_set in inp_sets_to_check:
             if inp_set is not None:
                 self.task_type = task_type(inp_set)
                 break
 
         # calcs_reversed needed below
-        if hasattr(self, "calcs_reversed") and self.calcs_reversed:
+        if calcs_reversed is not None:
             self.run_type = self._get_run_type(self.calcs_reversed)
             if inp_set is not None:
                 self.calc_type = self._get_calc_type(self.calcs_reversed, inp_set)

--- a/emmet-core/emmet/core/tasks.py
+++ b/emmet-core/emmet/core/tasks.py
@@ -457,9 +457,9 @@ class TaskDoc(StructureMetadata, extra="allow"):
         # of precedence: calcs_reversed, inputs, orig_inputs
         inp_set = None
         inp_sets_to_check = [self.input, self.orig_inputs]
-        if (calcs_reversed := getattr(self,"calcs_reversed", None)) is not None:
+        if (calcs_reversed := getattr(self, "calcs_reversed", None)) is not None:
             inp_sets_to_check = [calcs_reversed[0].input] + inp_sets_to_check
-            
+
         for inp_set in inp_sets_to_check:
             if inp_set is not None:
                 self.task_type = task_type(inp_set)

--- a/emmet-core/emmet/core/tasks.py
+++ b/emmet-core/emmet/core/tasks.py
@@ -467,13 +467,13 @@ class TaskDoc(StructureMetadata, extra="allow"):
 
         # calcs_reversed needed below
         if calcs_reversed is not None:
-            self.run_type = self._get_run_type(self.calcs_reversed)
+            self.run_type = self._get_run_type(calcs_reversed)
             if inp_set is not None:
-                self.calc_type = self._get_calc_type(self.calcs_reversed, inp_set)
+                self.calc_type = self._get_calc_type(calcs_reversed, inp_set)
 
             # TODO: remove after imposing TaskDoc schema on older tasks in collection
             if self.structure is None:
-                self.structure = self.calcs_reversed[0].output.structure
+                self.structure = calcs_reversed[0].output.structure
 
     # Make sure that the datetime field is properly formatted
     # (Unclear when this is not the case, please leave comment if observed)


### PR DESCRIPTION
Follow up to [#1074](https://github.com/materialsproject/emmet/pull/1074): When the `calcs_reversed` field is `None` in legacy task documents, the `inp_set` search in `TaskDoc.model_post_init` fails because `'NoneType' object is not subscriptable` (there's a call to access `self.calcs_reversed` as a list before it's determined if `calcs_reversed` is not `None`)