### PR TITLE
Run CI enum generation on forks outside MP

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
 
       - name: Set up Python
@@ -51,14 +52,14 @@ jobs:
           fi
 
   test:
-    name: ${{ matrix.package }} (${{ matrix.os }}/py${{ matrix.python-version }})
     needs: check-enums
-    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: ["ubuntu-latest"] # TODO openbabel for windows and mac
         package: ["emmet-core", "emmet-builders", "emmet-api"]
         python-version: ["3.10", "3.11"]
+    name: ${{ matrix.package }} (${{ matrix.os }}/py${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -64,6 +64,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
 
       - name: Set up Miniconda


### PR DESCRIPTION
Changing GH workflow to try to get it to run on forks that don't live in `materialsproject/emmet` / fix order of workflow attr assignment