### PR TITLE
allow BlessedCalcs model to be populated by name

### DIFF
--- a/emmet-core/emmet/core/vasp/material.py
+++ b/emmet-core/emmet/core/vasp/material.py
@@ -18,7 +18,7 @@ from emmet.core.vasp.calc_types import CalcType, RunType, TaskType
 SETTINGS = EmmetSettings()
 
 
-class BlessedCalcs(BaseModel):
+class BlessedCalcs(BaseModel, populate_by_name=True):
     GGA: Optional[ComputedStructureEntry] = None
     GGA_U: Optional[ComputedStructureEntry] = Field(None, alias="GGA+U")
     PBESol: Optional[ComputedStructureEntry] = Field(None, alias="PBEsol")


### PR DESCRIPTION
The behavior of pydantic's `alias` kwarg for `Field`s prevents model population using the original field name by default: [link](https://docs.pydantic.dev/2.10/api/config/#pydantic.config.ConfigDict.populate_by_name) 

This default behavior prevents serialization of documents with fields that match the actual field name, _and only accepts the alias_, i.e, 
`entries: {"GGA": None, "GGA_U": valid_entry, "SCAN": None, ... }` would serialize to 
`BlessedCalcs(GGA=None, GGA_U=None, SCAN=None, ...)` 
while 
`entries: {"GGA": None, "GGA+U": valid_entry, "SCAN": None, ... }` would serialize to 
`BlessedCalcs(GGA=None, GGA_U=valid_entry, SCAN=None, ...)`

For the api, this results in a query like `mpr.materials.search(material_ids=[id_list], fields["entries"])` to only return documents with `GGA`, `SCAN`, and `HSE` populated in the results

The `populate_by_name` attr allows both the field name and alias to be used for model population.