### PR TITLE
Tweak potcar validation

### DIFF
--- a/emmet-core/emmet/core/openmm/tasks.py
+++ b/emmet-core/emmet/core/openmm/tasks.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import io
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, Union, TYPE_CHECKING
 
 import openmm
 import pandas as pd  # type: ignore[import-untyped]
@@ -16,6 +16,9 @@ from pydantic import BaseModel, ConfigDict, Field
 from emmet.core.openff import MDTaskDocument  # type: ignore[import-untyped]
 from emmet.core.openff.tasks import CompressedStr  # type: ignore[import-untyped]
 from emmet.core.vasp.task_valid import TaskState  # type: ignore[import-untyped]
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
 class CalculationInput(BaseModel):  # type: ignore[call-arg]
@@ -161,7 +164,7 @@ class CalculationOutput(BaseModel):
     ) -> CalculationOutput:
         """Extract data from the output files in the directory."""
         state_file = Path(dir_name) / state_file_name
-        column_name_map = {
+        column_name_map: dict[str, str] = {
             '#"Step"': "steps_reported",
             "Potential Energy (kJ/mole)": "potential_energy",
             "Kinetic Energy (kJ/mole)": "kinetic_energy",
@@ -174,8 +177,8 @@ class CalculationOutput(BaseModel):
         if state_is_not_empty:
             data = pd.read_csv(state_file, header=0)
             data = data.rename(columns=column_name_map)
-            data = data.filter(items=column_name_map.values())
-            attributes = data.to_dict(orient="list")
+            data = data.filter(items=list(column_name_map.values()))
+            attributes: dict[str, Any] = data.to_dict(orient="list")  # type: ignore[assignment]
         else:
             attributes = {name: None for name in column_name_map.values()}
             state_file_name = None  # type: ignore[assignment]
@@ -184,14 +187,10 @@ class CalculationOutput(BaseModel):
         traj_is_not_empty = traj_file.exists() and traj_file.stat().st_size > 0
         traj_file_name = traj_file_name if traj_is_not_empty else None  # type: ignore
 
-        if traj_is_not_empty:
-            if embed_traj:
-                with open(traj_file, "rb") as f:
-                    traj_blob = f.read().hex()
-            else:
-                traj_blob = None
-        else:
-            traj_blob = None
+        traj_blob: str | None = None
+        if traj_is_not_empty and embed_traj:
+            with open(traj_file, "rb") as f:
+                traj_blob = f.read().hex()
 
         return CalculationOutput(
             dir_name=str(dir_name),

--- a/emmet-core/emmet/core/vasp/validation.py
+++ b/emmet-core/emmet/core/vasp/validation.py
@@ -365,7 +365,7 @@ def _potcar_stats_check(
     value from the pymatgen input set.
     """
     data_tol = 1.0e-6
-    exclude_keys = set([k.lower() for k in (exclude_keys or [])])
+    excl: set[str] = set([k.lower() for k in (exclude_keys or [])])
 
     try:
         potcar_details = task_doc.calcs_reversed[0].model_dump()["input"]["potcar_spec"]
@@ -409,14 +409,13 @@ def _potcar_stats_check(
         else:
             entry_keys = {
                 key: set([k.lower() for k in entry["summary_stats"]["keywords"][key]])
-                - exclude_keys
+                - excl
                 for key in ["header", "data"]
             }
             all_match = False
             for ref_stat in ref_summ_stats:
                 ref_keys = {
-                    key: set([k.lower() for k in ref_stat["keywords"][key]])
-                    - exclude_keys
+                    key: set([k.lower() for k in ref_stat["keywords"][key]]) - excl
                     for key in ["header", "data"]
                 }
 

--- a/emmet-core/emmet/core/vasp/validation.py
+++ b/emmet-core/emmet/core/vasp/validation.py
@@ -356,7 +356,7 @@ def _kspacing_warnings(input_set, inputs, data, warnings, kspacing_tolerance):
 
 
 def _potcar_stats_check(
-    task_doc, potcar_stats: dict, exclude_keys: Sequence[str] | None = ["sha", "copyr"]
+    task_doc, potcar_stats: dict, exclude_keys: Sequence[str] | None = ["sha256", "copyr"]
 ):
     """
     Checks to make sure the POTCAR summary stats is equal to the correct
@@ -392,7 +392,7 @@ def _potcar_stats_check(
             all_match = False
             break
 
-        if use_legacy_hash_check:
+        if use_legacy_hash_check:                    
             all_match = any(
                 all(
                     entry[key] == ref_stat[key]

--- a/emmet-core/emmet/core/vasp/validation.py
+++ b/emmet-core/emmet/core/vasp/validation.py
@@ -356,7 +356,9 @@ def _kspacing_warnings(input_set, inputs, data, warnings, kspacing_tolerance):
 
 
 def _potcar_stats_check(
-    task_doc, potcar_stats: dict, exclude_keys: Sequence[str] | None = ["sha256", "copyr"]
+    task_doc,
+    potcar_stats: dict,
+    exclude_keys: Sequence[str] | None = ["sha256", "copyr"],
 ):
     """
     Checks to make sure the POTCAR summary stats is equal to the correct
@@ -392,7 +394,7 @@ def _potcar_stats_check(
             all_match = False
             break
 
-        if use_legacy_hash_check:                    
+        if use_legacy_hash_check:
             all_match = any(
                 all(
                     entry[key] == ref_stat[key]

--- a/emmet-core/emmet/core/vasp/validation.py
+++ b/emmet-core/emmet/core/vasp/validation.py
@@ -1,5 +1,8 @@
+"""Current MP tools to validate VASP calculations."""
+from __future__ import annotations
+
 from datetime import datetime
-from typing import Dict, List, Union, Optional
+from typing import TYPE_CHECKING
 
 import numpy as np
 from pydantic import ConfigDict, Field, ImportString
@@ -14,6 +17,9 @@ from emmet.core.utils import DocEnum
 from emmet.core.tasks import TaskDoc
 from emmet.core.vasp.calc_types.enums import CalcType, TaskType
 from emmet.core.vasp.task_valid import TaskDocument
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 SETTINGS = EmmetSettings()
 
@@ -51,19 +57,19 @@ class ValidationDoc(EmmetBaseModel):
         description="Last updated date for this document",
         default_factory=datetime.utcnow,
     )
-    reasons: Optional[List[Union[DeprecationMessage, str]]] = Field(
+    reasons: list[DeprecationMessage | str] | None = Field(
         None, description="List of deprecation tags detailing why this task isn't valid"
     )
-    warnings: List[str] = Field(
+    warnings: list[str] = Field(
         [], description="List of potential warnings about this calculation"
     )
-    data: Dict = Field(
+    data: dict = Field(
         description="Dictioary of data used to perform validation."
         " Useful for post-mortem analysis"
     )
     model_config = ConfigDict(extra="allow")
-    nelements: Optional[int] = Field(None, description="Number of elements.")
-    symmetry_number: Optional[int] = Field(
+    nelements: int | None = Field(None, description="Number of elements.")
+    symmetry_number: int | None = Field(
         None,
         title="Space Group Number",
         description="The spacegroup number for the lattice.",
@@ -72,14 +78,14 @@ class ValidationDoc(EmmetBaseModel):
     @classmethod
     def from_task_doc(
         cls,
-        task_doc: Union[TaskDoc, TaskDocument],
+        task_doc: TaskDoc | TaskDocument,
         kpts_tolerance: float = SETTINGS.VASP_KPTS_TOLERANCE,
         kspacing_tolerance: float = SETTINGS.VASP_KSPACING_TOLERANCE,
-        input_sets: Dict[str, ImportString] = SETTINGS.VASP_DEFAULT_INPUT_SETS,
-        LDAU_fields: List[str] = SETTINGS.VASP_CHECKED_LDAU_FIELDS,
+        input_sets: dict[str, ImportString] = SETTINGS.VASP_DEFAULT_INPUT_SETS,
+        LDAU_fields: list[str] = SETTINGS.VASP_CHECKED_LDAU_FIELDS,
         max_allowed_scf_gradient: float = SETTINGS.VASP_MAX_SCF_GRADIENT,
-        max_magmoms: Dict[str, float] = SETTINGS.VASP_MAX_MAGMOM,
-        potcar_stats: Optional[Dict[CalcType, Dict[str, str]]] = None,
+        max_magmoms: dict[str, float] = SETTINGS.VASP_MAX_MAGMOM,
+        potcar_stats: dict[CalcType, dict[str, str]] | None = None,
     ) -> "ValidationDoc":
         """
         Determines if a calculation is valid based on expected input parameters from a pymatgen inputset
@@ -120,7 +126,7 @@ class ValidationDoc(EmmetBaseModel):
 
         reasons = []
         data = {}  # type: ignore
-        warnings: List[str] = []
+        warnings: list[str] = []
 
         if str(calc_type) in input_sets:
             try:
@@ -349,12 +355,15 @@ def _kspacing_warnings(input_set, inputs, data, warnings, kspacing_tolerance):
             )
 
 
-def _potcar_stats_check(task_doc, potcar_stats: dict):
+def _potcar_stats_check(
+    task_doc, potcar_stats: dict, exclude_keys: Sequence[str] | None = ["sha", "copyr"]
+):
     """
     Checks to make sure the POTCAR summary stats is equal to the correct
     value from the pymatgen input set.
     """
     data_tol = 1.0e-6
+    exclude_keys = set([k.lower() for k in (exclude_keys or [])])
 
     try:
         potcar_details = task_doc.calcs_reversed[0].model_dump()["input"]["potcar_spec"]
@@ -396,13 +405,20 @@ def _potcar_stats_check(task_doc, potcar_stats: dict):
             )
 
         else:
+            entry_keys = {
+                key: set([k.lower() for k in entry["summary_stats"]["keywords"][key]])
+                - exclude_keys
+                for key in ["header", "data"]
+            }
             all_match = False
             for ref_stat in ref_summ_stats:
-                key_match = all(
-                    set(ref_stat["keywords"][key])
-                    == set(entry["summary_stats"]["keywords"][key])
+                ref_keys = {
+                    key: set([k.lower() for k in ref_stat["keywords"][key]])
+                    - exclude_keys
                     for key in ["header", "data"]
-                )
+                }
+
+                key_match = all(entry_keys[k] == v for k, v in ref_keys.items())
 
                 data_match = False
                 if key_match:

--- a/emmet-core/setup.py
+++ b/emmet-core/setup.py
@@ -39,7 +39,7 @@ setup(
         "all": [
             "matcalc>=0.3.1",
             "seekpath>=2.0.1",
-            "robocrys>=0.2.8",
+            "robocrys>=0.2.11",
             "pymatgen-analysis-defects>=2024.7.18",
             "pymatgen-analysis-diffusion>=2024.7.15",
             "pymatgen-analysis-alloys>=0.0.6",


### PR DESCRIPTION
Changes how POTCARs are validated slightly. It seems that **most** if not all of the PBE_54 POTCARs are identical to the PBE_54_W_HASH variants. The latter set includes extra tags: COPYR (copyright) and SHA256 (hash of the file). The actual data contents appear to be the same

The POTCAR validation now defaults to excluding these COPYR and SHA256 fields to perform validation

Also bumps robocrys to 0.2.11 to remove circular software dependence

Noting this here for future reference: There appear to be extra GW-related tags in at least these PBE_54_W_HASH POTCAR: `['C','Na_pv','Mg_pv','Ca_sv','Cl',O','Li_sv']`. Can't say with certainty if those differences are important for regular DFT calcs, but they won't validate against PBE_54 POTCARs for the time being