### PR TITLE
Fall back to `JMolNN` if open babel is not installed when generating `MoleculeMetadata`

### DIFF
--- a/emmet-core/emmet/core/utils.py
+++ b/emmet-core/emmet/core/utils.py
@@ -9,7 +9,7 @@ from monty.json import MSONable
 from pydantic import BaseModel
 from pymatgen.analysis.elasticity.strain import Deformation
 from pymatgen.analysis.graphs import MoleculeGraph
-from pymatgen.analysis.local_env import JMolNN, OpenBabelNN, metal_edge_extender
+from pymatgen.analysis.local_env import JmolNN, OpenBabelNN, metal_edge_extender
 from pymatgen.analysis.molecule_matcher import MoleculeMatcher
 from pymatgen.analysis.structure_matcher import (
     AbstractComparator,


### PR DESCRIPTION
Closes #1149.