### PR TITLE
update elasticity builder asserts

### DIFF
--- a/emmet-builders/tests/test_elasticity.py
+++ b/emmet-builders/tests/test_elasticity.py
@@ -33,7 +33,7 @@ def test_elasticity_builder(tasks_store, materials_store, elasticity_store):
     builder.run()
 
     assert elasticity_store.count() == 6
-    assert elasticity_store.count({"deprecated": False}) == 6
+    assert elasticity_store.count({"deprecated": False}) == 2
 
 
 def test_serialization(tmpdir):


### PR DESCRIPTION
Following changes in #767 the elasticity builder tests were breaking. Discussion around the changes led to the conclusion that the newly failing docs should in fact be failing. 

Follow up checking of the fully built elasticity data using the updated code will need to be done. 

The test files for the builder should then be updated at that point to reflect the new expectations of the builder output
