### PR TITLE
Revert elasticity changes introduced in PR #767

### DIFF
--- a/emmet-builders/tests/test_elasticity.py
+++ b/emmet-builders/tests/test_elasticity.py
@@ -33,7 +33,7 @@ def test_elasticity_builder(tasks_store, materials_store, elasticity_store):
     builder.run()
 
     assert elasticity_store.count() == 6
-    assert elasticity_store.count({"deprecated": False}) == 2
+    assert elasticity_store.count({"deprecated": False}) == 6
 
 
 def test_serialization(tmpdir):

--- a/emmet-core/emmet/core/elasticity.py
+++ b/emmet-core/emmet/core/elasticity.py
@@ -426,9 +426,19 @@ def generate_derived_fitting_data(
     Get the derived fitting data from symmetry operations on the primary fitting data.
 
     It can happen that multiple primary deformations can be mapped to the same derived
-    deformation from different symmetry operations. In such cases, the stress for a
-    derived deformation is the average of all derived stresses, each corresponding to a
-    primary calculation. In doing so, we also check to ensure that:
+    deformation from different symmetry operations. Ideally, this cannot happen if one
+    use the same structure to determine all the symmetry operations.
+
+    However, this is not the case in atomate, where the deformation tasks are determined
+    based on the symmetry of the structure before the tight relaxation, which in this
+    function the structure is the relaxed structure. The symmetries can be different.
+
+    In atomate2, this is not a problem, because the deformation tasks are determined
+    based on the relaxed structure.
+
+    To make it work for all cases, the stress for a derived deformation is the average
+    of all derived stresses, each corresponding to a primary calculation.
+    In doing so, we also check to ensure that:
     1. only independent derived deformations are used
     2. for a specific derived strain, a primary deformation is only used (mapped)
        once to obtain the average


### PR DESCRIPTION
#767 removed a check on deformation tasks that was deemed unnecessary. 

This removal was based on the impression that the input for the elasticity builder would only have tasks related to elastic calculations, this however is not the current behavior due to the aggregation of tasks by the materials builder, so this check on the deformation matrix is needed. 



