### PR TITLE
Make task resource use atlas search

### DIFF
--- a/emmet-api/emmet/api/routes/materials/materials/query_operators.py
+++ b/emmet-api/emmet/api/routes/materials/materials/query_operators.py
@@ -62,6 +62,7 @@ Wildcards for unknown elements only supported for single chemsys queries",
         if chemsys:
             crit.update(chemsys_to_criteria(chemsys))
 
+        print("chemsys query", crit)
         return {"criteria": crit}
 
     def ensure_indexes(self):  # pragma: no cover

--- a/emmet-api/emmet/api/routes/materials/tasks/query_operators.py
+++ b/emmet-api/emmet/api/routes/materials/tasks/query_operators.py
@@ -11,8 +11,7 @@ from fastapi import Query
 from typing import Optional
 from monty.json import jsanitize
 
-FACETS_PARAMS = {"facets":    
-                     {
+FACETS_PARAMS ={
                         "calc_typeFacet": {
                             "type": "string",
                             "path": "calc_type",
@@ -21,8 +20,11 @@ FACETS_PARAMS = {"facets":
                             "type": "string",
                             "path": "task_type",
                         },
-                    }
-}
+                        "run_typeFacet": {
+                            "type": "string",
+                            "path": "run_type",
+                        },
+                }
 class LastUpdatedQuery(QueryOperator):
     def query(
         self,
@@ -249,8 +251,7 @@ class TaskFormulaQuery(QueryOperator):
                         }
                     }
 
-        return {"criteria": crit, 
-                **FACETS_PARAMS
+        return {"criteria": crit
         }
 
 class TaskChemsysQuery(QueryOperator):
@@ -265,8 +266,7 @@ class TaskChemsysQuery(QueryOperator):
         if chemsys:
             crit = chemsys_to_search(chemsys)
 
-        return {"criteria": crit,
-                **FACETS_PARAMS
+        return {"criteria": crit
         }
 
 class TaskTypeQuery(QueryOperator):
@@ -285,8 +285,7 @@ class TaskTypeQuery(QueryOperator):
                     "value": task_type
                 }
             }
-        return {"criteria": crit,
-                **FACETS_PARAMS
+        return {"criteria": crit
         }
 
 class CalcTypeQuery(QueryOperator):
@@ -305,8 +304,7 @@ class CalcTypeQuery(QueryOperator):
                     "value": calc_type,
                 }
             } 
-        return {"criteria": crit,
-                **FACETS_PARAMS
+        return {"criteria": crit
         }
     
 class RunTypeQuery(QueryOperator):
@@ -325,7 +323,30 @@ class RunTypeQuery(QueryOperator):
                     "value": run_type
                 }
             } 
-        return {"criteria": crit,
-                **FACETS_PARAMS
+        return {"criteria": crit
         }
     
+class FacetQuery(QueryOperator):
+    def query(
+        self,
+        facets: Optional[str] = Query(
+            None, description="Facets query to return facets meta information"
+        ),
+    ) -> STORE_PARAMS:
+        facets = {
+        }
+        if facets:
+            facets_list = [facet.strip() for facet in facets.split(",")] 
+            for f in facets_list:
+                facets.update(
+                    {
+                        f"{f}Facet": {
+                            "type": "string",
+                            "path": f,
+                        }
+                    }
+                )
+        else:
+            facets = {**FACETS_PARAMS}
+        return {"facets": facets}
+        

--- a/emmet-api/emmet/api/routes/materials/tasks/query_operators.py
+++ b/emmet-api/emmet/api/routes/materials/tasks/query_operators.py
@@ -35,13 +35,14 @@ class LastUpdatedQuery(QueryOperator):
             None, description="Maximum last updated UTC datetime"
         ),
     ) -> STORE_PARAMS:
-        crit: dict = defaultdict(dict)
+        crit = {}
 
-        if last_updated_min:
-            crit["last_updated"]["$gte"] = last_updated_min
-
-        if last_updated_max:
-            crit["last_updated"]["$lte"] = last_updated_max
+        if last_updated_min or last_updated_max:
+            crit["range"] = {"path" : "last_updated"}
+            if last_updated_min:
+                crit["range"]["gte"] = last_updated_min
+            if last_updated_max:
+                crit["range"]["lte"] = last_updated_max
 
         return {"criteria": crit}
 

--- a/emmet-api/emmet/api/routes/materials/tasks/query_operators.py
+++ b/emmet-api/emmet/api/routes/materials/tasks/query_operators.py
@@ -69,17 +69,6 @@ class MultipleTaskIDsQuery(QueryOperator):
                 }
 
         return {"criteria": crit, 
-                "facets":    
-                     {
-                        "calc_typeFacet": {
-                            "type": "string",
-                            "path": "calc_type",
-                        },
-                        "task_typeFacet": {
-                            "type": "string",
-                            "path": "task_type",
-                        },
-                    }
         }
 
     def post_process(self, docs, query):
@@ -325,7 +314,26 @@ class RunTypeQuery(QueryOperator):
             } 
         return {"criteria": crit
         }
-    
+class BatchQuery(QueryOperator):
+    def query(
+        self,
+        batches: Optional[str] = Query(
+            None, description="Comma-separated list of batch ids to query on"
+        ),
+    ) -> STORE_PARAMS:
+        crit = {
+        }
+        if batches:
+            batch_list = [b.strip() for b in batches.split(",")]
+            crit = {
+                "in": {
+                    "path": "batch_id",
+                    "value": batch_list
+                }
+            } 
+        return {"criteria": crit
+        }
+
 class FacetQuery(QueryOperator):
     def query(
         self,
@@ -333,12 +341,12 @@ class FacetQuery(QueryOperator):
             None, description="Facets query to return facets meta information"
         ),
     ) -> STORE_PARAMS:
-        facets = {
+        crit = {
         }
         if facets:
-            facets_list = [facet.strip() for facet in facets.split(",")] 
+            facets_list = [facet.strip() for facet in facets.split(",")]
             for f in facets_list:
-                facets.update(
+                crit.update(
                     {
                         f"{f}Facet": {
                             "type": "string",
@@ -347,6 +355,6 @@ class FacetQuery(QueryOperator):
                     }
                 )
         else:
-            facets = {**FACETS_PARAMS}
-        return {"facets": facets}
+            crit = {**FACETS_PARAMS}
+        return {"facets": crit}
         

--- a/emmet-api/emmet/api/routes/materials/tasks/query_operators.py
+++ b/emmet-api/emmet/api/routes/materials/tasks/query_operators.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from collections import defaultdict
 from maggma.api.query_operator import QueryOperator
 from maggma.api.utils import STORE_PARAMS
 from emmet.api.routes.materials.tasks.utils import (
@@ -13,20 +12,22 @@ from fastapi import Query, HTTPException
 from typing import Optional
 from monty.json import jsanitize
 
-FACETS_PARAMS ={
-                        "calc_typeFacet": {
-                            "type": "string",
-                            "path": "calc_type",
-                        },
-                        "task_typeFacet": {
-                            "type": "string",
-                            "path": "task_type",
-                        },
-                        "run_typeFacet": {
-                            "type": "string",
-                            "path": "run_type",
-                        },
-                }
+FACETS_PARAMS = {
+    "calc_typeFacet": {
+        "type": "string",
+        "path": "calc_type",
+    },
+    "task_typeFacet": {
+        "type": "string",
+        "path": "task_type",
+    },
+    "run_typeFacet": {
+        "type": "string",
+        "path": "run_type",
+    },
+}
+
+
 class LastUpdatedQuery(QueryOperator):
     def query(
         self,
@@ -40,7 +41,7 @@ class LastUpdatedQuery(QueryOperator):
         crit = {}
 
         if last_updated_min or last_updated_max:
-            crit["range"] = {"path" : "last_updated"}
+            crit["range"] = {"path": "last_updated"}
             if last_updated_min:
                 crit["range"]["gte"] = last_updated_min
             if last_updated_max:
@@ -60,18 +61,13 @@ class MultipleTaskIDsQuery(QueryOperator):
             None, description="Comma-separated list of task_ids to query on"
         ),
     ) -> STORE_PARAMS:
-        crit = {
-        }
+        crit = {}
         if task_ids:
             task_ids = [task_id.strip() for task_id in task_ids.split(",")]
-            crit = {
-                "in": {
-                       "path": "task_id",
-                        "value": task_ids
-                    }
-                }
+            crit = {"in": {"path": "task_id", "value": task_ids}}
 
-        return {"criteria": crit, 
+        return {
+            "criteria": crit,
         }
 
     def post_process(self, docs, query):
@@ -212,6 +208,7 @@ class DeprecationQuery(QueryOperator):
 
         return d
 
+
 class TaskFormulaQuery(QueryOperator):
     """
     Method to generate a query on search docs using multiple task_id values
@@ -223,28 +220,19 @@ class TaskFormulaQuery(QueryOperator):
             None, description="Comma-separated list of formula to query on"
         ),
     ) -> STORE_PARAMS:
-        crit = {
-        }
+        crit = {}
 
         if formula:
             formula_pretty = [formula.strip() for formula in formula.split(",")]
             if len(formula_pretty) == 1:
                 crit = {
-                    "equals": {
-                        "path": "formula_pretty",
-                            "value": formula_pretty[0]
-                        }
-                    }
+                    "equals": {"path": "formula_pretty", "value": formula_pretty[0]}
+                }
             else:
-                crit = {
-                    "in": {
-                        "path": "formula_pretty",
-                            "value": formula_pretty
-                        }
-                    }
+                crit = {"in": {"path": "formula_pretty", "value": formula_pretty}}
 
-        return {"criteria": crit
-        }
+        return {"criteria": crit}
+
 
 class TaskChemsysQuery(QueryOperator):
     def query(
@@ -253,13 +241,12 @@ class TaskChemsysQuery(QueryOperator):
             None, description="Comma-separated list of chemsys to query on"
         ),
     ) -> STORE_PARAMS:
-        crit = {
-        }
+        crit = {}
         if chemsys:
             crit = chemsys_to_search(chemsys)
 
-        return {"criteria": crit
-        }
+        return {"criteria": crit}
+
 
 class TaskTypeQuery(QueryOperator):
     def query(
@@ -268,17 +255,11 @@ class TaskTypeQuery(QueryOperator):
             None, description="Comma-separated list of task_types to query on"
         ),
     ) -> STORE_PARAMS:
-        crit = {
-        }
+        crit = {}
         if task_type:
-            crit = {
-                "equals": {
-                    "path": "task_type",
-                    "value": task_type
-                }
-            }
-        return {"criteria": crit
-        }
+            crit = {"equals": {"path": "task_type", "value": task_type}}
+        return {"criteria": crit}
+
 
 class TaskElementsQuery(QueryOperator):
     def query(
@@ -287,10 +268,10 @@ class TaskElementsQuery(QueryOperator):
             None, description="Comma-separated list of elements to query on"
         ),
         exclude_elements: Optional[str] = Query(
-            None, description="Comma-separated list of elements to exclude from query")
+            None, description="Comma-separated list of elements to exclude from query"
+        ),
     ) -> STORE_PARAMS:
-        crit = {
-        }
+        crit = {}
         if elements:
             try:
                 eles = [Element(e) for e in elements.strip().split(",")]
@@ -299,17 +280,13 @@ class TaskElementsQuery(QueryOperator):
                     status_code=400,
                     detail="Please provide a valid comma-seperated list of elements",
                 )
-            
+
             crit["exists"] = []
-            for el in eles:    
-                crit["exists"].append({
-                    "path": f"composition_reduced.{el}"
-                }
-                )
-            
-            return {"criteria": crit
-            }
-    
+            for el in eles:
+                crit["exists"].append({"path": f"composition_reduced.{el}"})
+
+            return {"criteria": crit}
+
         if exclude_elements:
             try:
                 eles = [Element(e) for e in exclude_elements.strip().split(",")]
@@ -318,16 +295,14 @@ class TaskElementsQuery(QueryOperator):
                     status_code=400,
                     detail="Please provide a comma-seperated list of elements",
                 )
-            
+
             crit["mustNot"] = []
             for ele in eles:
-                crit["mustNot"].append({
-                    "exists": {
-                    "path": f"composition_reduced.{ele}"
-                }
-                }
+                crit["mustNot"].append(
+                    {"exists": {"path": f"composition_reduced.{ele}"}}
                 )
         return {"criteria": crit}
+
 
 class CalcTypeQuery(QueryOperator):
     def query(
@@ -336,18 +311,17 @@ class CalcTypeQuery(QueryOperator):
             None, description="Comma-separated list of calc_types to query on"
         ),
     ) -> STORE_PARAMS:
-        crit = {
-        }
+        crit = {}
         if calc_type:
             crit = {
                 "equals": {
                     "path": "calc_type",
                     "value": calc_type,
                 }
-            } 
-        return {"criteria": crit
-        }
-    
+            }
+        return {"criteria": crit}
+
+
 class RunTypeQuery(QueryOperator):
     def query(
         self,
@@ -355,17 +329,12 @@ class RunTypeQuery(QueryOperator):
             None, description="Comma-separated list of run_types to query on"
         ),
     ) -> STORE_PARAMS:
-        crit = {
-        }
+        crit = {}
         if run_type:
-            crit = {
-                "equals": {
-                    "path": "run_type",
-                    "value": run_type
-                }
-            } 
-        return {"criteria": crit
-        }
+            crit = {"equals": {"path": "run_type", "value": run_type}}
+        return {"criteria": crit}
+
+
 class BatchQuery(QueryOperator):
     def query(
         self,
@@ -373,18 +342,12 @@ class BatchQuery(QueryOperator):
             None, description="Comma-separated list of batch ids to query on"
         ),
     ) -> STORE_PARAMS:
-        crit = {
-        }
+        crit = {}
         if batches:
             batch_list = [b.strip() for b in batches.split(",")]
-            crit = {
-                "in": {
-                    "path": "batch_id",
-                    "value": batch_list
-                }
-            } 
-        return {"criteria": crit
-        }
+            crit = {"in": {"path": "batch_id", "value": batch_list}}
+        return {"criteria": crit}
+
 
 class FacetQuery(QueryOperator):
     def query(
@@ -393,8 +356,7 @@ class FacetQuery(QueryOperator):
             None, description="Facets query to return facets meta information"
         ),
     ) -> STORE_PARAMS:
-        crit = {
-        }
+        crit = {}
         if facets:
             facets_list = [facet.strip() for facet in facets.split(",")]
             for f in facets_list:
@@ -409,4 +371,3 @@ class FacetQuery(QueryOperator):
         else:
             crit = {**FACETS_PARAMS}
         return {"facets": crit}
-        

--- a/emmet-api/emmet/api/routes/materials/tasks/query_operators.py
+++ b/emmet-api/emmet/api/routes/materials/tasks/query_operators.py
@@ -6,11 +6,23 @@ from emmet.api.routes.materials.tasks.utils import (
     calcs_reversed_to_trajectory,
     task_to_entry,
 )
+from emmet.api.routes.materials.tasks.utils import chemsys_to_search
 from fastapi import Query
 from typing import Optional
 from monty.json import jsanitize
 
-
+FACETS_PARAMS = {"facets":    
+                     {
+                        "calc_typeFacet": {
+                            "type": "string",
+                            "path": "calc_type",
+                        },
+                        "task_typeFacet": {
+                            "type": "string",
+                            "path": "task_type",
+                        },
+                    }
+}
 class LastUpdatedQuery(QueryOperator):
     def query(
         self,
@@ -43,18 +55,30 @@ class MultipleTaskIDsQuery(QueryOperator):
             None, description="Comma-separated list of task_ids to query on"
         ),
     ) -> STORE_PARAMS:
-        crit = {}
-
+        crit = {
+        }
         if task_ids:
-            crit.update(
-                {
-                    "task_id": {
-                        "$in": [task_id.strip() for task_id in task_ids.split(",")]
+            task_ids = [task_id.strip() for task_id in task_ids.split(",")]
+            crit = {
+                "in": {
+                       "path": "task_id",
+                        "value": task_ids
                     }
                 }
-            )
 
-        return {"criteria": crit}
+        return {"criteria": crit, 
+                "facets":    
+                     {
+                        "calc_typeFacet": {
+                            "type": "string",
+                            "path": "calc_type",
+                        },
+                        "task_typeFacet": {
+                            "type": "string",
+                            "path": "task_type",
+                        },
+                    }
+        }
 
     def post_process(self, docs, query):
         """
@@ -193,3 +217,115 @@ class DeprecationQuery(QueryOperator):
             d.append(deprecation)
 
         return d
+
+class TaskFormulaQuery(QueryOperator):
+    """
+    Method to generate a query on search docs using multiple task_id values
+    """
+
+    def query(
+        self,
+        formula: Optional[str] = Query(
+            None, description="Comma-separated list of formula to query on"
+        ),
+    ) -> STORE_PARAMS:
+        crit = {
+        }
+
+        if formula:
+            formula_pretty = [formula.strip() for formula in formula.split(",")]
+            if len(formula_pretty) == 1:
+                crit = {
+                    "equals": {
+                        "path": "formula_pretty",
+                            "value": formula_pretty[0]
+                        }
+                    }
+            else:
+                crit = {
+                    "in": {
+                        "path": "formula_pretty",
+                            "value": formula_pretty
+                        }
+                    }
+
+        return {"criteria": crit, 
+                **FACETS_PARAMS
+        }
+
+class TaskChemsysQuery(QueryOperator):
+    def query(
+        self,
+        chemsys: Optional[str] = Query(
+            None, description="Comma-separated list of chemsys to query on"
+        ),
+    ) -> STORE_PARAMS:
+        crit = {
+        }
+        if chemsys:
+            crit = chemsys_to_search(chemsys)
+
+        return {"criteria": crit,
+                **FACETS_PARAMS
+        }
+
+class TaskTypeQuery(QueryOperator):
+    def query(
+        self,
+        task_type: Optional[str] = Query(
+            None, description="Comma-separated list of task_types to query on"
+        ),
+    ) -> STORE_PARAMS:
+        crit = {
+        }
+        if task_type:
+            crit = {
+                "equals": {
+                    "path": "task_type",
+                    "value": task_type
+                }
+            }
+        return {"criteria": crit,
+                **FACETS_PARAMS
+        }
+
+class CalcTypeQuery(QueryOperator):
+    def query(
+        self,
+        calc_type: Optional[str] = Query(
+            None, description="Comma-separated list of calc_types to query on"
+        ),
+    ) -> STORE_PARAMS:
+        crit = {
+        }
+        if calc_type:
+            crit = {
+                "equals": {
+                    "path": "calc_type",
+                    "value": calc_type,
+                }
+            } 
+        return {"criteria": crit,
+                **FACETS_PARAMS
+        }
+    
+class RunTypeQuery(QueryOperator):
+    def query(
+        self,
+        run_type: Optional[str] = Query(
+            None, description="Comma-separated list of run_types to query on"
+        ),
+    ) -> STORE_PARAMS:
+        crit = {
+        }
+        if run_type:
+            crit = {
+                "equals": {
+                    "path": "run_type",
+                    "value": run_type
+                }
+            } 
+        return {"criteria": crit,
+                **FACETS_PARAMS
+        }
+    

--- a/emmet-api/emmet/api/routes/materials/tasks/query_operators.py
+++ b/emmet-api/emmet/api/routes/materials/tasks/query_operators.py
@@ -7,7 +7,8 @@ from emmet.api.routes.materials.tasks.utils import (
 )
 from pymatgen.core.periodic_table import Element
 
-from emmet.api.routes.materials.tasks.utils import chemsys_to_search
+
+from emmet.api.routes.materials.tasks.utils import chemsys_to_search, formula_to_search
 from fastapi import Query, HTTPException
 from typing import Optional
 from monty.json import jsanitize
@@ -223,13 +224,7 @@ class TaskFormulaQuery(QueryOperator):
         crit = {}
 
         if formula:
-            formula_pretty = [formula.strip() for formula in formula.split(",")]
-            if len(formula_pretty) == 1:
-                crit = {
-                    "equals": {"path": "formula_pretty", "value": formula_pretty[0]}
-                }
-            else:
-                crit = {"in": {"path": "formula_pretty", "value": formula_pretty}}
+            crit = formula_to_search(formula)
 
         return {"criteria": crit}
 

--- a/emmet-api/emmet/api/routes/materials/tasks/resources.py
+++ b/emmet-api/emmet/api/routes/materials/tasks/resources.py
@@ -1,4 +1,3 @@
-from maggma.api.query_operator import PaginationQuery, SparseFieldsQuery
 from maggma.api.resource import ReadOnlyResource
 
 from emmet.api.routes.materials.tasks.query_operators import (

--- a/emmet-api/emmet/api/routes/materials/tasks/resources.py
+++ b/emmet-api/emmet/api/routes/materials/tasks/resources.py
@@ -13,6 +13,7 @@ from emmet.api.routes.materials.tasks.query_operators import (
     LastUpdatedQuery,
     TaskFormulaQuery,
     TaskChemsysQuery,
+    TaskElementsQuery,
     TaskTypeQuery,
     CalcTypeQuery,
     RunTypeQuery,
@@ -193,7 +194,7 @@ def task_resource(task_store):
         TaskDoc,
         query_operators=[
             TaskChemsysQuery(),
-            ElementsQuery(),
+            TaskElementsQuery(),
             MultipleTaskIDsQuery(),
             LastUpdatedQuery(),
             TaskFormulaQuery(),

--- a/emmet-api/emmet/api/routes/materials/tasks/resources.py
+++ b/emmet-api/emmet/api/routes/materials/tasks/resources.py
@@ -16,6 +16,7 @@ from emmet.api.routes.materials.tasks.query_operators import (
     TaskTypeQuery,
     CalcTypeQuery,
     RunTypeQuery,
+    BatchQuery,
     FacetQuery,
 )
 from emmet.api.core.global_header import GlobalHeaderProcessor
@@ -199,6 +200,7 @@ def task_resource(task_store):
             TaskTypeQuery(),
             CalcTypeQuery(),
             RunTypeQuery(),
+            BatchQuery(),
             FacetQuery(),
             PaginationQuery(),
             SparseFieldsQuery(

--- a/emmet-api/emmet/api/routes/materials/tasks/resources.py
+++ b/emmet-api/emmet/api/routes/materials/tasks/resources.py
@@ -134,7 +134,6 @@ class TaskReadOnlyResource(ReadOnlyResource):
                             data = list(self.store.query(**query))
                     else:
                         pipeline = generate_atlas_search_pipeline(query)
-                        print("Piepline", pipeline)
 
                         data = list(self.store._collection.aggregate(pipeline))
                         
@@ -159,7 +158,8 @@ class TaskReadOnlyResource(ReadOnlyResource):
                 operator_meta.update(operator.meta())
 
             if data and 'meta' in data[0] and data[0]['meta']:
-                meta = Meta(total_doc=data[0]['meta'][0].get("count", {}).get("lowerBound", 1))
+                meta = Meta(total_doc=data[0]['meta'][0].get("count", {}).get("lowerBound", 1),
+                            facet = data[0]['meta'][0].get("facet", {}))
             else:
                 meta = Meta(total_doc=0)
 

--- a/emmet-api/emmet/api/routes/materials/tasks/resources.py
+++ b/emmet-api/emmet/api/routes/materials/tasks/resources.py
@@ -35,15 +35,16 @@ from pymongo.errors import NetworkTimeout, PyMongoError
 
 from maggma.api.models import Meta
 from maggma.api.models import Response as ResponseModel
-from maggma.api.query_operator import PaginationQuery, QueryOperator, SparseFieldsQuery
+from maggma.api.query_operator import PaginationQuery, QueryOperator, SparseFieldsQuery, SortQuery
 from maggma.api.resource import HeaderProcessor, HintScheme, Resource
 from maggma.api.resource.utils import attach_query_ops, generate_atlas_search_pipeline
 from maggma.api.utils import STORE_PARAMS, merge_atlas_querires, serialization_helper
 from maggma.core import Store
 from maggma.stores import MongoStore, S3Store
 
-
+settings = MAPISettings()  # type: ignore
 timeout = MAPISettings().TIMEOUT
+sort_fields = ["nelements", "chemsys", "formula_pretty", "task_id"]
 
 class TaskReadOnlyResource(ReadOnlyResource):
     """
@@ -134,7 +135,6 @@ class TaskReadOnlyResource(ReadOnlyResource):
                             data = list(self.store.query(**query))
                     else:
                         pipeline = generate_atlas_search_pipeline(query)
-
                         data = list(self.store._collection.aggregate(pipeline))
                         
 
@@ -202,6 +202,7 @@ def task_resource(task_store):
             RunTypeQuery(),
             BatchQuery(),
             FacetQuery(),
+            SortQuery(fields=sort_fields, max_num=1),
             PaginationQuery(),
             SparseFieldsQuery(
                 TaskDoc,

--- a/emmet-api/emmet/api/routes/materials/tasks/resources.py
+++ b/emmet-api/emmet/api/routes/materials/tasks/resources.py
@@ -124,9 +124,7 @@ class TaskReadOnlyResource(ReadOnlyResource):
                             ", ".join(overlap)
                         ),
                     )
-            query: dict[Any, Any] = merge_atlas_querires(
-                list(queries.values())
-            )  # TODO: Update merge_queries
+            query: dict[Any, Any] = merge_atlas_querires(list(queries.values()))
 
             self.store.connect()
 
@@ -141,6 +139,7 @@ class TaskReadOnlyResource(ReadOnlyResource):
                             data = list(self.store.query(**query))
                     else:
                         pipeline = generate_atlas_search_pipeline(query)
+                        print("pipeline", pipeline)
                         data = list(self.store._collection.aggregate(pipeline))
 
             except (NetworkTimeout, PyMongoError) as e:

--- a/emmet-api/emmet/api/routes/materials/tasks/resources.py
+++ b/emmet-api/emmet/api/routes/materials/tasks/resources.py
@@ -16,6 +16,7 @@ from emmet.api.routes.materials.tasks.query_operators import (
     TaskTypeQuery,
     CalcTypeQuery,
     RunTypeQuery,
+    FacetQuery,
 )
 from emmet.api.core.global_header import GlobalHeaderProcessor
 from emmet.api.core.settings import MAPISettings
@@ -198,6 +199,7 @@ def task_resource(task_store):
             TaskTypeQuery(),
             CalcTypeQuery(),
             RunTypeQuery(),
+            FacetQuery(),
             PaginationQuery(),
             SparseFieldsQuery(
                 TaskDoc,

--- a/emmet-api/emmet/api/routes/materials/tasks/utils.py
+++ b/emmet-api/emmet/api/routes/materials/tasks/utils.py
@@ -122,12 +122,14 @@ def chemsys_to_search(chemsys: str) -> Dict:
                     "path": "nelements",
                     "value": len(eles)
                 }
-
-            for el in eles:
+            
+            crit["exists"] = []
+            for el in eles:    
                 if el != "*":
-                    crit["exists"] =  {
+                    crit["exists"].append({
                         "path": f"composition_reduced.{el}"
                     }
+                    )
 
             return crit
     else:

--- a/emmet-api/emmet/api/routes/materials/tasks/utils.py
+++ b/emmet-api/emmet/api/routes/materials/tasks/utils.py
@@ -140,6 +140,7 @@ def chemsys_to_search(chemsys: str) -> Dict:
             crit = {"in": {"path": "chemsys", "value": query_vals}}
     return crit
 
+
 def formula_to_search(formulas: str) -> Dict:
     """
     Santizes formula into a dictionary to search with wild cards
@@ -178,17 +179,20 @@ def formula_to_search(formulas: str) -> Dict:
 
             comp = Composition(integer_formula).reduced_composition
             crit["equals"] = []
-            crit["equals"].append({"path": "formula_anonymous", "value": comp.anonymized_formula})
+            crit["equals"].append(
+                {"path": "formula_anonymous", "value": comp.anonymized_formula}
+            )
             real_elts = [
                 str(e)
                 for e in comp.elements
                 if e.as_dict().get("element", "A") not in dummies
             ]
 
-            
             for el, n in comp.to_reduced_dict.items():
                 if el in real_elts:
-                    crit["equals"].append({"path": f"composition_reduced.{el}", "value": n}) 
+                    crit["equals"].append(
+                        {"path": f"composition_reduced.{el}", "value": n}
+                    )
 
             return crit
 
@@ -206,12 +210,20 @@ def formula_to_search(formulas: str) -> Dict:
         ):
             # Assume fully anonymized formula
             if len(formula_list) == 1:
-                crit["equals"] = {"path": "formula_anonymous", "value": composition_list[0].anonymized_formula}
+                crit["equals"] = {
+                    "path": "formula_anonymous",
+                    "value": composition_list[0].anonymized_formula,
+                }
             else:
                 for comp in composition_list:
-                    crit['equals'].append({"path": "formula_anonymous", "value": comp.anonymized_formula})
+                    crit["equals"].append(
+                        {"path": "formula_anonymous", "value": comp.anonymized_formula}
+                    )
             return crit
 
         else:
-            crit["in"] = {"path": "formula_pretty", "value": [comp.reduced_formula for comp in composition_list]}
+            crit["in"] = {
+                "path": "formula_pretty",
+                "value": [comp.reduced_formula for comp in composition_list],
+            }
         return crit

--- a/emmet-api/emmet/api/routes/materials/tasks/utils.py
+++ b/emmet-api/emmet/api/routes/materials/tasks/utils.py
@@ -94,6 +94,7 @@ def task_to_entry(doc: dict, include_structure: bool = True):
             doc["task_id"]
         )
 
+
 def chemsys_to_search(chemsys: str) -> Dict:
     """
     Converts a chemsys string to a search query
@@ -108,7 +109,7 @@ def chemsys_to_search(chemsys: str) -> Dict:
     crit = {}
 
     chemsys_list = [chemsys_val.strip() for chemsys_val in chemsys.split(",")]
-    
+
     if "*" in chemsys:
         if len(chemsys_list) > 1:
             raise HTTPException(
@@ -118,18 +119,12 @@ def chemsys_to_search(chemsys: str) -> Dict:
         else:
             eles = chemsys_list[0].split("-")
 
-            crit["equals"] =  {
-                    "path": "nelements",
-                    "value": len(eles)
-                }
-            
+            crit["equals"] = {"path": "nelements", "value": len(eles)}
+
             crit["exists"] = []
-            for el in eles:    
+            for el in eles:
                 if el != "*":
-                    crit["exists"].append({
-                        "path": f"composition_reduced.{el}"
-                    }
-                    )
+                    crit["exists"].append({"path": f"composition_reduced.{el}"})
 
             return crit
     else:
@@ -139,17 +134,7 @@ def chemsys_to_search(chemsys: str) -> Dict:
             sorted_chemsys = "-".join(sorted(eles))
             query_vals.append(sorted_chemsys)
         if len(query_vals) == 1:
-            crit = {
-                    "equals": {
-                        "path": "chemsys",
-                        "value": query_vals[0]
-                        }
-                    }
+            crit = {"equals": {"path": "chemsys", "value": query_vals[0]}}
         else:
-            crit = {
-                    "in": {
-                        "path": "chemsys",
-                        "value": query_vals
-                        }
-                    }
+            crit = {"in": {"path": "chemsys", "value": query_vals}}
     return crit

--- a/emmet-api/tests/materials/tasks/test_query_operators.py
+++ b/emmet-api/tests/materials/tasks/test_query_operators.py
@@ -16,7 +16,7 @@ def test_multiple_task_ids_query():
     op = MultipleTaskIDsQuery()
 
     assert op.query(task_ids=" mp-149, mp-13") == {
-        "criteria": {"task_id": {"$in": ["mp-149", "mp-13"]}}
+        "criteria": {"in": {"path": "task_id", "value": ["mp-149", "mp-13"]}}
     }
 
     with ScratchDir("."):
@@ -24,7 +24,7 @@ def test_multiple_task_ids_query():
         new_op = loadfn("temp.json")
 
         assert new_op.query(task_ids=" mp-149, mp-13") == {
-            "criteria": {"task_id": {"$in": ["mp-149", "mp-13"]}}
+            "criteria": {"in": {"path": "task_id", "value": ["mp-149", "mp-13"]}}
         }
 
 


### PR DESCRIPTION
# Major changes: 
- Defined a custom ReadOnlyResource for the task collection (still inherit from the maggma ReadOnlyResource)
- Use custom query operators for TaskReadOnlyResource that work with atlas search 
- Enabled previously non-working queries 
- Added facet query for returning facet information 
- Removed hint scheme for task collection (no longer needed with the new search index) 

Designed to work with updated maggma release. Also, the roadmap is to use the same design pattern across all our collections. 

## TODOs:
- [ ] Update tests