### PR TITLE
Remove type guards from query operators

### DIFF
--- a/emmet-api/emmet/api/models.py
+++ b/emmet-api/emmet/api/models.py
@@ -79,8 +79,5 @@ class Response(BaseModel, Generic[DataT]):
         if v is None or hasattr(v, "model_dump"):
             v = Meta().model_dump()  # type: ignore[call-arg]
         if v.get("total_doc", None) is None:
-            if getattr(values, "data", None) is not None:
-                v["total_doc"] = len(values.data)
-            else:
-                v["total_doc"] = 0
+            v["total_doc"] = len(getattr(values, "data", []))
         return v

--- a/emmet-api/emmet/api/routes/materials/electronic_structure/query_operators.py
+++ b/emmet-api/emmet/api/routes/materials/electronic_structure/query_operators.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from sys import version_info
-from typing import TYPE_CHECKING
+from typing import Literal
 
 from fastapi import HTTPException, Query
 from emmet.api.query_operator import QueryOperator
@@ -12,14 +11,7 @@ from pymatgen.core.periodic_table import Element
 from pymatgen.electronic_structure.core import OrbitalType, Spin
 
 from emmet.core.electronic_structure import BSPathType, DOSProjectionType
-
-if TYPE_CHECKING:
-    from emmet.core.mpid import MPID, AlphaID
-
-if version_info >= (3, 8):
-    from typing import Literal  # type: ignore
-else:
-    from typing_extensions import Literal  # type: ignore
+from emmet.core.mpid import MPID, AlphaID
 
 
 class ESSummaryDataQuery(QueryOperator):

--- a/emmet-api/emmet/api/routes/materials/phonon/query_operators.py
+++ b/emmet-api/emmet/api/routes/materials/phonon/query_operators.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from fastapi import Path, Query
 
 from emmet.api.query_operator import QueryOperator
 from emmet.api.utils import STORE_PARAMS
-
-if TYPE_CHECKING:
-    from emmet.core.mpid import MPID, AlphaID
+from emmet.core.mpid import MPID, AlphaID
 
 
 class PhononImgQuery(QueryOperator):

--- a/emmet-api/emmet/api/routes/materials/xas/query_operators.py
+++ b/emmet-api/emmet/api/routes/materials/xas/query_operators.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from fastapi import Query
-from typing import TYPE_CHECKING
 
 from emmet.api.query_operator import QueryOperator
 from emmet.api.utils import STORE_PARAMS

--- a/emmet-api/emmet/api/utils.py
+++ b/emmet-api/emmet/api/utils.py
@@ -92,7 +92,7 @@ def merge_atlas_queries(queries: list[STORE_PARAMS]) -> STORE_PARAMS:
     }
 
 
-def attach_signature(function: Callable, defaults: dict, annotations: dict):
+def attach_signature(function: Callable, defaults: dict, annotations: dict) -> None:
     """
     Attaches signature for defaults and annotations for parameters to function.
 


### PR DESCRIPTION
Continuing from e83c011: removes a few other type guarding blocks in query operators to avoid forward refs.
Also cleans out some legacy code (checking if the python version > 3.8, which we require)