### PR TITLE
Fix TaskDoc.task_type

### DIFF
--- a/emmet-core/emmet/core/vasp/calc_types/utils.py
+++ b/emmet-core/emmet/core/vasp/calc_types/utils.py
@@ -78,7 +78,11 @@ def task_type(
         except Exception as e:
             raise Exception("Couldn't identify total number of kpt labels") from e
 
-        if num_kpt_labels > 0:
+        if num_kpt_labels > 0 or kpts.get("nkpoints", 0) > 0:
+            # calcs_reversed kpoints are read from vasprun.xml, which
+            # removes k-points labels --> check that nkpoints > 0
+            # orig_inputs are read from KPOINTS and retain
+            # user-input labels --> check num_kpt_labels > 0
             calc_type.append("NSCF Line")
         else:
             calc_type.append("NSCF Uniform")


### PR DESCRIPTION
Reopen #1127, had wrong branch. Minor bug where TaskDoc.task_type is incorrectly determined for older NSCF line calcs

In TaskDocument, the orig_inputs are used to determine the task_type. The KPOINTS in orig_inputs retain user-input labels, and the NSCF line check currently only looks for these being non-empty

In TaskDoc, the task_type is determined from calcs_reversed.0.input, failing that, input, and failing that, orig_inputs. Both calcs_reversed.0.input and input read KPOINTS from vasprun.xml, which may have labels removed (may have been an issue with older parsed tasks).
