### PR TITLE
Make species hash and coord hash optional in `MoleculeMetadata`

### DIFF
--- a/emmet-core/emmet/core/structure.py
+++ b/emmet-core/emmet/core/structure.py
@@ -20,6 +20,7 @@ try:
 except Exception:
     openbabel = None
 
+
 class StructureMetadata(EmmetBaseModel):
     """Mix-in class for structure metadata."""
 

--- a/emmet-core/emmet/core/structure.py
+++ b/emmet-core/emmet/core/structure.py
@@ -15,6 +15,10 @@ from emmet.core.symmetry import PointGroupData, SymmetryData
 T = TypeVar("T", bound="StructureMetadata")
 S = TypeVar("S", bound="MoleculeMetadata")
 
+try:
+    from openbabel import openbabel
+except Exception:
+    openbabel = None
 
 class StructureMetadata(EmmetBaseModel):
     """Mix-in class for structure metadata."""
@@ -313,8 +317,9 @@ class MoleculeMetadata(EmmetBaseModel):
             "formula_anonymous": comp.anonymized_formula,
             "chemsys": "-".join(elsyms),
             "symmetry": symmetry,
-            "species_hash": get_graph_hash(meta_molecule, "specie"),
-            "coord_hash": get_graph_hash(meta_molecule, "coords"),
         }
+        if openbabel:
+            data["species_hash"] = get_graph_hash(meta_molecule, "specie")
+            data["coord_hash"] = get_graph_hash(meta_molecule, "coords")
 
         return cls(**{k: v for k, v in data.items() if k in fields}, **kwargs)


### PR DESCRIPTION
This PR closes #1149 by making the species hash and coord hash fields optional in `MoleculeMetadata`, only generating them if OpenBabel is installed. In return, it is possible to generate `MoleculeMetadata` without relying on OpenBabel.

An alternate approach was given in https://github.com/materialsproject/emmet/pull/1150 where I used `JMolNN` as a fallbak option in place of `OpenBabelNN`, but I feel like the current PR is more suitable because it might be difficult to debug a scenario where a change in the environment's dependencies yields a different hash.

To reiterate what I mention in the issue report, the motivation behind this PR is that OpenBabel is a really annoying dependency to require since it is not on PyPI. This means any workflow infrastructure wanting to rely on `MoleculeMetadata` must rely on the user to install OpenBabel from source or Conda unless this PR is merged.