### PR TITLE
Replace relocated `GrainBoundary` import

### DIFF
--- a/emmet-core/emmet/core/grain_boundary.py
+++ b/emmet-core/emmet/core/grain_boundary.py
@@ -4,7 +4,7 @@ from enum import Enum
 from datetime import datetime
 from emmet.core.common import convert_datetime
 
-from pymatgen.analysis.gb.grain import GrainBoundary
+from pymatgen.core.interface import GrainBoundary
 
 
 class GBTypeEnum(Enum):


### PR DESCRIPTION
Replace relocated `GrainBoundary` import, otherwise getting the following warning:
```
venv/lib/python3.12/site-packages/pymatgen/analysis/gb/grain.py:7
  /Users/yang/developer/api/venv/lib/python3.12/site-packages/pymatgen/analysis/gb/grain.py:7: DeprecationWarning: Grain boundary analysis has been moved to pymatgen.core.interface.This stub is retained for backwards compatibility and will be removed Dec 31 2024.
    warnings.warn(
```