### PR TITLE
Improve error handling in `SymmetryData`

### DIFF
--- a/emmet-core/emmet/core/symmetry.py
+++ b/emmet-core/emmet/core/symmetry.py
@@ -3,7 +3,12 @@ from typing import Any, Dict, Optional
 from pydantic import BaseModel, Field
 from pymatgen.core import Structure
 from pymatgen.core.structure import Molecule
-from pymatgen.symmetry.analyzer import PointGroupAnalyzer, SpacegroupAnalyzer, spglib, SymmetryUndeterminedError
+from pymatgen.symmetry.analyzer import (
+    PointGroupAnalyzer,
+    SpacegroupAnalyzer,
+    spglib,
+    SymmetryUndeterminedError,
+)
 
 from emmet.core.settings import EmmetSettings
 from emmet.core.utils import ValueEnum
@@ -145,7 +150,7 @@ class SymmetryData(BaseModel):
     angle_tolerance: Optional[float] = Field(
         None,
         title="Angle Tolerance",
-        description="Angle tolerance provided to spglib to determine the symmetry of this structure."
+        description="Angle tolerance provided to spglib to determine the symmetry of this structure.",
     )
 
     version: Optional[str] = Field(None, title="spglib version")
@@ -162,16 +167,24 @@ class SymmetryData(BaseModel):
             "hall": None,
             "version": spglib.__version__,
             "symprec": SETTINGS.SYMPREC,
-            "angle_tolerance": SETTINGS.ANGLE_TOL
+            "angle_tolerance": SETTINGS.ANGLE_TOL,
         }
 
         try:
-            sg = SpacegroupAnalyzer(structure, symprec=symmetry["symprec"], angle_tolerance=symmetry["angle_tolerance"])
+            sg = SpacegroupAnalyzer(
+                structure,
+                symprec=symmetry["symprec"],
+                angle_tolerance=symmetry["angle_tolerance"],
+            )
         except SymmetryUndeterminedError:
             try:
                 symmetry["symprec"] = 1e-3
                 symmetry["angle_tolerance"] = 1
-                sg = SpacegroupAnalyzer(structure, symprec=symmetry["symprec"], angle_tolerance=symmetry["angle_tolerance"])
+                sg = SpacegroupAnalyzer(
+                    structure,
+                    symprec=symmetry["symprec"],
+                    angle_tolerance=symmetry["angle_tolerance"],
+                )
             except SymmetryUndeterminedError:
                 return SymmetryData(**symmetry)
 

--- a/emmet-core/emmet/core/symmetry.py
+++ b/emmet-core/emmet/core/symmetry.py
@@ -171,7 +171,7 @@ class SymmetryData(BaseModel):
             try:
                 symmetry["symprec"] = 1e-3
                 symmetry["angle_tolerance"] = 1
-                sg = SpacegroupAnalyzer(structure, symmetry["symprec"], 1)
+                sg = SpacegroupAnalyzer(structure, symprec=symmetry["symprec"], angle_tolerance=symmetry["angle_tolerance"])
             except SymmetryUndeterminedError:
                 return SymmetryData(**symmetry)
 

--- a/emmet-core/emmet/core/symmetry.py
+++ b/emmet-core/emmet/core/symmetry.py
@@ -157,7 +157,6 @@ class SymmetryData(BaseModel):
 
     @classmethod
     def from_structure(cls, structure: Structure) -> "SymmetryData":
-
         symmetry: Dict[str, Any] = {
             "source": "spglib",
             "symbol": None,

--- a/emmet-core/emmet/core/symmetry.py
+++ b/emmet-core/emmet/core/symmetry.py
@@ -144,7 +144,7 @@ class SymmetryData(BaseModel):
     symprec: Optional[float] = Field(
         None,
         title="Symmetry Finding Precision",
-        description="The precision provide to spglib to determine the symmetry of this structure.",
+        description="The precision provided to spglib to determine the symmetry of this structure.",
     )
 
     angle_tolerance: Optional[float] = Field(

--- a/emmet-core/setup.py
+++ b/emmet-core/setup.py
@@ -29,7 +29,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "numpy<2",
-        "pymatgen",
+        "pymatgen>=2024.6.10",
         "monty>=2024.2.2",
         "pydantic>=2.0",
         "pydantic-settings>=2.0",


### PR DESCRIPTION
Hi everyone, just a small PR:

The `SymmetryData` model currently has `optional` fields, and therefore can be constructed even if symmetry information is unknown, e.g. if spglib fails.

This PR improves error handling in `.from_structure` to gracefully handle cases where spglib cannot determine the symmetry of a structure. A common use case where this might be encountered is if an otherwise valid `StructureMeta` (or a subclass of `StructureMeta`) is instantiated, but with symmetry information unknown.

The PR also improves handling of `angle_tolerance` to ensure that this is picked up from `EmmetSettings` instead of assuming the default value, and records this alongside `symprec` in the document model. This is also an optional field so as not to break backwards compatibility.

It might be better to make these fields non-optional, but that would be a breaking change and I don't want to suggest it in this PR.
