### PR TITLE
make calc type enums IgnoreCase

### DIFF
--- a/emmet-core/dev_scripts/generate_enums.py
+++ b/emmet-core/dev_scripts/generate_enums.py
@@ -1,4 +1,5 @@
 """Module to define various calculation types as Enums for VASP."""
+
 from __future__ import annotations
 from importlib.resources import files as import_resource_files
 from itertools import product
@@ -130,7 +131,11 @@ from emmet.core.utils import ValueEnum, IgnoreCaseEnum
                     enum_name,
                     docstr[enum_name],
                     sorted_enums,
-                    enum_class=("IgnoreCase" if enum_name == "RunType" else "Value")
+                    enum_class=(
+                        "IgnoreCase"
+                        if enum_name in ["RunType", "CalcType"]
+                        else "Value"
+                    )
                     + "Enum",
                 )
             )

--- a/emmet-core/emmet/core/vasp/calc_types/enums.py
+++ b/emmet-core/emmet/core/vasp/calc_types/enums.py
@@ -100,7 +100,7 @@ class TaskType(ValueEnum):
     Unrecognized = "Unrecognized"
 
 
-class CalcType(ValueEnum):
+class CalcType(IgnoreCaseEnum):
     """VASP calculation types."""
 
     AM05_DFPT = "AM05 DFPT"


### PR DESCRIPTION
CalcType Enums should also be IgnoreCase for pydantic validation

- Task types for task docs should be fixed in the future to make IgnoreCase enums no longer needed