### PR TITLE
Change name of interchange_meta -> mol_specs and add structure to MDTaskDocument

### DIFF
--- a/emmet-core/emmet/core/openff/tasks.py
+++ b/emmet-core/emmet/core/openff/tasks.py
@@ -17,6 +17,7 @@ from pydantic import (
 )
 from monty.json import MSONable
 
+from pymatgen.core import Structure
 from emmet.core.vasp.task_valid import TaskState  # type: ignore[import-untyped]
 
 
@@ -83,8 +84,17 @@ class MDTaskDocument(BaseModel, extra="allow"):  # type: ignore[call-arg]
         None, description="An interchange object serialized to json."
     )
 
-    interchange_meta: Optional[list[MoleculeSpec]] = Field(
-        None, description="Molecules within the system."
+    mol_specs: Optional[list[MoleculeSpec]] = Field(
+        None,
+        description="Molecules within the system. Only makes sense "
+        "for molecular systems.",
+    )
+
+    structure: Optional[Structure] = Field(
+        None,
+        title="Structure",
+        description="The final structure for the simulation. Saved only "
+        "if specified by job.",
     )
 
     force_field: Optional[str] = Field(None, description="The classical MD forcefield.")
@@ -103,6 +113,6 @@ class MDTaskDocument(BaseModel, extra="allow"):  # type: ignore[call-arg]
 class ClassicalMDTaskDocument(MDTaskDocument):
     """Definition of the OpenMM task document."""
 
-    interchange_meta: Optional[list[MoleculeSpec]] = Field(
+    mol_specs: Optional[list[MoleculeSpec]] = Field(
         None, description="Molecules within the system."
     )

--- a/emmet-core/emmet/core/openmm/tasks.py
+++ b/emmet-core/emmet/core/openmm/tasks.py
@@ -243,12 +243,6 @@ class OpenMMTaskDocument(MDTaskDocument):
         "task document.",
     )
 
-    interchange_meta: Optional[Union[list[MoleculeSpec], Structure, str]] = Field(
-        None,
-        title="Interchange meta data",
-        description="Metadata for the interchange",
-    )
-
 
 class OpenMMInterchange(BaseModel):
     """An object to sit in the place of the Interchance object


### PR DESCRIPTION
Change name of interchange_meta -> mol_specs and add structure to MDTaskDocument

A small 11th hour renaming. Would love to get this in before the new emmet release @tschaume.