### PR TITLE
Update release workflow to support PEP 625 for source distribution file names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,12 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.11
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools setuptools_scm wheel
+          pip install --upgrade setuptools setuptools_scm wheel
 
       - name: Build packages
         run: python setup.py sdist bdist_wheel


### PR DESCRIPTION
As reported in #1148, our source distribution file names are not compliant with PEP 625, (e.g., `emmet-api-0.84.3rc4.tar.gz` vs `emmet_api-0.84.3rc4.tar.gz`)

Bumping the minimum versions for the build packages rectifies this.

Support for PEP 625 was added to setuptools in [69.4.0](https://pypi.org/project/setuptools/69.4.0/), however that version was yanked, along with a few other version up through 72.0.0, so installing build packages with `--upgrade` explicitly should get us where we want to be.

Uploads to TestPyPi now show the correct name normalization: [test-emmet-core](https://test.pypi.org/project/tsmathis-emmet-core/#files)

Bumping the python version as well while we're here.