### PR TITLE
add transport-analysis as optional dependency to emmet-core

### DIFF
--- a/emmet-core/setup.py
+++ b/emmet-core/setup.py
@@ -44,6 +44,7 @@ setup(
             "pymatgen-analysis-diffusion>=2024.7.15",
             "pymatgen-analysis-alloys>=0.0.6",
             "solvation-analysis>=0.4.1",
+            "transport-analysis",
             "MDAnalysis>=2.7.0",
             "pyarrow",
         ],


### PR DESCRIPTION
transport-analysis is imported in emmet-core, but not listed as a dependency in core's setup.py

https://github.com/materialsproject/emmet/blob/7d6cea7a556a84379020c9ec22b9bf1004c5fc2d/emmet-core/emmet/core/openff/benchmarking.py#L4-L8


