### PR TITLE
Slim version of TaskDoc for production

### DIFF
--- a/emmet-builders/emmet/builders/vasp/task_validator.py
+++ b/emmet-builders/emmet/builders/vasp/task_validator.py
@@ -75,7 +75,9 @@ class TaskValidator(MapBuilder):
             potcar_stats=self.potcar_stats,
         )
 
-        bad_tags = list(set(task_doc.tags).intersection(self.settings.DEPRECATED_TAGS))
+        bad_tags = list(
+            set(task_doc.tags or []).intersection(self.settings.DEPRECATED_TAGS)
+        )
         if len(bad_tags) > 0:
             validation_doc.warnings.append(f"Manual Deprecation by tags: {bad_tags}")
             validation_doc.valid = False

--- a/emmet-core/emmet/core/material.py
+++ b/emmet-core/emmet/core/material.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 from pymatgen.core import Structure
 from pymatgen.core.structure import Molecule
 
+from emmet.core.base import EmmetBaseModel
 from emmet.core.common import convert_datetime
 from emmet.core.mpid import MPID, AlphaID, MPculeID
 from emmet.core.structure import MoleculeMetadata, StructureMetadata
@@ -18,6 +19,7 @@ from emmet.core.vasp.validation import DeprecationMessage
 
 if TYPE_CHECKING:
     from typing import Any
+
     from typing_extensions import Self
 
 
@@ -46,7 +48,7 @@ class PropertyOrigin(BaseModel):
         return config
 
 
-class MaterialsDoc(StructureMetadata):
+class MaterialsDoc(StructureMetadata, EmmetBaseModel):
     """
     Definition for a core Materials Document
     """
@@ -137,7 +139,7 @@ class MaterialsDoc(StructureMetadata):
         return config
 
 
-class CoreMoleculeDoc(MoleculeMetadata):
+class CoreMoleculeDoc(MoleculeMetadata, EmmetBaseModel):
     """
     Definition for a core Molecule Document
     """

--- a/emmet-core/emmet/core/material_property.py
+++ b/emmet-core/emmet/core/material_property.py
@@ -10,21 +10,23 @@ from pydantic import Field, model_validator
 from pydantic.json_schema import SkipJsonSchema
 from pymatgen.core import Structure
 
+from emmet.core.base import EmmetBaseModel
 from emmet.core.common import convert_datetime
 from emmet.core.material import PropertyOrigin
-from emmet.core.mpid import AlphaID, MPID
+from emmet.core.mpid import MPID, AlphaID
 from emmet.core.structure import StructureMetadata
 from emmet.core.utils import utcnow
 from emmet.core.vasp.validation import DeprecationMessage
 
 if TYPE_CHECKING:
     from typing import Any
+
     from typing_extensions import Self
 
     from emmet.core.mpid import MPID
 
 
-class PropertyDoc(StructureMetadata):
+class PropertyDoc(StructureMetadata, EmmetBaseModel):
     """
     Base model definition for any singular materials property.
 

--- a/emmet-core/emmet/core/spectrum.py
+++ b/emmet-core/emmet/core/spectrum.py
@@ -4,13 +4,14 @@ from datetime import datetime
 
 from pydantic import Field, field_validator
 
+from emmet.core.base import EmmetBaseModel
 from emmet.core.common import convert_datetime
-from emmet.core.mpid import AlphaID, MPID
+from emmet.core.mpid import MPID, AlphaID
 from emmet.core.structure import StructureMetadata
 from emmet.core.utils import utcnow
 
 
-class SpectrumDoc(StructureMetadata):
+class SpectrumDoc(StructureMetadata, EmmetBaseModel):
     """
     Base model definition for any spectra document. This should contain
     metadata on the structure the spectra pertains to

--- a/emmet-core/emmet/core/structure.py
+++ b/emmet-core/emmet/core/structure.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, TypeVar
 
-from pydantic import Field
+from pydantic import BaseModel, Field
 from pymatgen.core.composition import Composition
 from pymatgen.core.periodic_table import Element
 from pymatgen.core.structure import Molecule, Structure
 
-from emmet.core.base import EmmetBaseModel
 from emmet.core.symmetry import PointGroupData, SymmetryData
 from emmet.core.utils import get_graph_hash
 
@@ -25,7 +24,7 @@ except Exception:
     openbabel = None
 
 
-class StructureMetadata(EmmetBaseModel):
+class StructureMetadata(BaseModel):
     """Mix-in class for structure metadata."""
 
     # Structure metadata
@@ -162,7 +161,7 @@ class StructureMetadata(EmmetBaseModel):
         return cls(**kwargs)
 
 
-class MoleculeMetadata(EmmetBaseModel):
+class MoleculeMetadata(BaseModel):
     """Mix-in class for molecule metadata."""
 
     charge: int | None = Field(None, description="Charge of the molecule")

--- a/emmet-core/emmet/core/tasks.py
+++ b/emmet-core/emmet/core/tasks.py
@@ -383,7 +383,7 @@ class CoreTaskDoc(StructureMetadata):
             vasp_objects=vasp_objects,
         )
 
-        props = {
+        props: dict[str, Any] = {
             "structure": [],
             "cart_coords": [],
             "electronic_steps": [],

--- a/emmet-core/emmet/core/tasks.py
+++ b/emmet-core/emmet/core/tasks.py
@@ -313,7 +313,7 @@ class CoreTaskDoc(StructureMetadata):
                 for char in batch_id
                 if (not char.isalnum()) and (char not in {"-", "_"})
             )
-            if len(invalid_chars) > 0:
+            if invalid_chars:
                 raise ValueError(
                     f"Invalid characters in batch_id: {' '.join(invalid_chars)}"
                 )

--- a/emmet-core/emmet/core/tasks.py
+++ b/emmet-core/emmet/core/tasks.py
@@ -4,16 +4,16 @@ from __future__ import annotations
 
 import logging
 import re
+import warnings
 from collections.abc import Mapping
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-import warnings
 
 import numpy as np
 from monty.json import MontyDecoder
 from monty.serialization import loadfn
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from pymatgen.analysis.structure_analyzer import oxide_type
 from pymatgen.core.structure import Structure
 from pymatgen.core.trajectory import Trajectory
@@ -21,8 +21,9 @@ from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEn
 from pymatgen.io.vasp import Incar, Kpoints, Poscar
 
 from emmet.core.common import convert_datetime
-from emmet.core.mpid import AlphaID, MPID
+from emmet.core.mpid import MPID, AlphaID
 from emmet.core.structure import StructureMetadata
+from emmet.core.trajectory import Trajectory as CoreTrajectory
 from emmet.core.utils import utcnow
 from emmet.core.vasp.calc_types import (
     CalcType,
@@ -35,6 +36,7 @@ from emmet.core.vasp.calc_types import (
 from emmet.core.vasp.calculation import (
     Calculation,
     CalculationInput,
+    CoreCalculationOutput,
     PotcarSpec,
     RunStatistics,
     VaspObject,
@@ -44,6 +46,7 @@ from emmet.core.vasp.utils import TASK_NAMES, discover_and_sort_vasp_files
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
     from typing_extensions import Self
 
 monty_decoder = MontyDecoder()
@@ -243,137 +246,68 @@ class AnalysisDoc(BaseModel):
         )
 
 
-class TaskDoc(StructureMetadata, extra="allow"):
-    """Calculation-level details about VASP calculations that power Materials Project."""
+class CoreTaskDoc(StructureMetadata):
+    """Calculation-level details about VASP calculations that power the Materials Project."""
 
-    tags: list[str] | None = Field(
-        [], title="tag", description="Metadata tagged to a given task."
-    )
-    dir_name: str | None = Field(None, description="The directory for this VASP task")
-
-    state: TaskState | None = Field(None, description="State of this calculation")
-
-    calcs_reversed: list[Calculation] | None = Field(
+    batch_id: str | None = Field(
         None,
-        title="Calcs reversed data",
-        description="Detailed data for each VASP calculation contributing to the task document.",
+        description="Identifier for this calculation; should provide rough information about the calculation origin and purpose.",
     )
-
-    structure: Structure | None = Field(
-        None, description="Final output structure from the task"
-    )
-
-    task_type: TaskType | CalcType | None = Field(
-        None, description="The type of calculation."
-    )
-
-    run_type: RunType | None = Field(
-        None, description="The functional used in the calculation."
-    )
-
     calc_type: CalcType | None = Field(
         None, description="The functional and task type used in the calculation."
     )
-
+    completed_at: datetime | None = Field(
+        None, description="Timestamp for when this task was completed"
+    )
+    dir_name: str | None = Field(None, description="The directory for this VASP task")
+    icsd_id: int | None = Field(
+        None, description="Inorganic Crystal Structure Database id of the structure"
+    )
+    input: CalculationInput | None = Field(
+        None,
+        description="VASP calculation inputs",
+    )
+    last_updated: datetime = Field(
+        description="Timestamp for the most recent calculation for this task document",
+        default_factory=utcnow,
+    )
+    orig_inputs: CalculationInput | None = Field(
+        None,
+        description="The exact set of input parameters used to generate the current task document.",
+    )
+    output: CoreCalculationOutput | None = Field(
+        None,
+        description="VASP calculation outputs.",
+    )
+    run_type: RunType | None = Field(
+        None, description="The functional used in the calculation."
+    )
+    structure: Structure | None = Field(
+        None, description="Final output structure from the task"
+    )
+    tags: list[str] | None = Field(
+        None, title="tag", description="Metadata tagged to a given task."
+    )
     task_id: MPID | AlphaID | None = Field(
         None,
         description="The (task) ID of this calculation, used as a universal reference across property documents."
         "This comes in the form: mp-******.",
     )
-
-    orig_inputs: CalculationInput | None = Field(
-        None,
-        description="The exact set of input parameters used to generate the current task document.",
-    )
-
-    input: CalculationInput | None = Field(
-        None,
-        description="The input structure used to generate the current task document.",
-    )
-
-    output: OutputDoc | None = Field(
-        None,
-        description="The exact set of output parameters used to generate the current task document.",
-    )
-
-    included_objects: list[VaspObject] | None = Field(
-        None, description="List of VASP objects included with this task document"
-    )
-    vasp_objects: dict[VaspObject, Any] | None = Field(
-        None, description="Vasp objects associated with this task"
-    )
-    entry: ComputedEntry | None = Field(
-        None, description="The ComputedEntry from the task doc"
-    )
-
-    task_label: str | None = Field(None, description="A description of the task")
-    author: str | None = Field(
-        None, description="Author extracted from transformations"
-    )
-    icsd_id: str | int | None = Field(
-        None, description="Inorganic Crystal Structure Database id of the structure"
+    task_type: TaskType | CalcType | None = Field(
+        None, description="The type of calculation."
     )
     transformations: Any | None = Field(
         None,
         description="Information on the structural transformations, parsed from a "
         "transformations.json file",
     )
-    additional_json: dict[str, Any] | None = Field(
-        None, description="Additional json loaded from the calculation directory"
+    vasp_objects: dict[VaspObject, Any] | None = Field(
+        None, description="Vasp objects associated with this task"
     )
 
-    custodian: list[CustodianDoc] | None = Field(
-        None,
-        title="Calcs reversed data",
-        description="Detailed custodian data for each VASP calculation contributing to the task document.",
-    )
-
-    analysis: AnalysisDoc | None = Field(
-        None,
-        title="Calculation Analysis",
-        description="Some analysis of calculation data after collection.",
-    )
-
-    last_updated: datetime = Field(
-        default_factory=utcnow,
-        description="Timestamp for the most recent calculation for this task document",
-    )
-
-    completed_at: datetime | None = Field(
-        None, description="Timestamp for when this task was completed"
-    )
-
-    batch_id: str | None = Field(
-        None,
-        description="Identifier for this calculation; should provide rough information about the calculation origin and purpose.",
-    )
-
-    run_stats: Mapping[str, RunStatistics] | None = Field(
-        None,
-        description="Summary of runtime statistics for each calculation in this task",
-    )
-
-    # Note that private fields are needed because TaskDoc permits extra info
-    # added to the model, unlike TaskDocument. Because of this, when pydantic looks up
-    # attrs on the model, it searches for them in the model extra dict first, and if it
-    # can't find them, throws an AttributeError. It does this before looking to see if the
-    # class has that attr defined on it.
-
-    # _structure_entry: ComputedStructureEntry | None= PrivateAttr(None)
-
-    @model_validator(mode="before")
-    @classmethod
-    def set_model_pre_fields(cls, values: Any) -> Any:
-        """Ensure all important model fields are set and refreshed."""
-
-        # Make sure that the datetime field is properly formatted
-        # (Unclear when this is not the case, please leave comment if observed)
-        values["last_updated"] = convert_datetime(
-            cls, values.get("last_updated", utcnow())
-        )
-
-        # Ensure batch_id includes only valid characters
-        if (batch_id := values.get("batch_id")) is not None:
+    @field_validator("batch_id", mode="before")
+    def validate_batch_id(cls, batch_id: str):
+        if batch_id:
             invalid_chars = set(
                 char
                 for char in batch_id
@@ -383,6 +317,147 @@ class TaskDoc(StructureMetadata, extra="allow"):
                 raise ValueError(
                     f"Invalid characters in batch_id: {' '.join(invalid_chars)}"
                 )
+        return batch_id
+
+    @field_validator("last_updated", mode="before")
+    @classmethod
+    def handle_datetime(cls, last_updated) -> Any:
+        return convert_datetime(cls, last_updated)
+
+    @classmethod
+    def from_directory(
+        cls,
+        dir_name: Path | str,
+        volumetric_files: tuple[str, ...] = _VOLUMETRIC_FILES,
+        **vasp_calculation_kwargs,
+    ) -> tuple[Self, CoreTrajectory]:
+        """
+        Create a CoreTaskDoc and corresponding CoreTrajectory from a
+        directory containing VASP files.
+
+        Only parses a single calculation. Use TaskDoc.from_directory(...)
+        to parse multiple calculations.
+
+        Parameters
+        ----------
+        dir_name
+            The path to the folder containing the calculation outputs.
+        volumetric_files
+            Volumetric files to search for.
+        **vasp_calculation_kwargs
+            Additional parsing options that will be passed to the
+            :obj:`.Calculation.from_vasp_files` function.
+
+        Returns
+        -------
+        CoreTaskDoc
+            A slim task document for the calculation.
+        CoreTrajectory
+            A low memory document for the calculation's trajectory.
+        """
+        dir_name = Path(dir_name)
+        task_files = _find_vasp_files(dir_name, volumetric_files=volumetric_files)
+
+        calc_doc, vasp_objects = Calculation.from_vasp_files(
+            dir_name, "standard", **task_files["standard"], **vasp_calculation_kwargs
+        )
+        transformations, icsd_id, tags, author = _parse_transformations(dir_name)
+        task_doc = cls.from_structure(
+            calc_type=calc_doc.calc_type,
+            completed_at=calc_doc.completed_at,
+            dir_name=get_uri(dir_name),
+            icsd_id=icsd_id,
+            input=InputDoc.from_vasp_calc_doc(calc_doc),
+            meta_structure=calc_doc.output.structure,
+            orig_inputs=_parse_orig_inputs(dir_name),
+            output=CoreCalculationOutput(
+                **calc_doc.output.model_dump(
+                    include=set(CoreCalculationOutput.model_fields())
+                )
+            ),
+            run_type=calc_doc.run_type,
+            structure=calc_doc.output.structure,
+            tags=tags,
+            task_type=calc_doc.task_type,
+            transformations=transformations,
+            vasp_objects=vasp_objects,
+        )
+
+        props = {
+            "structure": [],
+            "cart_coords": [],
+            "electronic_steps": [],
+            "energy": [],
+            "e_wo_entrp": [],
+            "e_fr_energy": [],
+            "forces": [],
+            "stress": [],
+        }
+
+        for ionic_step in calc_doc.output.ionic_steps:
+            props["structure"].append(ionic_step.structure)
+            props["energy"].append(ionic_step.e_0_energy)
+            for k in (
+                "e_fr_energy",
+                "e_wo_entrp",
+                "forces",
+                "stress",
+                "electronic_steps",
+            ):
+                props[k].append(getattr(ionic_step, k))
+
+        trajectory = CoreTrajectory._from_dict(
+            props, task_type=calc_doc.task_type, run_type=calc_doc.run_type
+        )
+
+        return (task_doc, trajectory)
+
+
+class TaskDoc(CoreTaskDoc, extra="allow"):
+    """Flexible wrapper around CoreTaskDoc"""
+
+    additional_json: dict[str, Any] | None = Field(
+        None, description="Additional json loaded from the calculation directory"
+    )
+    analysis: AnalysisDoc | None = Field(
+        None,
+        title="Calculation Analysis",
+        description="Some analysis of calculation data after collection.",
+    )
+    author: str | None = Field(
+        None, description="Author extracted from transformations"
+    )
+    calcs_reversed: list[Calculation] | None = Field(
+        None,
+        title="Calcs reversed data",
+        description="Detailed data for each VASP calculation contributing to the task document.",
+    )
+    custodian: list[CustodianDoc] | None = Field(
+        None,
+        title="Calcs reversed data",
+        description="Detailed custodian data for each VASP calculation contributing to the task document.",
+    )
+    entry: ComputedEntry | None = Field(
+        None, description="The ComputedEntry from the task doc"
+    )
+    included_objects: list[VaspObject] | None = Field(
+        None, description="List of VASP objects included with this task document"
+    )
+    output: OutputDoc | None = Field(
+        None,
+        description="The exact set of output parameters used to generate the current task document.",
+    )
+    run_stats: Mapping[str, RunStatistics] | None = Field(
+        None,
+        description="Summary of runtime statistics for each calculation in this task",
+    )
+    state: TaskState | None = Field(None, description="State of this calculation")
+    task_label: str | None = Field(None, description="A description of the task")
+
+    @model_validator(mode="before")
+    @classmethod
+    def set_model_pre_fields(cls, values: Any) -> Any:
+        """Ensure all important model fields are set and refreshed."""
 
         # Always refresh task_type, calc_type, run_type
         # if attributes containing input sets are available.
@@ -437,6 +512,7 @@ class TaskDoc(StructureMetadata, extra="allow"):
     ) -> Self:
         """
         Create a task document from a directory containing VASP files.
+
 
         Parameters
         ----------
@@ -511,7 +587,6 @@ class TaskDoc(StructureMetadata, extra="allow"):
         doc = cls.from_structure(
             structure=calcs_reversed[0].output.structure,
             meta_structure=calcs_reversed[0].output.structure,
-            include_structure=True,
             dir_name=dir_name,
             calcs_reversed=calcs_reversed,
             analysis=analysis,
@@ -592,7 +667,6 @@ class TaskDoc(StructureMetadata, extra="allow"):
         doc = cls.from_structure(
             structure=calcs_reversed[0].output.structure,
             meta_structure=calcs_reversed[0].output.structure,
-            include_structure=True,
             dir_name=get_uri(dir_name),
             calcs_reversed=calcs_reversed,
             analysis=analysis,

--- a/emmet-core/emmet/core/trajectory.py
+++ b/emmet-core/emmet/core/trajectory.py
@@ -2,24 +2,23 @@
 
 from __future__ import annotations
 
-from copy import deepcopy
+import logging
 from collections import defaultdict
 from collections.abc import Iterable
+from copy import deepcopy
 from enum import Enum
-import logging
-import numpy as np
-from pydantic import BaseModel, Field, model_validator
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from pymatgen.core import Element, Structure, Molecule
-from pymatgen.core.trajectory import Trajectory as PmgTrajectory
-
+import numpy as np
 from monty.dev import requires
 from monty.serialization import dumpfn
+from pydantic import BaseModel, Field, model_validator
+from pymatgen.core import Element, Molecule, Structure
+from pymatgen.core.trajectory import Trajectory as PmgTrajectory
 
-from emmet.core.math import Vector3D, Matrix3D
-from emmet.core.vasp.calc_types import RunType, TaskType, run_type, task_type, calc_type
+from emmet.core.math import Matrix3D, Vector3D
+from emmet.core.vasp.calc_types import RunType, TaskType, calc_type, run_type, task_type
 from emmet.core.vasp.calculation import ElectronicStep
 
 logger = logging.getLogger(__name__)
@@ -36,10 +35,11 @@ except ImportError:
 
 if TYPE_CHECKING:
     from typing import Any
+
     from typing_extensions import Self
 
-    from emmet.core.vasp.calculation import Calculation
     from emmet.core.vasp.calc_types import CalcType
+    from emmet.core.vasp.calculation import Calculation
 
 
 class TrajFormat(Enum):
@@ -656,7 +656,7 @@ class Trajectory(AtomTrajectory):
         return dict(props), rt, tt, ct
 
     @classmethod
-    def from_task_doc(cls, task_doc: Any, **kwargs) -> list["Trajectory"]:
+    def from_task_doc(cls, task_doc, **kwargs) -> list["Trajectory"]:
         """
         Create trajectories from a TaskDoc.
 

--- a/emmet-core/emmet/core/vasp/calculation.py
+++ b/emmet-core/emmet/core/vasp/calculation.py
@@ -2,15 +2,15 @@
 
 from __future__ import annotations
 
-from functools import cached_property
 import logging
 import os
 from datetime import datetime
+from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from pydantic import BaseModel, ConfigDict, Field, model_validator, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from pymatgen.command_line.bader_caller import bader_analysis_from_path
 from pymatgen.command_line.chargemol_caller import ChargemolAnalysis
 from pymatgen.core.lattice import Lattice
@@ -19,18 +19,9 @@ from pymatgen.core.trajectory import Trajectory
 from pymatgen.electronic_structure.bandstructure import BandStructure
 from pymatgen.electronic_structure.core import OrbitalType
 from pymatgen.electronic_structure.dos import CompleteDos, Dos
-from pymatgen.io.vasp import (
-    BSVasprun,
-    Kpoints,
-    Locpot,
-    Oszicar,
-    Outcar,
-    Poscar,
-    Potcar as VaspPotcar,
-    PotcarSingle,
-    Vasprun,
-    VolumetricData,
-)
+from pymatgen.io.vasp import BSVasprun, Kpoints, Locpot, Oszicar, Outcar, Poscar
+from pymatgen.io.vasp import Potcar as VaspPotcar
+from pymatgen.io.vasp import PotcarSingle, Vasprun, VolumetricData
 
 from emmet.core.math import ListMatrix3D, Matrix3D, Vector3D
 from emmet.core.utils import ValueEnum
@@ -510,22 +501,9 @@ class IonicStep(BaseModel):  # type: ignore
         return self
 
 
-class CalculationOutput(BaseModel):
-    """Document defining VASP calculation outputs."""
+class CoreCalculationOutput(BaseModel):
+    """Document defining core VASP calculation outputs."""
 
-    energy: float | None = Field(
-        None, description="The final total DFT energy for the calculation"
-    )
-    energy_per_atom: float | None = Field(
-        None, description="The final DFT energy per atom for the calculation"
-    )
-    structure: Structure | None = Field(
-        None, description="The final structure from the calculation"
-    )
-    efermi: float | None = Field(
-        None, description="The Fermi level from the calculation in eV"
-    )
-    is_metal: bool | None = Field(None, description="Whether the system is metallic")
     bandgap: float | None = Field(
         None, description="The band gap from the calculation in eV"
     )
@@ -533,17 +511,47 @@ class CalculationOutput(BaseModel):
         None,
         description="The conduction band minimum in eV (if system is not metallic)",
     )
-    vbm: float | None = Field(
-        None, description="The valence band maximum in eV (if system is not metallic)"
-    )
-    is_gap_direct: bool | None = Field(
-        None, description="Whether the band gap is direct"
+    density: float | None = Field(
+        None, description="Density of final structure in units of g/cc."
     )
     direct_gap: float | None = Field(
         None, description="Direct band gap in eV (if system is not metallic)"
     )
-    transition: str | None = Field(
-        None, description="Band gap transition given by CBM and VBM k-points"
+    dos_properties: dict[str, dict[str, dict[str, float]]] | None = Field(
+        None,
+        description="Element- and orbital-projected band properties (in eV) for the "
+        "DOS. All properties are with respect to the Fermi level.",
+    )
+    efermi: float | None = Field(
+        None, description="The Fermi level from the calculation in eV"
+    )
+    energy: float | None = Field(
+        None, description="The final total DFT energy for the calculation"
+    )
+    energy_per_atom: float | None = Field(
+        None, description="The final DFT energy per atom for the calculation"
+    )
+    epsilon_ionic: ListMatrix3D | None = Field(
+        None, description="The ionic part of the dielectric constant"
+    )
+    epsilon_static: ListMatrix3D | None = Field(
+        None, description="The high-frequency dielectric constant"
+    )
+    epsilon_static_wolfe: ListMatrix3D | None = Field(
+        None,
+        description="The high-frequency dielectric constant w/o local field effects",
+    )
+    frequency_dependent_dielectric: FrequencyDependentDielectric | None = Field(
+        None,
+        description="Frequency-dependent dielectric information from an LOPTICS "
+        "calculation",
+    )
+    is_gap_direct: bool | None = Field(
+        None, description="Whether the band gap is direct"
+    )
+    is_metal: bool | None = Field(None, description="Whether the system is metallic")
+    locpot: dict[int, list[float]] | None = Field(
+        None, description="Average of the local potential along the crystal axes"
     )
     mag_density: float | None = Field(
         None,
@@ -553,38 +561,33 @@ class CalculationOutput(BaseModel):
     optical_absorption_coeff: list | None = Field(
         None, description="Optical absorption coefficient in cm^-1"
     )
-    epsilon_static: ListMatrix3D | None = Field(
-        None, description="The high-frequency dielectric constant"
-    )
-    epsilon_static_wolfe: ListMatrix3D | None = Field(
-        None,
-        description="The high-frequency dielectric constant w/o local field effects",
-    )
-    epsilon_ionic: ListMatrix3D | None = Field(
-        None, description="The ionic part of the dielectric constant"
-    )
-    frequency_dependent_dielectric: FrequencyDependentDielectric | None = Field(
-        None,
-        description="Frequency-dependent dielectric information from an LOPTICS "
-        "calculation",
-    )
-    ionic_steps: list[IonicStep] | None = Field(
-        None, description="Energy, forces, structure, etc. for each ionic step"
-    )
-    num_electronic_steps: list[int] | None = Field(
-        None, description="The number of electronic steps in each ionic step."
-    )
-    locpot: dict[int, list[float]] | None = Field(
-        None, description="Average of the local potential along the crystal axes"
-    )
     outcar: dict[str, Any] | None = Field(
         None, description="Information extracted from the OUTCAR file"
+    )
+    structure: Structure | None = Field(
+        None, description="The final structure from the calculation"
+    )
+    transition: str | None = Field(
+        None, description="Band gap transition given by CBM and VBM k-points"
+    )
+    vbm: float | None = Field(
+        None, description="The valence band maximum in eV (if system is not metallic)"
+    )
+
+
+class CalculationOutput(CoreCalculationOutput):
+    """Wrapper for CoreCalculationOutput for parsing and storing larger fields."""
+
+    elph_displaced_structures: ElectronPhononDisplacedStructures | None = Field(
+        None,
+        description="Electron-phonon displaced structures, generated by setting "
+        "PHON_LMC = True.",
     )
     force_constants: list[list[Matrix3D]] | None = Field(
         None, description="Force constants between every pair of atoms in the structure"
     )
-    normalmode_frequencies: list[float] | None = Field(
-        None, description="Frequencies in THz of the normal modes at Gamma"
+    ionic_steps: list[IonicStep] | None = Field(
+        None, description="Energy, forces, structure, etc. for each ionic step"
     )
     normalmode_eigenvals: list[float] | None = Field(
         None,
@@ -594,15 +597,11 @@ class CalculationOutput(BaseModel):
     normalmode_eigenvecs: list[list[Vector3D]] | None = Field(
         None, description="Normal mode eigenvectors of phonon modes at Gamma"
     )
-    elph_displaced_structures: ElectronPhononDisplacedStructures | None = Field(
-        None,
-        description="Electron-phonon displaced structures, generated by setting "
-        "PHON_LMC = True.",
+    normalmode_frequencies: list[float] | None = Field(
+        None, description="Frequencies in THz of the normal modes at Gamma"
     )
-    dos_properties: dict[str, dict[str, dict[str, float]]] | None = Field(
-        None,
-        description="Element- and orbital-projected band properties (in eV) for the "
-        "DOS. All properties are with respect to the Fermi level.",
+    num_electronic_steps: list[int] | None = Field(
+        None, description="The number of electronic steps in each ionic step."
     )
     run_stats: RunStatistics | None = Field(
         None, description="Summary of runtime statistics for this calculation"

--- a/emmet-core/emmet/core/vasp/material.py
+++ b/emmet-core/emmet/core/vasp/material.py
@@ -11,7 +11,6 @@ from emmet.core.base import EmmetMeta
 from emmet.core.material import MaterialsDoc as CoreMaterialsDoc
 from emmet.core.material import PropertyOrigin
 from emmet.core.settings import EmmetSettings
-from emmet.core.structure import StructureMetadata
 from emmet.core.tasks import TaskDoc
 from emmet.core.utils import utcnow
 from emmet.core.vasp.calc_types import CalcType, RunType, TaskType
@@ -28,7 +27,7 @@ class BlessedCalcs(BaseModel, populate_by_name=True):
     HSE: ComputedStructureEntry | None = None
 
 
-class MaterialsDoc(CoreMaterialsDoc, StructureMetadata):
+class MaterialsDoc(CoreMaterialsDoc):
     calc_types: Mapping[str, CalcType] | None = Field(  # type: ignore
         None,
         description="Calculation types for all the calculations that make up this material",

--- a/emmet-core/emmet/core/vasp/validation_legacy.py
+++ b/emmet-core/emmet/core/vasp/validation_legacy.py
@@ -3,21 +3,22 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
-from pydantic import Field, ImportString, field_validator
+from pydantic import BaseModel, Field, ImportString, field_validator
 from pymatgen.core.structure import Structure
 from pymatgen.io.vasp.inputs import Kpoints
 from pymatgen.io.vasp.sets import VaspInputSet
 
 from emmet.core.base import EmmetBaseModel
 from emmet.core.common import convert_datetime
-from emmet.core.mpid import MPID
+from emmet.core.mpid import MPID, AlphaID
 from emmet.core.settings import EmmetSettings
-from emmet.core.tasks import TaskDoc
+from emmet.core.tasks import CoreTaskDoc, TaskDoc
 from emmet.core.utils import utcnow
-from emmet.core.vasp.calc_types.enums import CalcType, TaskType, RunType
+from emmet.core.vasp.calc_types.enums import CalcType, TaskType
+from emmet.core.vasp.calculation import CoreCalculationOutput
 from emmet.core.vasp.task_valid import TaskDocument
 from emmet.core.vasp.validation import DeprecationMessage
 
@@ -27,12 +28,21 @@ if TYPE_CHECKING:
 SETTINGS = EmmetSettings()
 
 
-class ValidationDoc(EmmetBaseModel):
+class ValidationDataDict(BaseModel):
+    encut_ratio: float | None = Field(None)
+    max_gradient: Optional[float] = Field(None)
+    kspacing_delta: float | None = Field(None)
+    kpts_ratio: float | None = Field(None)
+
+
+class ValidationDoc(EmmetBaseModel, extra="allow"):
     """
     Validation document for a VASP calculation
     """
 
-    task_id: MPID = Field(..., description="The task_id for this validation document")
+    task_id: MPID | AlphaID = Field(
+        ..., description="The task_id for this validation document"
+    )
     valid: bool = Field(False, description="Whether this task is valid or not")
     last_updated: datetime = Field(
         description="Last updated date for this document",
@@ -44,21 +54,19 @@ class ValidationDoc(EmmetBaseModel):
     warnings: list[str] = Field(
         [], description="List of potential warnings about this calculation"
     )
-    data: dict = Field(
+    data: ValidationDataDict | None = Field(
+        None,
         description="Dictioary of data used to perform validation."
-        " Useful for post-mortem analysis"
+        " Useful for post-mortem analysis",
     )
-
     nelements: int | None = Field(None, description="Number of elements.")
     symmetry_number: int | None = Field(
         None,
         title="Space Group Number",
         description="The spacegroup number for the lattice.",
     )
-    run_type: RunType | None = Field(
-        None, description="The run type of the calculation"
-    )
-    calc_type: CalcType | None = Field(None, description="The calculation type.")
+    chemsys: str | None = Field(None)
+    formula_pretty: str | None = Field(None)
 
     @field_validator("last_updated", mode="before")
     @classmethod
@@ -68,7 +76,7 @@ class ValidationDoc(EmmetBaseModel):
     @classmethod
     def from_task_doc(
         cls,
-        task_doc: TaskDoc | TaskDocument,
+        task_doc: CoreTaskDoc | TaskDoc | TaskDocument,
         kpts_tolerance: float = SETTINGS.VASP_KPTS_TOLERANCE,
         kspacing_tolerance: float = SETTINGS.VASP_KSPACING_TOLERANCE,
         input_sets: dict[str, ImportString] = SETTINGS.VASP_DEFAULT_INPUT_SETS,
@@ -99,16 +107,23 @@ class ValidationDoc(EmmetBaseModel):
         calc_type = task_doc.calc_type
         task_type = task_doc.task_type
         run_type = task_doc.run_type
-        inputs = task_doc.orig_inputs
         chemsys = task_doc.chemsys
-        calcs_reversed = [
-            calc if not hasattr(calc, "model_dump") else calc.model_dump()
-            for calc in task_doc.calcs_reversed
-        ]
+        formula_pretty = task_doc.formula_pretty
 
-        if calcs_reversed[0].get("input", {}).get("structure", None):
-            structure = calcs_reversed[0]["input"]["structure"]
+        if isinstance(task_doc, (TaskDoc, TaskDocument)):
+            inputs = task_doc.orig_inputs
+            calcs_reversed = [
+                calc if not hasattr(calc, "model_dump") else calc.model_dump()
+                for calc in task_doc.calcs_reversed
+            ]
+
+            if calcs_reversed[0].get("input", {}).get("structure", None):
+                structure = calcs_reversed[0]["input"]["structure"]
+            else:
+                structure = task_doc.input.structure or task_doc.output.structure
         else:
+            inputs = task_doc.input
+            calcs_reversed = None
             structure = task_doc.input.structure or task_doc.output.structure
 
         if isinstance(structure, dict):
@@ -195,11 +210,12 @@ class ValidationDoc(EmmetBaseModel):
                 if _u_value_checks(task_doc, valid_input_set, warnings):
                     reasons.append(DeprecationMessage.LDAU)
 
-                # Check the max upwards SCF step
-                if _scf_upward_check(
-                    calcs_reversed, inputs, data, max_allowed_scf_gradient, warnings
-                ):
-                    reasons.append(DeprecationMessage.MAX_SCF)
+                if calcs_reversed:
+                    # Check the max upwards SCF step
+                    if _scf_upward_check(
+                        calcs_reversed, inputs, data, max_allowed_scf_gradient, warnings
+                    ):
+                        reasons.append(DeprecationMessage.MAX_SCF)
 
                 # Check for Am and Po elements. These currently do not have proper elemental entries
                 # and will not get treated properly by the thermo builder.
@@ -207,8 +223,16 @@ class ValidationDoc(EmmetBaseModel):
                     reasons.append(DeprecationMessage.MANUAL)
 
                 # Check for magmom anomalies for specific elements
-                if _magmom_check(calcs_reversed, structure, max_magmoms=max_magmoms):
-                    reasons.append(DeprecationMessage.MAG)
+                if calcs_reversed:
+                    if _magmom_check(
+                        calcs_reversed, structure, max_magmoms=max_magmoms
+                    ):
+                        reasons.append(DeprecationMessage.MAG)
+                else:
+                    if _magmom_check(
+                        task_doc.output, structure, max_magmoms=max_magmoms
+                    ):
+                        reasons.append(DeprecationMessage.MAG)
             else:
                 if "Unrecognized" in str(calc_type):
                     reasons.append(DeprecationMessage.UNKNOWN)
@@ -225,6 +249,8 @@ class ValidationDoc(EmmetBaseModel):
             warnings=warnings,
             nelements=nelements,
             symmetry_number=symmetry_number,
+            chemsys=chemsys,
+            formula_pretty=formula_pretty,
         )
 
         return doc
@@ -359,7 +385,8 @@ def _potcar_stats_check(
 
     try:
         potcar_details = task_doc.calcs_reversed[0].model_dump()["input"]["potcar_spec"]
-
+    except AttributeError:
+        potcar_details = task_doc.input.model_dump()["potcar_spec"]
     except KeyError:
         # Assume it is an old calculation without potcar_spec data and treat it as passing POTCAR hash check
         return False
@@ -436,20 +463,32 @@ def _potcar_stats_check(
 
 
 def _magmom_check(
-    calcs_reversed: list, structure: Structure, max_magmoms: dict[str, float]
+    calc: list | CoreCalculationOutput,
+    structure: Structure,
+    max_magmoms: dict[str, float],
 ):
     """
     Checks for maximum magnetization values for specific elements.
     Returns True if the maximum absolute value outlined below is exceded for the associated element.
     """
-    if (outcar := calcs_reversed[0]["output"]["outcar"]) and (
-        mag_info := outcar.get("magnetization", [])
-    ):
-        return any(
-            abs(mag_info[isite].get("tot", 0.0))
-            > abs(max_magmoms.get(site.label, np.inf))
-            for isite, site in enumerate(structure)
-        )
+
+    if isinstance(calc, CoreCalculationOutput):
+        if (outcar := calc.outcar) and (mag_info := outcar.get("magnetization", [])):
+            return any(
+                abs(mag_info[isite].get("tot", 0.0))
+                > abs(max_magmoms.get(site.label, np.inf))
+                for isite, site in enumerate(structure)
+            )
+    else:
+        if (outcar := calc[0]["output"]["outcar"]) and (
+            mag_info := outcar.get("magnetization", [])
+        ):
+            return any(
+                abs(mag_info[isite].get("tot", 0.0))
+                > abs(max_magmoms.get(site.label, np.inf))
+                for isite, site in enumerate(structure)
+            )
+
     return False
 
 

--- a/emmet-core/tests/test_utils.py
+++ b/emmet-core/tests/test_utils.py
@@ -5,18 +5,18 @@ from pathlib import Path
 import numpy as np
 import pytest
 from bson.objectid import ObjectId
-from emmet.core.utils import (
-    DocEnum,
-    ValueEnum,
-    jsanitize,
-    get_hash_blocked,
-    get_flat_models_from_model,
-    dynamic_import,
-)
 from monty.json import MSONable
 from monty.serialization import dumpfn
 
 from emmet.core.tasks import TaskDoc
+from emmet.core.utils import (
+    DocEnum,
+    ValueEnum,
+    dynamic_import,
+    get_flat_models_from_model,
+    get_hash_blocked,
+    jsanitize,
+)
 
 
 def test_jsanitize():
@@ -124,7 +124,6 @@ def test_model_flatten():
         "CustodianDoc",
         "ElectronPhononDisplacedStructures",
         "ElectronicStep",
-        "EmmetMeta",
         "FrequencyDependentDielectric",
         "IonicStep",
         "OutputDoc",


### PR DESCRIPTION
~~Will be considered experimental until performance + compatibility with builder/api client can be tested~~
~~@esoteric-ephemera, check if the field split I made here makes sense. Can worry about model validators and a parsing method later after I've tested the basic schema works for the build pipelines + api~~
~~Based this branch off your `alpha_id` branch for the updated `task_id` typing.~~
~~Also makes more sense for the top level `output` field to be the calc output right?~~

Now ready, broad strokes:
- `CoreTaskDoc` represents a single calculation, can't parse multiple calcs
    - `TaskDoc` parsing behavior remains unchanged, can parse multiple calcs in a single dir
- `TaskDoc` is now a superset of `CoreTaskDoc`
    - `CoreTaskDoc` is strict on typing
    - no `calcs_reversed` in `CoreTaskDoc` or other fields that shouldn't be stored at the database level
    - `CoreTaskDoc.output` is an instance of `emmet.core.tasks.calculation.CoreCalculationOutput` for parity with `(Core)TaskDoc.input` being an instance of `emmet.core.tasks.calculation.CalculationInput` -> i.e., all relevant quantities  at surface of document, not nested
- `CalculationOutput` is now a superset of `CoreCalculationOutput`
- `TaskDoc.output` (`emmet.core.tasks.OutputDoc`) shadows `CoreTaskDoc.output` (`emmet.core.vasp.calculation.CoreCalculationOutput`)

Notes:
- `TaskDoc` behavior and parsing shouldn't be effected at all (no downstream breaks)
- Parsing `CoreTaskDoc` from a directory yields a tuple of (CoreTaskDoc, CoreTrajectory)
   - on the caller to handle storing their trajectory and task document (and making sure `CoreTaskDoc.task_id` and `CoreTrajectory.identifier` are set correctly)

- [x] Tests are gtg, the slim models (`CoreTaskDoc` & `CoreCalculationOutput`) are just slices of the existing models