### PR TITLE
Update depreacted methods in pymatgen graphs

### DIFF
--- a/emmet-core/emmet/core/bonds.py
+++ b/emmet-core/emmet/core/bonds.py
@@ -69,7 +69,7 @@ class BondingDoc(PropertyDoc):
 
         for method in preferred_methods:
             try:
-                sg = StructureGraph.with_local_env_strategy(structure, method)
+                sg = StructureGraph.from_local_env_strategy(structure, method)
 
                 # ensure edge weights are specifically bond lengths
                 edge_weights = []

--- a/emmet-core/emmet/core/molecules/bonds.py
+++ b/emmet-core/emmet/core/molecules/bonds.py
@@ -273,7 +273,7 @@ def nbo_molecule_graph(mol: Molecule, nbo: dict[str, Any]):
     :return:
     """
 
-    mg = MoleculeGraph.with_empty_graph(mol)
+    mg = MoleculeGraph.from_empty_graph(mol)
 
     alpha_bonds, warnings = _bonds_hybridization(nbo, 1)
     beta_bonds, new_warnings = _bonds_hybridization(nbo, 3)

--- a/emmet-core/emmet/core/utils.py
+++ b/emmet-core/emmet/core/utils.py
@@ -282,7 +282,7 @@ def make_mol_graph(
 
     :return: mol_graph, a MoleculeGraph
     """
-    mol_graph = MoleculeGraph.with_local_env_strategy(mol, OpenBabelNN())
+    mol_graph = MoleculeGraph.from_local_env_strategy(mol, OpenBabelNN())
     mol_graph = metal_edge_extender(mol_graph)
     if critic_bonds:
         mg_edges = mol_graph.graph.edges()


### PR DESCRIPTION
A few methods in `pymatgen/analysis/graphs` are deprecated but still used in emmet-core (e.g. https://github.com/materialsproject/pymatgen/blob/c1db75380fbf8e94bbb58ce85c10d9dffade0c5e/src/pymatgen/analysis/graphs.py#L314)
Switching to the updated versions.