### PR TITLE
add build arch arg for api server Dockerfile

### DIFF
--- a/emmet-api/Dockerfile
+++ b/emmet-api/Dockerfile
@@ -18,7 +18,7 @@ RUN wget -q https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-
   chmod +x wait-for-it.sh && mv wait-for-it.sh /root/.local/bin/
 
 FROM base
-ARG BUILDARCH
+ARG BUILDARCH=x86_64
 COPY --from=builder /root/.local/lib/python3.11/site-packages /root/.local/lib/python3.11/site-packages
 COPY --from=builder /root/.local/bin /root/.local/bin
 COPY --from=builder /usr/lib/$BUILDARCH-linux-gnu/libsnappy* /usr/lib/$BUILDARCH-linux-gnu/


### PR DESCRIPTION
adds build arch flag for developing on different architectures

arm -> aarch64
intel -> x86_64