### PR TITLE
Avoid extrapolation in NEB fitting

### DIFF
--- a/emmet-core/emmet/core/neb.py
+++ b/emmet-core/emmet/core/neb.py
@@ -118,7 +118,7 @@ class BarrierAnalysis(BaseModel):
         spline_fit = CubicSpline(frame_index, energies, **spline_kwargs)
         analysis["cubic_spline_pars"] = spline_fit.c.tolist()
 
-        crit_points = spline_fit.derivative().roots()
+        crit_points = spline_fit.derivative().roots(extrapolate=False)
         analysis["ts_frame_index"] = -1
         analysis["ts_energy"] = -np.inf
         for crit_point in crit_points:


### PR DESCRIPTION
While calculating the barrier for a NEB calculation based on a spline fit, the roots of the derivative may also be in a region outside the [0,1] interval and this may result in a much high barrier. For example one of the fits I got had this shape and the barrier value came from the outer peaks, while the NEB fitted data is of course only comprised in the [0,1] region: 
<img width="560" alt="fit" src="https://github.com/user-attachments/assets/6107aca4-45de-42ff-be57-63b3a2846f91" />

To fix this it seems enough to specify to avoid extrapolation.