### PR TITLE
Remove maggma from emmet-api pyproject

### DIFF
--- a/emmet-api/pyproject.toml
+++ b/emmet-api/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "pymatgen-analysis-defects>=2024.10.22",
     "pymatgen-io-validation>=0.1.1",
     "uvicorn>=0.18.3",
-    "maggma",
+    "pymongo>=4.10.1",
 ]
 
 [project.urls]
@@ -64,6 +64,8 @@ test = [
     "types-requests",
     "starlette[full]",
     "wincertstore",
+    "pymongo==4.10.1",
+    "mongomock",
 ]
 docs = [
     "mkdocs",


### PR DESCRIPTION
Mistakenly added maggma dependence back to emmet-api in the setup.py --> pyproject.toml transition