### PR TITLE
update composition stub model to use RootModel

### DIFF
--- a/emmet-core/emmet/core/stubs.py
+++ b/emmet-core/emmet/core/stubs.py
@@ -7,7 +7,7 @@ outside the standard MSONable model
 from typing import Dict
 
 import pymatgen.core.composition
-from pydantic import BaseModel
+from pydantic import RootModel
 from pymatgen.core.periodic_table import Element
 
 """
@@ -17,10 +17,10 @@ in as Stubbed classes to prevent name clashing
 """
 
 
-class StubComposition(BaseModel):
+class StubComposition(RootModel):
     """A dictionary mapping element to total quantity"""
 
-    __root__: Dict[Element, float]
+    root: Dict[Element, float]
 
 
 @classmethod  # type: ignore


### PR DESCRIPTION
overlooked in pydantic v2 transition
 
`BaseModel` plus `__root__` field should instead be just `RootModel` with `root` field.
raises: ```raise TypeError("To define root models, use `pydantic.RootModel` rather than a field called '__root__'")```

Per: [changes to base model](https://docs.pydantic.dev/latest/migration/#changes-to-pydanticbasemodel)
