### PR TITLE
Alphabetical ID (redo #1178)

### DIFF
--- a/emmet-core/emmet/core/mpid.py
+++ b/emmet-core/emmet/core/mpid.py
@@ -424,14 +424,14 @@ class AlphaID(str):
             if exc_str:
                 raise TypeError(exc_str)
 
-            test = self._string_to_base_10_value(test._identifier)
+            diff = self._string_to_base_10_value(test._identifier)
         elif isinstance(test, str):
-            test = self._string_to_base_10_value(test)
+            diff = self._string_to_base_10_value(test)
         elif not isinstance(test, int):
             raise NotImplementedError(f"Cannot add AlphaID to type {type(test)}")
 
         return AlphaID(
-            int(self) + test,
+            int(self) + diff,
             padlen=self._padlen,
             prefix=self._prefix,
             separator=self._separator,

--- a/emmet-core/tests/test_mpid.py
+++ b/emmet-core/tests/test_mpid.py
@@ -59,38 +59,54 @@ def test_to_str():
 
 
 def test_alpha_id():
-
     # Test initialization from MPID-like string
     mpid_like_idx = AlphaID("mp-149")
-    assert mpid_like_idx == AlphaID(149,prefix="mp",separator="-")
+    assert mpid_like_idx == AlphaID(149, prefix="mp", separator="-")
     assert mpid_like_idx._prefix == "mp"
     assert mpid_like_idx._separator == "-"
     assert int(mpid_like_idx) == 149
+
     assert mpid_like_idx == MPID("mp-149")
     assert mpid_like_idx == AlphaID(MPID("mp-149"))
     assert AlphaID("mvc-160") == MPID("mvc-160")
     assert AlphaID(160) == MPID("160")
     assert mpid_like_idx + MPID("mp-140") == AlphaID("mp-289")
     assert mpid_like_idx - MPID("mp-140") == AlphaID("mp-9")
-    
+
+    # Test relationality - should always be False if prefix / separator don't match
+    assert mpid_like_idx > MPID("mp-140")
+    mvc_idx = AlphaID("mvc-140")
+    assert not mpid_like_idx < mvc_idx
+    assert not mpid_like_idx > mvc_idx
+
     majik_num = 137
 
-    # Test initialization from int
-    for pfx in (None, "iamaprefix",):
+    ref_idx = AlphaID(majik_num, prefix="cats", separator="^")
+    assert ref_idx < AlphaID(
+        majik_num + 100, prefix=ref_idx._prefix, separator=ref_idx._separator
+    )
+    assert ref_idx > AlphaID(
+        majik_num - 100, prefix=ref_idx._prefix, separator=ref_idx._separator
+    )
 
-        for separator in ("-",":",">"):
-            idx = AlphaID(majik_num,prefix=pfx,separator=separator)
+    # Test initialization from int
+    for pfx in (
+        None,
+        "iamaprefix",
+    ):
+        for separator in ("-", ":", ">"):
+            idx = AlphaID(majik_num, prefix=pfx, separator=separator)
             assert int(idx) == majik_num
 
             # Test integer equality
             assert idx == majik_num
 
             # Test in/equality when prefix and separators do not match
-            assert idx != AlphaID(majik_num,prefix="unusedprefix")
+            assert idx != AlphaID(majik_num, prefix="unusedprefix")
 
             # Test equality when separators differ but prefixes are None
             # (separators are unset)
-            idx_diff_sep = AlphaID(majik_num,prefix=pfx,separator="&")
+            idx_diff_sep = AlphaID(majik_num, prefix=pfx, separator="&")
             if pfx is None:
                 assert idx == idx_diff_sep
             else:
@@ -98,11 +114,11 @@ def test_alpha_id():
 
             # Test integer addition
             assert idx + 1 == majik_num + 1
-            assert idx + 1 == AlphaID( majik_num + 1, prefix=pfx, separator=separator)
+            assert idx + 1 == AlphaID(majik_num + 1, prefix=pfx, separator=separator)
 
             # Test string addition/subtraction
-            assert idx + "y" == AlphaID(majik_num + 24, prefix=pfx,separator=separator)
-            assert idx - "z" == AlphaID(majik_num - 25, prefix=pfx,separator=separator)
+            assert idx + "y" == AlphaID(majik_num + 24, prefix=pfx, separator=separator)
+            assert idx - "z" == AlphaID(majik_num - 25, prefix=pfx, separator=separator)
 
             # Test equality, addition, subtraction of AlphaID
             other_idx = AlphaID(100)
@@ -113,7 +129,7 @@ def test_alpha_id():
 
                 assert idx + other_idx == majik_num + 100
                 assert idx + other_idx == AlphaID(majik_num + 100)
-    
+
     # test iterative addition / subtraction
     last_val = None
     next_val = None
@@ -124,6 +140,6 @@ def test_alpha_id():
             assert alpha - 1 == last_val
             assert alpha - AlphaID(1) == last_val
             assert alpha == next_val
-            
+
         last_val = alpha
         next_val = alpha + 1

--- a/emmet-core/tests/test_mpid.py
+++ b/emmet-core/tests/test_mpid.py
@@ -89,6 +89,17 @@ def test_alpha_id():
         majik_num - 100, prefix=ref_idx._prefix, separator=ref_idx._separator
     )
 
+    # test padding
+    padded_idx = AlphaID(majik_num, prefix="cats", separator="^", padlen=8)
+    assert ref_idx == padded_idx
+    assert int(ref_idx) == int(padded_idx)
+    assert str(padded_idx) == ref_idx._prefix + ref_idx._separator + (
+        8 - len(str(ref_idx._identifier))
+    ) * "a" + str(ref_idx._identifier)
+
+    assert AlphaID(majik_num, padlen=10) < AlphaID(majik_num + 1)
+    assert AlphaID(majik_num, padlen=10) > AlphaID(majik_num - 1)
+
     # Test initialization from int
     for pfx in (
         None,

--- a/emmet-core/tests/test_mpid.py
+++ b/emmet-core/tests/test_mpid.py
@@ -1,4 +1,4 @@
-from emmet.core.mpid import MPID, MPculeID
+from emmet.core.mpid import MPID, MPculeID, AlphaID
 import pytest
 
 
@@ -56,3 +56,74 @@ def test_to_str():
         str(MPculeID("b9ba54febc77d2a9177accf4605767db-F6Li1P1-1-2"))
         == "b9ba54febc77d2a9177accf4605767db-F6Li1P1-1-2"
     )
+
+
+def test_alpha_id():
+
+    # Test initialization from MPID-like string
+    mpid_like_idx = AlphaID("mp-149")
+    assert mpid_like_idx == AlphaID(149,prefix="mp",separator="-")
+    assert mpid_like_idx._prefix == "mp"
+    assert mpid_like_idx._separator == "-"
+    assert int(mpid_like_idx) == 149
+    assert mpid_like_idx == MPID("mp-149")
+    assert mpid_like_idx == AlphaID(MPID("mp-149"))
+    assert AlphaID("mvc-160") == MPID("mvc-160")
+    assert AlphaID(160) == MPID("160")
+    assert mpid_like_idx + MPID("mp-140") == AlphaID("mp-289")
+    assert mpid_like_idx - MPID("mp-140") == AlphaID("mp-9")
+    
+    majik_num = 137
+
+    # Test initialization from int
+    for pfx in (None, "iamaprefix",):
+
+        for separator in ("-",":",">"):
+            idx = AlphaID(majik_num,prefix=pfx,separator=separator)
+            assert int(idx) == majik_num
+
+            # Test integer equality
+            assert idx == majik_num
+
+            # Test in/equality when prefix and separators do not match
+            assert idx != AlphaID(majik_num,prefix="unusedprefix")
+
+            # Test equality when separators differ but prefixes are None
+            # (separators are unset)
+            idx_diff_sep = AlphaID(majik_num,prefix=pfx,separator="&")
+            if pfx is None:
+                assert idx == idx_diff_sep
+            else:
+                assert idx != idx_diff_sep
+
+            # Test integer addition
+            assert idx + 1 == majik_num + 1
+            assert idx + 1 == AlphaID( majik_num + 1, prefix=pfx, separator=separator)
+
+            # Test string addition/subtraction
+            assert idx + "y" == AlphaID(majik_num + 24, prefix=pfx,separator=separator)
+            assert idx - "z" == AlphaID(majik_num - 25, prefix=pfx,separator=separator)
+
+            # Test equality, addition, subtraction of AlphaID
+            other_idx = AlphaID(100)
+            assert other_idx != idx
+            if pfx is None:
+                assert idx - other_idx == majik_num - 100
+                assert idx - other_idx == AlphaID(majik_num - 100)
+
+                assert idx + other_idx == majik_num + 100
+                assert idx + other_idx == AlphaID(majik_num + 100)
+    
+    # test iterative addition / subtraction
+    last_val = None
+    next_val = None
+    for i in range(5000):
+        alpha = AlphaID(i)
+        assert int(alpha) == i
+        if i > 0:
+            assert alpha - 1 == last_val
+            assert alpha - AlphaID(1) == last_val
+            assert alpha == next_val
+            
+        last_val = alpha
+        next_val = alpha + 1


### PR DESCRIPTION
**Mistakenly closed #1178 by rebasing git history. This PR expands upon it.**

Defines a new `AlphaID` class that could eventually replace / contain the current `MPID` class. 

From internal discussions, the benefit of the `MPID` system was brevity when the system was relatively new. "mp-149" is easy to remember whereas the current batch of MPIDs are > 3,000,000. 

To replace / augment the current `MPID` system, we need an identifier that:
- Can be sorted
- Can mint an $N+1$ ID given that $N$ IDs have currently been assigned
- Is easy to remember

From this, it was suggested that an alphabetical string (to avoid clashes with the current MPIDs, no numbers can be used) could be used instead. The integer value of this string would essentially be taken as base-26 representation, i.e.:
- "a" = $0 \times 26^0 = 0$
- "bc" = $1 \times 26^1 + 2 \times 26^0 = 28$
- "aaft" = $0 \times 26^3 + 0 \times 26^2 + 5 \times 26^1 + 19 \times 26^0 = 149$

The current implementation supports these features, as well as addition, subtraction, ==, <, > with other AlphaID, int, and the existing MPID. Includes convenience constructor from MPID to AlphaID.

**Tests included for these features.**

To make these easy to remember, we may want to set the pad length (the number of leading zeroes or "a" characters) to be at least 6, which would give us $26^6 = 308,915,776$ total task IDs (minus the ~3,100,000 that have currently been assigned).

Suggestions / discussion are welcome