### PR TITLE
updates to use FileMetadata in discovery (and add lazy md5 calculation)

### DIFF
--- a/emmet-core/emmet/core/tasks.py
+++ b/emmet-core/emmet/core/tasks.py
@@ -1130,6 +1130,7 @@ def _find_vasp_files(
     def _update_task_files(tpath) -> None:
         for category, files in discover_and_sort_vasp_files(tpath).items():
             for f in files:
+                f = f.name
                 tasks = sorted([t for t in task_names if t in f])
                 task = "standard" if len(tasks) == 0 else tasks[0]
                 if task not in task_files:

--- a/emmet-core/emmet/core/vasp/utils.py
+++ b/emmet-core/emmet/core/vasp/utils.py
@@ -37,7 +37,6 @@ class FileMetadata(BaseModel):
         return v
 
     @computed_field
-    @property
     def md5(self) -> Optional[str]:
         """MD5 checksum of the file (computed lazily if needed)."""
         if self._md5 is not None:
@@ -153,7 +152,7 @@ def discover_vasp_files(
         for p in scan_dir:
             # Check that at least one VASP file matches the file name
             if p.is_file() and any(f for f in _vasp_files if f in p.name):
-                vasp_files.append(FileMetadata(name=p.name, path=p))
+                vasp_files.append(FileMetadata(name=p.name, path=Path(p.path)))
     return vasp_files
 
 
@@ -249,6 +248,6 @@ def recursive_discover_vasp_files(
                     return
                 paths[Path(tdir).resolve()] = tpaths
 
-    vasp_files: dict[Path, list[str]] = {}
+    vasp_files: dict[Path, list[FileMetadata]] = {}
     _recursive_discover_vasp_files(target_dir, vasp_files)
     return vasp_files

--- a/emmet-core/emmet/core/vasp/utils.py
+++ b/emmet-core/emmet/core/vasp/utils.py
@@ -46,7 +46,7 @@ class FileMetadata(BaseModel):
         if self.validate_path_exists():
             try:
                 self._md5 = get_md5_blocked(self.path)
-            except Exception as e:
+            except Exception:
                 self._md5 = None
 
         return self._md5

--- a/emmet-core/emmet/core/vasp/utils.py
+++ b/emmet-core/emmet/core/vasp/utils.py
@@ -56,6 +56,7 @@ class FileMetadata(BaseModel):
             raise ValueError(f"Path does not exist: {self.path}")
         if not self.path.is_file():
             raise ValueError(f"Path is not a file: {self.path}")
+        return True
 
     def reset_md5(self):
         """Force recomputation of MD5 checksum on next call to md5 property."""

--- a/emmet-core/emmet/core/vasp/utils.py
+++ b/emmet-core/emmet/core/vasp/utils.py
@@ -1,10 +1,11 @@
 """Define utilities needed for parsing VASP calculations."""
+
 from __future__ import annotations
 from collections import defaultdict
 import os
 from pathlib import Path
-from pydantic import BaseModel, model_validator
-from typing import TYPE_CHECKING
+from pydantic import BaseModel, Field, PrivateAttr, computed_field, model_validator
+from typing import TYPE_CHECKING, Optional
 
 from emmet.core.utils import get_md5_blocked
 
@@ -13,30 +14,60 @@ if TYPE_CHECKING:
     from emmet.core.typing import PathLike
 
 
-class FileMeta(BaseModel):
+class FileMetadata(BaseModel):
     """
     Lightweight model to enable validation on files via MD5.
 
-    Fields:
-        name (str) : Name of the VASP file without suffixes (e.g., INCAR)
-        path (str) : Path to the VASP file
-        md5 (str) : The MD5 checksum of the file. Does not need to be
-            set, the model will populate it automatically from a
-            valid file path.
     """
 
-    name: str
-    path: str
-    md5: str
+    name: str = Field(
+        description="Name of the VASP file without suffixes (e.g., INCAR)"
+    )
+    path: Path = Field(description="Path to the VASP file")
+    _md5: Optional[str] = PrivateAttr(default=None)
 
     @model_validator(mode="before")
-    def check_path_md5(cls, v: Any) -> Any:
-        """Ensure path is a str, and md5 file is populated."""
-        if fp := v.get("path"):
-            v["path"] = str(fp)
-            if not v.get("md5") and Path(fp).exists():
-                v["md5"] = get_md5_blocked(fp)
+    def coerce_path(cls, v: Any) -> Any:
+        """Only coerce to Path. No existence check here."""
+        if "path" in v:
+            path = v["path"]
+            if not isinstance(path, Path):
+                path = Path(path)
+            v["path"] = path
         return v
+
+    @computed_field
+    @property
+    def md5(self) -> Optional[str]:
+        """MD5 checksum of the file (computed lazily if needed)."""
+        if self._md5 is not None:
+            return self._md5
+
+        if self.validate_path_exists():
+            try:
+                self._md5 = get_md5_blocked(self.path)
+            except Exception as e:
+                self._md5 = None
+
+        return self._md5
+
+    def validate_path_exists(self):
+        if not self.path.exists():
+            raise ValueError(f"Path does not exist: {self.path}")
+        if not self.path.is_file():
+            raise ValueError(f"Path is not a file: {self.path}")
+
+    def reset_md5(self):
+        """Force recomputation of MD5 checksum on next call to md5 property."""
+        self._md5 = None
+
+    def __hash__(self):
+        return hash(self.path)
+
+    def __eq__(self, other):
+        if not isinstance(other, FileMetadata):
+            return NotImplemented
+        return self.path == other.path
 
 
 VASP_INPUT_FILES = [
@@ -101,7 +132,7 @@ for f in VASP_INPUT_FILES:
 
 def discover_vasp_files(
     target_dir: PathLike,
-) -> list[str]:
+) -> list[FileMetadata]:
     """
     Scan a target directory and identify VASP files.
 
@@ -111,23 +142,23 @@ def discover_vasp_files(
 
     Returns
     -----------
-    List of file names as str.
+    List of FileMetadata for the identified files.
     """
 
     head_dir = Path(target_dir)
-    vasp_files: list[str] = []
+    vasp_files: list[FileMetadata] = []
 
     with os.scandir(head_dir) as scan_dir:
         for p in scan_dir:
             # Check that at least one VASP file matches the file name
             if p.is_file() and any(f for f in _vasp_files if f in p.name):
-                vasp_files.append(p.name)
+                vasp_files.append(FileMetadata(name=p.name, path=p))
     return vasp_files
 
 
 def discover_and_sort_vasp_files(
     target_dir: PathLike,
-) -> dict[str, list[str]]:
+) -> dict[str, list[FileMetadata]]:
     """
     Find and sort VASP files from a directory for TaskDoc.
 
@@ -137,12 +168,12 @@ def discover_and_sort_vasp_files(
 
     Returns
     -----------
-    dict of str (categories) to list of str (list of VASP files in
+    dict of str (categories) to list of FileMetadata (list of VASP files in
         that category)
     """
-    by_type: dict[str, list[str]] = defaultdict(list)
+    by_type: dict[str, list[FileMetadata]] = defaultdict(list)
     for _f in discover_vasp_files(target_dir):
-        f = _f.lower()
+        f = _f.name.lower()
         for k in (
             "vasprun",
             "contcar",
@@ -168,7 +199,7 @@ def recursive_discover_vasp_files(
     target_dir: PathLike,
     only_valid: bool = False,
     max_depth: int | None = None,
-) -> dict[Path, list[str]]:
+) -> dict[Path, list[FileMetadata]]:
     """
     Recursively scan a target directory and identify VASP files.
 
@@ -185,7 +216,7 @@ def recursive_discover_vasp_files(
 
     Returns
     -----------
-    List of file names as str.
+    dict of Path  to list of FileMetadata identified as VASP files.
     """
 
     head_dir = Path(target_dir).resolve()
@@ -199,7 +230,7 @@ def recursive_discover_vasp_files(
         return True
 
     def _recursive_discover_vasp_files(
-        tdir: PathLike, paths: dict[Path, list[str]]
+        tdir: PathLike, paths: dict[Path, list[FileMetadata]]
     ) -> None:
         if Path(tdir).is_dir() and _path_depth_check(tdir):
             with os.scandir(tdir) as scan_dir:
@@ -210,7 +241,8 @@ def recursive_discover_vasp_files(
                 # Check if minimum number of VASP files are present
                 # TODO: update with vaspout.h5 parsing
                 if only_valid and any(
-                    not any(f in file for file in tpaths) for f in REQUIRED_VASP_FILES
+                    not any(f in file.name for file in tpaths)
+                    for f in REQUIRED_VASP_FILES
                 ):
                     # Incomplete calculation input/output
                     return

--- a/emmet-core/tests/vasp/test_utils.py
+++ b/emmet-core/tests/vasp/test_utils.py
@@ -3,7 +3,6 @@
 from tempfile import TemporaryDirectory
 from pathlib import Path
 
-from emmet.core.utils import get_md5_blocked
 from emmet.core.vasp.utils import (
     recursive_discover_vasp_files,
     discover_and_sort_vasp_files,

--- a/emmet-core/tests/vasp/test_utils.py
+++ b/emmet-core/tests/vasp/test_utils.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from emmet.core.vasp.utils import (
     recursive_discover_vasp_files,
     discover_and_sort_vasp_files,
-    FileMeta,
+    FileMetadata,
 )
 
 
@@ -24,7 +24,7 @@ IBRION = -1
     with zopen(file_name := "INCAR.bz2", "wb") as f:
         f.write(incar_bytes)
 
-    file_meta = FileMeta(name="INCAR", path=file_name)
+    file_meta = FileMetadata(name="INCAR", path=file_name)
     assert Path(file_meta.path).exists()
     assert file_meta.md5 == hashlib.md5(incar_bytes).hexdigest()
 
@@ -85,18 +85,24 @@ def test_file_discovery():
             tmp_dir / "block_2025_02_30/launcher_2025_02_31/launcher_2025_02_31_0001"
         )
 
-    assert set(sorted_files["contcar_file"]) == {"CONTCAR.relax1"}
-    assert set(sorted_files["vasprun_file"]) == {"vasprun.xml.relax1"}
-    assert set(sorted_files["outcar_file"]) == {"OUTCAR.relax1"}
-    assert set(sorted_files["volumetric_files"]) == {"AECCAR0.bz2", "LOCPOT.gz"}
-    assert set(sorted_files["elph_poscars"]) == {"POSCAR.T=300.gz", "POSCAR.T=1000.gz"}
+    assert set([b.name for b in sorted_files["contcar_file"]]) == {"CONTCAR.relax1"}
+    assert set([b.name for b in sorted_files["vasprun_file"]]) == {"vasprun.xml.relax1"}
+    assert set([b.name for b in sorted_files["outcar_file"]]) == {"OUTCAR.relax1"}
+    assert set([b.name for b in sorted_files["volumetric_files"]]) == {
+        "AECCAR0.bz2",
+        "LOCPOT.gz",
+    }
+    assert set([b.name for b in sorted_files["elph_poscars"]]) == {
+        "POSCAR.T=300.gz",
+        "POSCAR.T=1000.gz",
+    }
 
     assert len(vasp_files) == len(
         directory_structure
     )  # should find all of the defined calculation directories
     for calc_dir, files in directory_structure.items():
         assert (base_path := tmp_dir / calc_dir) in vasp_files
-        assert all(f in vasp_files[base_path] for f in files)
+        assert all(f in [b.name for b in vasp_files[base_path]] for f in files)
 
     # Should only find two valid calculation directories
     valid_calc_dirs = (
@@ -104,7 +110,7 @@ def test_file_discovery():
         "block_2025_02_30/launcher_2025_02_31/launcher_2025_02_31_0001",
     )
     assert all(
-        f in valid_vasp_files[tmp_dir / p]
+        f in [b.name for b in valid_vasp_files[tmp_dir / p]]
         for p in valid_calc_dirs
         for f in directory_structure[p]
     )

--- a/emmet-core/tests/vasp/test_utils.py
+++ b/emmet-core/tests/vasp/test_utils.py
@@ -3,6 +3,7 @@
 from tempfile import TemporaryDirectory
 from pathlib import Path
 
+from emmet.core.utils import get_md5_blocked
 from emmet.core.vasp.utils import (
     recursive_discover_vasp_files,
     discover_and_sort_vasp_files,
@@ -24,7 +25,7 @@ IBRION = -1
     with zopen(file_name := "INCAR.bz2", "wb") as f:
         f.write(incar_bytes)
 
-    file_meta = FileMetadata(name="INCAR", path=file_name)
+    file_meta = FileMetadata(name="INCAR.bz2", path=file_name)
     assert Path(file_meta.path).exists()
     assert file_meta.md5 == hashlib.md5(incar_bytes).hexdigest()
 


### PR DESCRIPTION
Updating discovery to use/return FileMetadata rather than str so can make use of all the info. Making the md5 calculation lazy so that we don't perform it unless it's asked for.

## Contributor Checklist

- [ X] I have run the tests locally and they passed.
- [ X] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR
