### PR TITLE
uvicorn was moved into an optional import in maggma

### DIFF
--- a/emmet-api/setup.py
+++ b/emmet-api/setup.py
@@ -17,7 +17,7 @@ setup(
         "fastapi",
         "gunicorn",
         "boto3",
-        "maggma",
+        "maggma[api]",
         "ddtrace",
         "setproctitle",
         "shapely",


### PR DESCRIPTION
see [here](https://github.com/materialsproject/maggma/commit/5bb459c90dd1629666ba72f8d637c04bd9ff58ed) for changes in maggma, which is causing some tests to fail [here](https://github.com/materialsproject/emmet/actions/runs/10480613487/job/29028572864)

@yang-ruoxi, @tschaume