### PR TITLE
Project `run_type` to ensure `entries` field is correctly constructed

### DIFF
--- a/emmet-builders/emmet/builders/vasp/materials.py
+++ b/emmet-builders/emmet/builders/vasp/materials.py
@@ -186,6 +186,7 @@ class MaterialsBuilder(Builder):
             # needed for run_type and task_type
             "calcs_reversed.input.parameters",
             "calcs_reversed.input.incar",
+            "calcs_reversed.run_type",
             "orig_inputs",
             "input.structure",
             # needed for entry from task_doc


### PR DESCRIPTION
There seems to be a bug in `MaterialsBuilder` where `run_type` is not projected, leading to a `"run_type": None` in the corresponding `entry`. Following this through the builder pipeline will result in those entries not being seen as valid by the compatibility scheme.

It's unclear to me when this bug was introduced, I assume it hasn't hit any Materials Project production builds because it would have been very noticeable.

Thanks to @basveeling for identifying and fixing this bug.