### PR TITLE
update imports for matcalc

### DIFF
--- a/emmet-builders/emmet/builders/materials/ml.py
+++ b/emmet-builders/emmet/builders/materials/ml.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Optional, Union
 
 from maggma.builders.map_builder import MapBuilder
 from maggma.core import Store
-from matcalc.utils import get_universal_calculator
+from matcalc import PESCalculator
 from pymatgen.core import Structure
 
 from emmet.core.ml import MLDoc
@@ -43,7 +43,7 @@ class MLBuilder(MapBuilder):
         self.materials = materials
         self.ml_potential = ml_potential
         self.kwargs = kwargs
-        self.model = get_universal_calculator(model, **(model_kwargs or {}))
+        self.model = PESCalculator.load_universal(model, **(model_kwargs or {}))
         self.prop_kwargs = prop_kwargs or {}
 
         if provenance == {}:

--- a/emmet-core/emmet/core/ml.py
+++ b/emmet-core/emmet/core/ml.py
@@ -1,10 +1,6 @@
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
-from matcalc.elasticity import ElasticityCalc
-from matcalc.eos import EOSCalc
-from matcalc.phonon import PhononCalc
-from matcalc.relaxation import RelaxCalc
-from matcalc.utils import get_universal_calculator
+from matcalc import ElasticityCalc, EOSCalc, PESCalculator, PhononCalc, RelaxCalc
 from pydantic import Field, validator
 from pymatgen.analysis.elasticity import ElasticTensor
 from pymatgen.core import Structure
@@ -150,9 +146,9 @@ class MLDoc(ElasticityDoc):
         Returns:
             MLDoc
         """
-        calculator = get_universal_calculator(calculator)
+        calculator = PESCalculator.load_universal(calculator)
 
-        results = {}
+        results = {}  # type: ignore
         for prop_cls in (RelaxCalc, PhononCalc, EOSCalc, ElasticityCalc):
             kwds = (prop_kwargs or {}).get(prop_cls.__name__, {})
             output = prop_cls(calculator, **kwds).calc(structure)

--- a/emmet-core/setup.py
+++ b/emmet-core/setup.py
@@ -37,7 +37,7 @@ setup(
     ],
     extras_require={
         "all": [
-            "matcalc>=0.0.4",
+            "matcalc>=0.3.1",
             "seekpath>=2.0.1",
             "robocrys>=0.2.8",
             "pymatgen-analysis-defects>=2024.7.18",


### PR DESCRIPTION
matcalc had a few minor version releases in the last couple weeks and our current imports are from ~v0.1.2-ish

[v0.3.1](https://github.com/materialsvirtuallab/matcalc/releases/tag/v0.3.1) in particular made some previously exposed modules private with public re-exports