### PR TITLE
Fix for MaterialsBuilder when `TaskDoc.tags` is `None`

### DIFF
--- a/emmet-builders/emmet/builders/vasp/materials.py
+++ b/emmet-builders/emmet/builders/vasp/materials.py
@@ -238,9 +238,11 @@ class MaterialsBuilder(Builder):
         grouped_tasks = self.filter_and_group_tasks(tasks, task_transformations)
         materials = []
         for group in grouped_tasks:
+            # commercial_license = True means that the default CC-BY license is applied
+            # commercial_license = True means that a CC-BY-NC license is applied
             commercial_license = True
             for task_doc in group:
-                if set(task_doc.tags).intersection(
+                if task_dog.tags and set(task_doc.tags).intersection(
                     set(self.settings.NON_COMMERCIAL_TAGS)
                 ):
                     commercial_license = False

--- a/emmet-builders/emmet/builders/vasp/materials.py
+++ b/emmet-builders/emmet/builders/vasp/materials.py
@@ -238,8 +238,8 @@ class MaterialsBuilder(Builder):
         grouped_tasks = self.filter_and_group_tasks(tasks, task_transformations)
         materials = []
         for group in grouped_tasks:
-            # commercial_license = True means that the default CC-BY license is applied
-            # commercial_license = True means that a CC-BY-NC license is applied
+            # commercial_license == True means that the default CC-BY license is applied
+            # commercial_license == False means that a CC-BY-NC license is applied
             commercial_license = True
             for task_doc in group:
                 if task_dog.tags and set(task_doc.tags).intersection(

--- a/emmet-builders/emmet/builders/vasp/materials.py
+++ b/emmet-builders/emmet/builders/vasp/materials.py
@@ -242,7 +242,7 @@ class MaterialsBuilder(Builder):
             # commercial_license == False means that a CC-BY-NC license is applied
             commercial_license = True
             for task_doc in group:
-                if task_dog.tags and set(task_doc.tags).intersection(
+                if task_doc.tags and set(task_doc.tags).intersection(
                     set(self.settings.NON_COMMERCIAL_TAGS)
                 ):
                     commercial_license = False


### PR DESCRIPTION
The schema allows `tags` to be `None` but the materials builder will fail if tags are not specified.

I have added a comment to explain what the `commercial_license` variable means. I think this is correct?