### PR TITLE
Resolve mypy issues in emmet-api

### DIFF
--- a/emmet-api/emmet/api/routes/materials/materials/query_operators.py
+++ b/emmet-api/emmet/api/routes/materials/materials/query_operators.py
@@ -409,12 +409,16 @@ class FormulaAutoCompleteQuery(QueryOperator):
             comp_red = comp.reduced_composition.items()
 
             for i, j in comp_red:
+                # The keys of pymatgen's Composition can be Element, Species, or DummySpecies
+                # Element and Species both have a name attr, DummySpecies doesn't by default
+                # This bothers mypy a lot, so we placate it here - all three have __str__ methods:
+                spec_name = str(getattr(i, "name", None) or i)
                 if j != 1:
-                    ind_str.append(i.name + str(int(j)))
+                    ind_str.append(spec_name + str(int(j)))
                 else:
-                    ind_str.append(i.name)
+                    ind_str.append(spec_name)
 
-                eles.append(i.name)
+                eles.append(spec_name)
 
         final_terms = ["".join(entry) for entry in permutations(ind_str)]
 

--- a/emmet-api/requirements/deployment.txt
+++ b/emmet-api/requirements/deployment.txt
@@ -186,7 +186,7 @@ pydantic-settings==2.7.1
     #   maggma
 pydash==8.0.5
     # via maggma
-pymatgen==2025.1.24
+pymatgen==2024.11.13
     # via
     #   emmet-core
     #   mp-pyrho

--- a/emmet-api/requirements/ubuntu-latest_py3.10.txt
+++ b/emmet-api/requirements/ubuntu-latest_py3.10.txt
@@ -184,7 +184,7 @@ pydantic-settings==2.7.1
     #   maggma
 pydash==8.0.5
     # via maggma
-pymatgen==2025.1.24
+pymatgen==2024.11.13
     # via
     #   emmet-core
     #   mp-pyrho

--- a/emmet-api/requirements/ubuntu-latest_py3.10_extras.txt
+++ b/emmet-api/requirements/ubuntu-latest_py3.10_extras.txt
@@ -310,7 +310,7 @@ pyflakes==3.2.0
     # via flake8
 pygments==2.19.1
     # via mkdocs-material
-pymatgen==2025.1.24
+pymatgen==2024.11.13
     # via
     #   emmet-core
     #   mp-pyrho

--- a/emmet-api/requirements/ubuntu-latest_py3.11.txt
+++ b/emmet-api/requirements/ubuntu-latest_py3.11.txt
@@ -182,7 +182,7 @@ pydantic-settings==2.7.1
     #   maggma
 pydash==8.0.5
     # via maggma
-pymatgen==2025.1.24
+pymatgen==2024.11.13
     # via
     #   emmet-core
     #   mp-pyrho

--- a/emmet-api/requirements/ubuntu-latest_py3.11_extras.txt
+++ b/emmet-api/requirements/ubuntu-latest_py3.11_extras.txt
@@ -306,7 +306,7 @@ pyflakes==3.2.0
     # via flake8
 pygments==2.19.1
     # via mkdocs-material
-pymatgen==2025.1.24
+pymatgen==2024.11.13
     # via
     #   emmet-core
     #   mp-pyrho

--- a/emmet-builders/requirements/ubuntu-latest_py3.10.txt
+++ b/emmet-builders/requirements/ubuntu-latest_py3.10.txt
@@ -250,7 +250,7 @@ pydantic-settings==2.7.1
     #   maggma
 pydash==8.0.5
     # via maggma
-pymatgen==2025.1.24
+pymatgen==2024.11.13
     # via
     #   emmet-core
     #   matcalc

--- a/emmet-builders/requirements/ubuntu-latest_py3.10_extras.txt
+++ b/emmet-builders/requirements/ubuntu-latest_py3.10_extras.txt
@@ -469,7 +469,7 @@ pyflakes==3.2.0
     # via flake8
 pygments==2.19.1
     # via mkdocs-material
-pymatgen==2025.1.24
+pymatgen==2024.11.13
     # via
     #   chgnet
     #   emmet-core

--- a/emmet-builders/requirements/ubuntu-latest_py3.11.txt
+++ b/emmet-builders/requirements/ubuntu-latest_py3.11.txt
@@ -248,7 +248,7 @@ pydantic-settings==2.7.1
     #   maggma
 pydash==8.0.5
     # via maggma
-pymatgen==2025.1.24
+pymatgen==2024.11.13
     # via
     #   emmet-core
     #   matcalc

--- a/emmet-builders/requirements/ubuntu-latest_py3.11_extras.txt
+++ b/emmet-builders/requirements/ubuntu-latest_py3.11_extras.txt
@@ -465,7 +465,7 @@ pyflakes==3.2.0
     # via flake8
 pygments==2.19.1
     # via mkdocs-material
-pymatgen==2025.1.24
+pymatgen==2024.11.13
     # via
     #   chgnet
     #   emmet-core

--- a/emmet-core/requirements/deployment.txt
+++ b/emmet-core/requirements/deployment.txt
@@ -73,7 +73,7 @@ pydantic-core==2.27.2
     # via pydantic
 pydantic-settings==2.7.1
     # via emmet-core (emmet/emmet-core/setup.py)
-pymatgen==2025.1.24
+pymatgen==2024.11.13
     # via emmet-core (emmet/emmet-core/setup.py)
 pyparsing==3.2.1
     # via matplotlib

--- a/emmet-core/requirements/ubuntu-latest_py3.10.txt
+++ b/emmet-core/requirements/ubuntu-latest_py3.10.txt
@@ -68,7 +68,7 @@ pydantic-core==2.27.2
     # via pydantic
 pydantic-settings==2.7.1
     # via emmet-core (setup.py)
-pymatgen==2025.1.24
+pymatgen==2024.11.13
     # via emmet-core (setup.py)
 pyparsing==3.2.1
     # via matplotlib

--- a/emmet-core/requirements/ubuntu-latest_py3.10_extras.txt
+++ b/emmet-core/requirements/ubuntu-latest_py3.10_extras.txt
@@ -470,7 +470,7 @@ pyflakes==3.2.0
     # via flake8
 pygments==2.19.1
     # via mkdocs-material
-pymatgen==2025.1.24
+pymatgen==2024.11.13
     # via
     #   chgnet
     #   emmet-core

--- a/emmet-core/requirements/ubuntu-latest_py3.11.txt
+++ b/emmet-core/requirements/ubuntu-latest_py3.11.txt
@@ -68,7 +68,7 @@ pydantic-core==2.27.2
     # via pydantic
 pydantic-settings==2.7.1
     # via emmet-core (setup.py)
-pymatgen==2025.1.24
+pymatgen==2024.11.13
     # via emmet-core (setup.py)
 pyparsing==3.2.1
     # via matplotlib

--- a/emmet-core/requirements/ubuntu-latest_py3.11_extras.txt
+++ b/emmet-core/requirements/ubuntu-latest_py3.11_extras.txt
@@ -466,7 +466,7 @@ pyflakes==3.2.0
     # via flake8
 pygments==2.19.1
     # via mkdocs-material
-pymatgen==2025.1.24
+pymatgen==2024.11.13
     # via
     #   chgnet
     #   emmet-core


### PR DESCRIPTION
Fixing mypy issues in `emmet-api` related to the fact that pymatgen's `Composition` can take `Element`, `Species`, and `DummySpecies` as keys, and only the former two have a `name` attr that is a `str`