### PR TITLE
force dynamic enum generation for emmet-core

### DIFF
--- a/emmet-core/emmet/core/qchem/calc_types/__init__.py
+++ b/emmet-core/emmet/core/qchem/calc_types/__init__.py
@@ -1,7 +1,7 @@
-from pathlib import Path
+import importlib
 
 try:
-    import emmet.core.qchem.calc_types.enums
+    importlib.import_module("emmet.core.qchem.calc_types.enums")
 except ImportError:
     import emmet.core.qchem.calc_types.generate
 

--- a/emmet-core/emmet/core/vasp/calc_types/__init__.py
+++ b/emmet-core/emmet/core/vasp/calc_types/__init__.py
@@ -1,7 +1,9 @@
 """Module defining vasp calculation types."""
 
+import importlib
+
 try:
-    import emmet.core.vasp.calc_types.enums
+    importlib.import_module("emmet.core.vasp.calc_types.enums")
 except ImportError:
     import emmet.core.vasp.calc_types.generate
 


### PR DESCRIPTION
adding the explicit call to importlib forces the full module import, and triggers the corresponding exception to autogenerate the enums. 

the static import statement can cause importlib's bootstrapping to fail in environments that only partially initialize the module at startup
