### PR TITLE
Update _user_settings datetime

### DIFF
--- a/emmet-core/emmet/core/_user_settings.py
+++ b/emmet-core/emmet/core/_user_settings.py
@@ -1,7 +1,7 @@
-from datetime import datetime
-
 from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
+
+from emmet.core.types.typing import DateTimeType
 
 
 class TypedUserSettingsDict(TypedDict):
@@ -9,7 +9,7 @@ class TypedUserSettingsDict(TypedDict):
     sector: str
     job_role: str
     is_email_subscribed: bool
-    message_last_read: datetime
+    message_last_read: DateTimeType
     agreed_terms: bool
 
 


### PR DESCRIPTION
Ensure datetimes serialize correctly and get initialized with a date

Context:
- Users [reported](https://matsci.org/t/locked-out-by-complete-registration-popup/66392) being unable to register / get past the registration modal
- After tracking down the issue, we found that the `message_last_read` field in `emmet.core._user_seeings` was set variously to: unset, `None`, `str`, or BSON ISODate
- Setting all users with either unset or `None` fields to a str ISO-compatible date resolved the registration issue