### PR TITLE
XASDoc update concurrent with pymatgen update

### DIFF
--- a/emmet-core/emmet/core/xas.py
+++ b/emmet-core/emmet/core/xas.py
@@ -70,15 +70,8 @@ class XASDoc(SpectrumDoc):
     @classmethod
     def check_spectrum_non_positive_values(cls, v, eps=1.0e-12) -> XAS:
         if isinstance(v, dict):
-            try:
-                v = XAS.from_dict(v)
-            except ValueError as exc:
-                if (
-                    "Double check the intensities. Most of them are non-positive."
-                    in str(exc)
-                ):
-                    v["y"] = [y if y > 0.0 else abs(eps) for y in v["y"]]
-                    v = XAS.from_dict(v)
+            v["y"] = [y if y > 0.0 else abs(eps) for y in v["y"]]
+            v = XAS.from_dict(v)
         return v
 
     @classmethod


### PR DESCRIPTION
Very minor fix related to the `XASDoc` - previously we relied on the `XAS` class in pymatgen to fail to construct when too many non-positive frequencies were passed in. Now that an exception is no longer thrown, the document model just needs to patch non-positive frequencies on the fly.