### PR TITLE
Update how summary magnetic ordering is determined for electronic structure docs

### DIFF
--- a/emmet-core/emmet/core/electronic_structure.py
+++ b/emmet-core/emmet/core/electronic_structure.py
@@ -460,7 +460,6 @@ class ElectronicStructureDoc(PropertyDoc, ElectronicStructureSummary):
             summary_efermi = bs_entry.setyawan_curtarolo.efermi  # type: ignore
             is_gap_direct = bs_entry.setyawan_curtarolo.is_gap_direct  # type: ignore
             is_metal = bs_entry.setyawan_curtarolo.is_metal  # type: ignore
-            summary_magnetic_ordering = bs_entry.setyawan_curtarolo.magnetic_ordering  # type: ignore
 
             for origin in origins:
                 if origin["name"] == "setyawan_curtarolo":
@@ -473,7 +472,6 @@ class ElectronicStructureDoc(PropertyDoc, ElectronicStructureSummary):
             summary_cbm = dos_cbm
             summary_vbm = dos_vbm
             summary_efermi = dos_efermi
-            summary_magnetic_ordering = dos_mag_ordering
             is_metal = True if np.isclose(dos_gap, 0.0, atol=0.01, rtol=0) else False
 
             for origin in origins:
@@ -487,10 +485,16 @@ class ElectronicStructureDoc(PropertyDoc, ElectronicStructureSummary):
                     origin["last_updated"] = new_origin_last_updated
                     origin["task_id"] = new_origin_task_id
 
+        summary_magnetic_ordering = CollinearMagneticStructureAnalyzer(
+            kwargs["meta_structure"],
+            round_magmoms=True,
+            threshold_nonmag=0.2,
+            threshold=0,
+        ).ordering
+
         return cls.from_structure(
             material_id=MPID(material_id),
             task_id=summary_task,
-            meta_structure=structure,
             band_gap=summary_band_gap,
             cbm=summary_cbm,
             vbm=summary_vbm,

--- a/emmet-core/tests/test_electronic_structure.py
+++ b/emmet-core/tests/test_electronic_structure.py
@@ -40,6 +40,7 @@ def test_from_bsdos_1(bandstructure, dos, structure):
         deprecated=False,
         setyawan_curtarolo={"mp-1056141": bandstructure},
         structures={"mp-1671247": structure, "mp-1056141": structure},
+        meta_structure=structure,
     )
 
     assert str(es_doc.material_id) == "mp-13"
@@ -80,6 +81,7 @@ def test_from_bsdos_2(bandstructure_fs, dos_fs):
         is_metal=True,
         deprecated=False,
         setyawan_curtarolo={"mp-1612487": bs},
+        meta_structure=dos.structure,
     )
 
     assert str(es_doc.material_id) == "mp-25375"


### PR DESCRIPTION
determining the magnetic ordering for an electronic structure doc using the structures from either the bandstructure or dos task documents has been causing a discrepancy between the magnetic ordering determined by the magnetism builder, which uses the structure from the blessed task for a material to determine magnetic ordering.

callers of the `from_bsdos` function should pass the blessed structure for the material explicitly through the `meta_strucutre` kwarg