### PR TITLE
make all datetime factories consistent to use utcnow func in utils

### DIFF
--- a/emmet-core/emmet/core/_general_store.py
+++ b/emmet-core/emmet/core/_general_store.py
@@ -1,6 +1,8 @@
 from pydantic import BaseModel, Field
 from typing import Dict
 
+from emmet.core.utils import utcnow
+
 try:
     from typing import Literal, Optional  # type: ignore
 except ImportError:
@@ -23,5 +25,5 @@ class GeneralStoreDoc(BaseModel):
 
     last_updated: datetime = Field(
         description="Timestamp for when this document was last updated",
-        default_factory=datetime.utcnow,
+        default_factory=utcnow,
     )

--- a/emmet-core/emmet/core/_messages.py
+++ b/emmet-core/emmet/core/_messages.py
@@ -1,7 +1,10 @@
-from typing import List, Optional
 from datetime import datetime
-from pydantic import BaseModel, Field
 from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+from emmet.core.utils import utcnow
 
 
 class MessageType(Enum):
@@ -37,7 +40,7 @@ class MessagesDoc(BaseModel):
     )
 
     last_updated: datetime = Field(
-        default_factory=datetime.utcnow,
+        default_factory=utcnow,
         title="Last Updated",
         description="The last updated UTC timestamp for the message.",
     )

--- a/emmet-core/emmet/core/charge_density.py
+++ b/emmet-core/emmet/core/charge_density.py
@@ -1,6 +1,9 @@
-from pydantic import ConfigDict, BaseModel, Field
 from datetime import datetime
 from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from emmet.core.utils import utcnow
 
 
 class VolumetricDataDoc(BaseModel):
@@ -12,8 +15,8 @@ class VolumetricDataDoc(BaseModel):
         None, description="Unique object ID for the charge density data."
     )
 
-    last_updated: Optional[datetime] = Field(
-        None,
+    last_updated: datetime = Field(
+        default_factory=utcnow,
         description="Timestamp for the most recent update to the charge density data.",
     )
 

--- a/emmet-core/emmet/core/common.py
+++ b/emmet-core/emmet/core/common.py
@@ -1,14 +1,31 @@
-from emmet.core.utils import ValueEnum
-from datetime import datetime
+from datetime import datetime, timezone
+
 from monty.json import MontyDecoder
+
+from emmet.core.utils import ValueEnum, utcnow
 
 
 def convert_datetime(cls, v):
+    if not v:
+        return utcnow()
+
     if isinstance(v, dict):
         if v.get("$date"):
-            return datetime.fromisoformat(v["$date"])
+            dt = datetime.fromisoformat(v["$date"])
+            if not dt.tzinfo:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt
 
-    return MontyDecoder().process_decoded(v)
+    if isinstance(v, str):
+        dt = datetime.fromisoformat(v)
+        if not dt.tzinfo:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+
+    v = MontyDecoder().process_decoded(v)
+    if not v.tzinfo:
+        v = v.replace(tzinfo=timezone.utc)
+    return v
 
 
 class Status(ValueEnum):

--- a/emmet-core/emmet/core/corrected_entries.py
+++ b/emmet-core/emmet/core/corrected_entries.py
@@ -9,6 +9,7 @@ from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEn
 from emmet.core.base import EmmetBaseModel
 from emmet.core.thermo import ThermoType
 from emmet.core.vasp.calc_types.enums import RunType
+from emmet.core.utils import utcnow
 
 
 class CorrectedEntriesDoc(EmmetBaseModel):
@@ -34,5 +35,5 @@ class CorrectedEntriesDoc(EmmetBaseModel):
 
     last_updated: datetime = Field(
         description="Timestamp for the most recent calculation update for this property.",
-        default_factory=datetime.utcnow,
+        default_factory=utcnow,
     )

--- a/emmet-core/emmet/core/electrode.py
+++ b/emmet-core/emmet/core/electrode.py
@@ -16,7 +16,7 @@ from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEn
 
 from emmet.core.common import convert_datetime
 from emmet.core.mpid import MPID
-from emmet.core.utils import ValueEnum
+from emmet.core.utils import ValueEnum, utcnow
 
 
 class BatteryType(str, ValueEnum):
@@ -210,8 +210,8 @@ class BaseElectrode(BaseModel):
         None, description="Maximum absolute difference in adjacent voltage steps."
     )
 
-    last_updated: Optional[datetime] = Field(
-        None,
+    last_updated: datetime = Field(
+        default_factory=utcnow,
         description="Timestamp for the most recent calculation for this Material document.",
     )
 
@@ -301,7 +301,7 @@ class InsertionElectrodeDoc(InsertionVoltagePairDoc, BaseElectrode):
             return None
 
         d = cls.get_elec_doc(ie)
-        d["last_updated"] = datetime.utcnow()
+        d["last_updated"] = utcnow()
 
         stripped_host = ie.fully_charged_entry.structure.copy()
         stripped_host.remove_species([d["working_ion"]])
@@ -537,7 +537,7 @@ class ConversionElectrodeDoc(ConversionVoltagePairDoc, BaseElectrode):
                 "formula_charge": comp_charge.reduced_formula,
                 "formula_discharge": comp_discharge.reduced_formula,
                 "reaction": ce.voltage_pairs[0].rxn.as_dict(),
-                "last_updated": datetime.utcnow(),
+                "last_updated": utcnow(),
             }
             return d
 

--- a/emmet-core/emmet/core/electronic_structure.py
+++ b/emmet-core/emmet/core/electronic_structure.py
@@ -9,7 +9,7 @@ from math import isnan
 from typing import Dict, List, Optional, Type, TypeVar, Union
 
 import numpy as np
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from pymatgen.analysis.magnetism.analyzer import (
     CollinearMagneticStructureAnalyzer,
     Ordering,
@@ -23,9 +23,11 @@ from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.symmetry.bandstructure import HighSymmKpath
 from typing_extensions import Literal
 
+from emmet.core.common import convert_datetime
 from emmet.core.material_property import PropertyDoc
 from emmet.core.mpid import MPID
 from emmet.core.settings import EmmetSettings
+from emmet.core.utils import utcnow
 
 SETTINGS = EmmetSettings()
 
@@ -55,12 +57,17 @@ class BSObjectDoc(BaseModel):
 
     last_updated: datetime = Field(
         description="The timestamp when this calculation was last updated",
-        default_factory=datetime.utcnow,
+        default_factory=utcnow,
     )
 
     data: Optional[Union[Dict, BandStructureSymmLine]] = Field(
         None, description="The band structure object for the given calculation ID"
     )
+
+    @field_validator("last_updated", mode="before")
+    @classmethod
+    def handle_datetime(cls, v):
+        return convert_datetime(cls, v)
 
 
 class DOSObjectDoc(BaseModel):
@@ -76,12 +83,17 @@ class DOSObjectDoc(BaseModel):
 
     last_updated: datetime = Field(
         description="The timestamp when this calculation was last updated.",
-        default_factory=datetime.utcnow,
+        default_factory=utcnow,
     )
 
     data: Optional[CompleteDos] = Field(
         None, description="The density of states object for the given calculation ID."
     )
+
+    @field_validator("last_updated", mode="before")
+    @classmethod
+    def handle_datetime(cls, v):
+        return convert_datetime(cls, v)
 
 
 class ElectronicStructureBaseData(BaseModel):
@@ -196,11 +208,6 @@ class ElectronicStructureDoc(PropertyDoc, ElectronicStructureSummary):
 
     dos: Optional[DosData] = Field(
         None, description="Density of states data for the material."
-    )
-
-    last_updated: datetime = Field(
-        description="Timestamp for when this document was last updated.",
-        default_factory=datetime.utcnow,
     )
 
     @classmethod

--- a/emmet-core/emmet/core/fermi.py
+++ b/emmet-core/emmet/core/fermi.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 from pydantic import BaseModel, Field, field_validator
 
 from emmet.core.common import convert_datetime
+from emmet.core.utils import utcnow
 
 
 class FermiDoc(BaseModel):
@@ -27,8 +28,8 @@ class FermiDoc(BaseModel):
         description="The Materials Project ID of the material. This comes in the form: mp-******.",
     )
 
-    last_updated: Optional[datetime] = Field(
-        None,
+    last_updated: datetime = Field(
+        default_factory=utcnow,
         description="Timestamp for the most recent calculation for this fermi surface document.",
     )
 

--- a/emmet-core/emmet/core/grain_boundary.py
+++ b/emmet-core/emmet/core/grain_boundary.py
@@ -1,10 +1,12 @@
-from typing import List, Optional
-from pydantic import field_validator, BaseModel, Field
-from enum import Enum
 from datetime import datetime
-from emmet.core.common import convert_datetime
+from enum import Enum
+from typing import List, Optional
 
+from pydantic import BaseModel, Field, field_validator
 from pymatgen.core.interface import GrainBoundary
+
+from emmet.core.common import convert_datetime
+from emmet.core.utils import utcnow
 
 
 class GBTypeEnum(Enum):
@@ -76,8 +78,8 @@ class GrainBoundaryDoc(BaseModel):
         None, description="Dash-delimited string of elements in the material."
     )
 
-    last_updated: Optional[datetime] = Field(
-        None,
+    last_updated: datetime = Field(
+        default_factory=utcnow,
         description="Timestamp for the most recent calculation for this Material document.",
     )
 

--- a/emmet-core/emmet/core/material.py
+++ b/emmet-core/emmet/core/material.py
@@ -12,6 +12,7 @@ from pymatgen.core.structure import Molecule
 from emmet.core.common import convert_datetime
 from emmet.core.mpid import MPID, MPculeID
 from emmet.core.structure import MoleculeMetadata, StructureMetadata
+from emmet.core.utils import utcnow
 from emmet.core.vasp.validation import DeprecationMessage
 
 
@@ -26,7 +27,7 @@ class PropertyOrigin(BaseModel):
     )
     last_updated: datetime = Field(  # type: ignore
         description="The timestamp when this calculation was last updated",
-        default_factory=datetime.utcnow,
+        default_factory=utcnow,
     )
 
     @field_validator("last_updated", mode="before")
@@ -84,12 +85,12 @@ class MaterialsDoc(StructureMetadata):
 
     last_updated: datetime = Field(
         description="Timestamp for when this document was last updated.",
-        default_factory=datetime.utcnow,
+        default_factory=utcnow,
     )
 
     created_at: datetime = Field(
         description="Timestamp for when this material document was first created.",
-        default_factory=datetime.utcnow,
+        default_factory=utcnow,
     )
 
     origins: Optional[List[PropertyOrigin]] = Field(
@@ -114,6 +115,11 @@ class MaterialsDoc(StructureMetadata):
             structure=structure,
             **kwargs,
         )
+
+    @field_validator("last_updated", "created_at", mode="before")
+    @classmethod
+    def handle_datetime(cls, v):
+        return convert_datetime(cls, v)
 
 
 class CoreMoleculeDoc(MoleculeMetadata):
@@ -165,12 +171,12 @@ class CoreMoleculeDoc(MoleculeMetadata):
 
     last_updated: datetime = Field(
         description="Timestamp for when this document was last updated",
-        default_factory=datetime.utcnow,
+        default_factory=utcnow,
     )
 
     created_at: datetime = Field(
         description="Timestamp for when this document was first created",
-        default_factory=datetime.utcnow,
+        default_factory=utcnow,
     )
 
     origins: Optional[List[PropertyOrigin]] = Field(
@@ -190,3 +196,8 @@ class CoreMoleculeDoc(MoleculeMetadata):
         return super().from_molecule(  # type: ignore
             meta_molecule=molecule, molecule_id=molecule_id, molecule=molecule, **kwargs
         )
+
+    @field_validator("last_updated", "created_at", mode="before")
+    @classmethod
+    def handle_datetime(cls, v):
+        return convert_datetime(cls, v)

--- a/emmet-core/emmet/core/material_property.py
+++ b/emmet-core/emmet/core/material_property.py
@@ -12,6 +12,7 @@ from emmet.core.common import convert_datetime
 from emmet.core.material import PropertyOrigin
 from emmet.core.mpid import MPID
 from emmet.core.structure import StructureMetadata
+from emmet.core.utils import utcnow
 from emmet.core.vasp.validation import DeprecationMessage
 
 S = TypeVar("S", bound="PropertyDoc")
@@ -43,7 +44,7 @@ class PropertyDoc(StructureMetadata):
 
     last_updated: datetime = Field(
         description="Timestamp for the most recent calculation update for this property.",
-        default_factory=datetime.utcnow,
+        default_factory=utcnow,
     )
 
     origins: Sequence[PropertyOrigin] = Field(

--- a/emmet-core/emmet/core/mobility/migrationgraph.py
+++ b/emmet-core/emmet/core/mobility/migrationgraph.py
@@ -8,6 +8,8 @@ from pymatgen.core import Structure
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEntry
 
+from emmet.core.utils import utcnow
+
 try:
     from pymatgen.analysis.diffusion.neb.full_path_mapper import MigrationGraph
     from pymatgen.analysis.diffusion.utils.supercells import get_sc_fromstruct
@@ -29,8 +31,8 @@ class MigrationGraphDoc(EmmetBaseModel):
         ..., description="The battery id for this MigrationGraphDoc"
     )
 
-    last_updated: Optional[datetime] = Field(
-        None,
+    last_updated: datetime = Field(
+        default_factory=utcnow,
         description="Timestamp for the most recent calculation for this MigrationGraph document.",
     )
 

--- a/emmet-core/emmet/core/molecules/molecule_property.py
+++ b/emmet-core/emmet/core/molecules/molecule_property.py
@@ -12,6 +12,7 @@ from emmet.core.material import PropertyOrigin
 from emmet.core.mpid import MPculeID
 from emmet.core.structure import MoleculeMetadata
 
+from emmet.core.utils import utcnow
 
 __author__ = "Evan Spotte-Smith <ewcspottesmith@lbl.gov>"
 
@@ -66,7 +67,7 @@ class PropertyDoc(MoleculeMetadata):
 
     last_updated: datetime = Field(
         description="Timestamp for the most recent calculation update for this property",
-        default_factory=datetime.utcnow,
+        default_factory=utcnow,
     )
 
     origins: Sequence[PropertyOrigin] = Field(

--- a/emmet-core/emmet/core/openff/tasks.py
+++ b/emmet-core/emmet/core/openff/tasks.py
@@ -19,6 +19,7 @@ from pydantic import (
 from pymatgen.core import Structure
 from typing_extensions import Annotated
 
+from emmet.core.utils import utcnow
 from emmet.core.vasp.task_valid import TaskState
 
 
@@ -105,8 +106,8 @@ class MDTaskDocument(BaseModel):  # type: ignore[call-arg]
     # task_label: Optional[str] = Field(None, description="A description of the task")
     # TODO: where does task_label get added
 
-    last_updated: Optional[datetime] = Field(
-        None,
+    last_updated: datetime = Field(
+        default_factory=utcnow,
         description="Timestamp for the most recent calculation for this task document",
     )
 

--- a/emmet-core/emmet/core/phonon.py
+++ b/emmet-core/emmet/core/phonon.py
@@ -897,12 +897,12 @@ class PhononWebsiteBS(BaseModel):
 
     last_updated: datetime = Field(
         description="Timestamp for the most recent calculation update for this property",
-        default_factory=datetime.utcnow,
+        default_factory=utcnow,
     )
 
     created_at: datetime = Field(
         description="Timestamp for when this material document was first created",
-        default_factory=datetime.utcnow,
+        default_factory=utcnow,
     )
 
 
@@ -925,12 +925,12 @@ class Ddb(BaseModel):
 
     last_updated: datetime = Field(
         description="Timestamp for the most recent calculation update for this property",
-        default_factory=datetime.utcnow,
+        default_factory=utcnow,
     )
 
     created_at: datetime = Field(
         description="Timestamp for when this material document was first created",
-        default_factory=datetime.utcnow,
+        default_factory=utcnow,
     )
 
 
@@ -1028,12 +1028,12 @@ class Phonon(StructureMetadata):
 
     last_updated: datetime = Field(
         description="Timestamp for when this document was last updated",
-        default_factory=datetime.utcnow,
+        default_factory=utcnow,
     )
 
     created_at: datetime = Field(
         description="Timestamp for when this material document was first created",
-        default_factory=datetime.utcnow,
+        default_factory=utcnow,
     )
 
 
@@ -1087,12 +1087,12 @@ class SoundVelocity(BaseModel):
 
     last_updated: datetime = Field(
         description="Timestamp for when this document was last updated",
-        default_factory=datetime.utcnow,
+        default_factory=utcnow,
     )
 
     created_at: datetime = Field(
         description="Timestamp for when this material document was first created",
-        default_factory=datetime.utcnow,
+        default_factory=utcnow,
     )
 
 
@@ -1110,12 +1110,12 @@ class ThermalDisplacement(BaseModel):
 
     last_updated: datetime = Field(
         description="Timestamp for the most recent calculation update for this property",
-        default_factory=datetime.utcnow,
+        default_factory=utcnow,
     )
 
     created_at: datetime = Field(
         description="Timestamp for when this material document was first created",
-        default_factory=datetime.utcnow,
+        default_factory=utcnow,
     )
 
     nsites: int = Field(

--- a/emmet-core/emmet/core/provenance.py
+++ b/emmet-core/emmet/core/provenance.py
@@ -12,7 +12,7 @@ from pymatgen.core.structure import Structure
 from emmet.core.common import convert_datetime
 from emmet.core.material_property import PropertyDoc
 from emmet.core.mpid import MPID
-from emmet.core.utils import ValueEnum
+from emmet.core.utils import ValueEnum, utcnow
 
 
 class Database(ValueEnum):
@@ -79,7 +79,7 @@ class SNLAbout(BaseModel):
     )
 
     created_at: datetime = Field(
-        default_factory=datetime.utcnow, description="The creation date for this SNL."
+        default_factory=utcnow, description="The creation date for this SNL."
     )
 
     @field_validator("created_at", mode="before")
@@ -134,7 +134,7 @@ class ProvenanceDoc(PropertyDoc):
         " of this material for the entry closest matching the material input",
     )
 
-    @field_validator("created_at", mode="before")
+    @field_validator("last_updated", "created_at", mode="before")
     @classmethod
     def handle_datetime(cls, v):
         return convert_datetime(cls, v)

--- a/emmet-core/emmet/core/spectrum.py
+++ b/emmet-core/emmet/core/spectrum.py
@@ -3,10 +3,12 @@
 from datetime import datetime
 from typing import List
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
+from emmet.core.common import convert_datetime
 from emmet.core.mpid import MPID
 from emmet.core.structure import StructureMetadata
+from emmet.core.utils import utcnow
 
 
 class SpectrumDoc(StructureMetadata):
@@ -31,9 +33,14 @@ class SpectrumDoc(StructureMetadata):
 
     last_updated: datetime = Field(
         description="Timestamp for the most recent calculation update for this property.",
-        default_factory=datetime.utcnow,
+        default_factory=utcnow,
     )
 
     warnings: List[str] = Field(
         [], description="Any warnings related to this property."
     )
+
+    @field_validator("last_updated", mode="before")
+    @classmethod
+    def handle_datetime(cls, v):
+        return convert_datetime(cls, v)

--- a/emmet-core/emmet/core/structure_group.py
+++ b/emmet-core/emmet/core/structure_group.py
@@ -11,6 +11,7 @@ from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEn
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from emmet.core.mpid import MPID
 from emmet.core.common import convert_datetime
+from emmet.core.utils import utcnow
 
 logger = logging.getLogger(__name__)
 
@@ -92,8 +93,8 @@ class StructureGroupDoc(BaseModel):
         "present the chemsys will also include the ignored species.",
     )
 
-    last_updated: Optional[datetime] = Field(
-        None, description="Timestamp when this document was built."
+    last_updated: datetime = Field(
+        default_factory=utcnow, description="Timestamp when this document was built."
     )
 
     # Make sure that the datetime field is properly formatted

--- a/emmet-core/emmet/core/task.py
+++ b/emmet-core/emmet/core/task.py
@@ -1,6 +1,7 @@
 """ Core definition of a Task Document which represents a calculation from some program"""
+
 from datetime import datetime
-from typing import Union, Optional
+from typing import Optional, Union
 
 from pydantic import Field
 

--- a/emmet-core/emmet/core/tasks.py
+++ b/emmet-core/emmet/core/tasks.py
@@ -433,8 +433,8 @@ class TaskDoc(StructureMetadata, extra="allow"):
         description="Some analysis of calculation data after collection.",
     )
 
-    last_updated: Optional[datetime] = Field(
-        utcnow(),
+    last_updated: datetime = Field(
+        default_factory=utcnow,
         description="Timestamp for the most recent calculation for this task document",
     )
 

--- a/emmet-core/emmet/core/thermo.py
+++ b/emmet-core/emmet/core/thermo.py
@@ -12,7 +12,7 @@ from emmet.core.base import EmmetMeta
 from emmet.core.material import PropertyOrigin
 from emmet.core.material_property import PropertyDoc
 from emmet.core.mpid import MPID
-from emmet.core.utils import ValueEnum
+from emmet.core.utils import ValueEnum, utcnow
 from emmet.core.vasp.calc_types.enums import RunType
 
 
@@ -251,7 +251,7 @@ class ThermoDoc(PropertyDoc):
                 PropertyOrigin(
                     name="energy",
                     task_id=blessed_entry.data["task_id"],
-                    last_updated=d.get("last_updated", datetime.utcnow()),
+                    last_updated=d.get("last_updated", utcnow()),
                 )
             ]
 
@@ -324,5 +324,5 @@ class PhaseDiagramDoc(BaseModel):
 
     last_updated: datetime = Field(
         description="Timestamp for the most recent calculation update for this property",
-        default_factory=datetime.utcnow,
+        default_factory=utcnow,
     )

--- a/emmet-core/emmet/core/vasp/validation.py
+++ b/emmet-core/emmet/core/vasp/validation.py
@@ -1,20 +1,22 @@
 """Current MP tools to validate VASP calculations."""
+
 from __future__ import annotations
 
 from datetime import datetime
 from typing import TYPE_CHECKING
 
 import numpy as np
-from pydantic import ConfigDict, Field, ImportString
+from pydantic import ConfigDict, Field, ImportString, field_validator
 from pymatgen.core.structure import Structure
 from pymatgen.io.vasp.inputs import Kpoints
 from pymatgen.io.vasp.sets import VaspInputSet
 
-from emmet.core.settings import EmmetSettings
 from emmet.core.base import EmmetBaseModel
+from emmet.core.common import convert_datetime
 from emmet.core.mpid import MPID
-from emmet.core.utils import DocEnum
+from emmet.core.settings import EmmetSettings
 from emmet.core.tasks import TaskDoc
+from emmet.core.utils import DocEnum, utcnow
 from emmet.core.vasp.calc_types.enums import CalcType, TaskType
 from emmet.core.vasp.task_valid import TaskDocument
 
@@ -55,7 +57,7 @@ class ValidationDoc(EmmetBaseModel):
     valid: bool = Field(False, description="Whether this task is valid or not")
     last_updated: datetime = Field(
         description="Last updated date for this document",
-        default_factory=datetime.utcnow,
+        default_factory=utcnow,
     )
     reasons: list[DeprecationMessage | str] | None = Field(
         None, description="List of deprecation tags detailing why this task isn't valid"
@@ -74,6 +76,11 @@ class ValidationDoc(EmmetBaseModel):
         title="Space Group Number",
         description="The spacegroup number for the lattice.",
     )
+
+    @field_validator("last_updated", mode="before")
+    @classmethod
+    def handle_datetime(cls, v):
+        return convert_datetime(cls, v)
 
     @classmethod
     def from_task_doc(

--- a/emmet-core/tests/test_optimade.py
+++ b/emmet-core/tests/test_optimade.py
@@ -1,9 +1,8 @@
-from datetime import datetime
-
 import pytest
 from pymatgen.core.structure import Structure
 
 from . import test_structures
+from emmet.core.utils import utcnow
 
 try:
     from emmet.core.optimade import OptimadeMaterialsDoc
@@ -17,6 +16,6 @@ def test_oxidation_state(structure: Structure):
     """Very simple test to make sure this actually works"""
     print(f"Should work : {structure.composition}")
     doc = OptimadeMaterialsDoc.from_structure(
-        structure, material_id=33, last_updated=datetime.utcnow()
+        structure, material_id=33, last_updated=utcnow()
     )
     assert doc is not None

--- a/emmet-core/tests/test_provenance.py
+++ b/emmet-core/tests/test_provenance.py
@@ -1,10 +1,9 @@
-from datetime import datetime
-
 import pytest
 from pymatgen.core import Lattice, Structure
 from pymatgen.util.provenance import Author, HistoryNode, StructureNL
 
 from emmet.core.provenance import Database, ProvenanceDoc, SNLDict
+from emmet.core.utils import utcnow
 
 
 @pytest.fixture
@@ -21,7 +20,7 @@ def snls(structure):
             structure,
             authors=[Author("test{i}", "test@test.com").as_dict()],
             history=[HistoryNode("nothing", "url.com", {})],
-            created_at=datetime.utcnow(),
+            created_at=utcnow(),
             references="",
         ).as_dict()
         for i in range(3)


### PR DESCRIPTION
split out housekeeping changes introduced in #1243 to reduce noise in diffs