### PR TITLE
Fix TaskDoc bugs in latest emmet-core

### DIFF
--- a/emmet-core/emmet/core/tasks.py
+++ b/emmet-core/emmet/core/tasks.py
@@ -1046,7 +1046,10 @@ def _get_state(calcs_reversed: list[Calculation], analysis: AnalysisDoc) -> Task
     all_calcs_completed = all(
         c.has_vasp_completed == TaskState.SUCCESS for c in calcs_reversed
     )
-    if analysis.errors and len(analysis.errors) == 0 and all_calcs_completed:
+    if (
+        analysis.errors is None
+        or (isinstance(analysis.errors, list) and len(analysis.errors) == 0)
+    ) and all_calcs_completed:
         return TaskState.SUCCESS  # type: ignore
     return TaskState.FAILED  # type: ignore
 

--- a/emmet-core/tests/test_task.py
+++ b/emmet-core/tests/test_task.py
@@ -1,6 +1,7 @@
 import pytest
 
 from tests.conftest import assert_schemas_equal, get_test_object
+from emmet.core.vasp.task_valid import TaskState
 
 
 @pytest.mark.parametrize(
@@ -14,7 +15,7 @@ from tests.conftest import assert_schemas_equal, get_test_object
 def test_analysis_summary(test_dir, object_name):
     from monty.json import MontyDecoder, jsanitize
 
-    from emmet.core.tasks import AnalysisDoc
+    from emmet.core.tasks import AnalysisDoc, _get_state
     from emmet.core.vasp.calculation import Calculation
 
     test_object = get_test_object(object_name)
@@ -29,6 +30,7 @@ def test_analysis_summary(test_dir, object_name):
         # task_files are in the order of {"relax2","relax1"}
 
     test_doc = AnalysisDoc.from_vasp_calc_docs(calcs_reversed)
+    assert _get_state(calcs_reversed, test_doc) == TaskState.SUCCESS
     valid_doc = test_object.task_doc["analysis"]
     assert_schemas_equal(test_doc, valid_doc)
 
@@ -139,6 +141,7 @@ def test_task_doc(test_dir, object_name, tmpdir):
     assert test_doc.model_dump()["foo"] == "bar"
 
     assert len(test_doc.calcs_reversed) == len(test_object.task_files)
+    assert test_doc.state == TaskState.SUCCESS
 
     # ensure that number of electronic steps are correctly populated
     for cr in test_doc.calcs_reversed:


### PR DESCRIPTION
- #1248 : better check on when `AnalysisDoc.errors` is non-populated
- #1249 : temporary fix for non-colinear magnetic moments while #1226 is pending