### PR TITLE
Missing (Core)TaskDoc fields

### DIFF
--- a/emmet-core/emmet/core/arrow.py
+++ b/emmet-core/emmet/core/arrow.py
@@ -212,7 +212,7 @@ def arrowize(obj) -> pa.DataType:
             )
         # DO NOT CHANGE ARGS - IGNORE MYPY
         # recursive_guard kwarg does not exist in python <3.12
-        return arrowize(obj._evaluate(globals(), locals(), frozenset()))
+        return arrowize(obj._evaluate(globals(), locals(), frozenset()))  # type: ignore[call-arg,arg-type]
 
     if isinstance(obj, typing.TypeVar):
         return arrowize(obj.__constraints__[1])

--- a/emmet-core/emmet/core/tasks.py
+++ b/emmet-core/emmet/core/tasks.py
@@ -333,6 +333,10 @@ class CoreTaskDoc(StructureMetadata):
         WrapSerializer(_ser_json_like),
     ] = Field(None, description="Vasp objects associated with this task")
 
+    vasp_version: str | None = Field(
+        None, description="The version of VASP used for this task."
+    )
+
     @field_validator("batch_id", mode="before")
     def validate_batch_id(cls, batch_id: str):
         if batch_id:
@@ -404,6 +408,7 @@ class CoreTaskDoc(StructureMetadata):
             task_type=calc_doc.task_type,
             transformations=transformations,
             vasp_objects=vasp_objects,
+            vasp_version=calc_doc.vasp_version,
         )
 
         trajectory = get_trajectories_from_calculations([calc_doc])[0]
@@ -608,6 +613,7 @@ class TaskDoc(CoreTaskDoc, extra="allow"):
             vasp_objects=vasp_objects,
             included_objects=included_objects,
             task_type=calcs_reversed[0].task_type,
+            vasp_version=calcs_reversed[0].vasp_version,
         )
         return doc.model_copy(update=additional_fields)
 

--- a/emmet-core/emmet/core/vasp/calculation.py
+++ b/emmet-core/emmet/core/vasp/calculation.py
@@ -31,7 +31,7 @@ from pymatgen.io.vasp import PotcarSingle, Vasprun, VolumetricData
 from typing_extensions import NotRequired, TypedDict
 
 from emmet.core.band_theory import ElectronicBS, ElectronicDos
-from emmet.core.math import ListMatrix3D, Matrix3D, Vector3D
+from emmet.core.math import ListMatrix3D, Matrix3D, Vector3D, Vector6D
 from emmet.core.trajectory import RelaxTrajectory, Trajectory
 from emmet.core.vasp.models import ElectronicStep, ChgcarLike
 from emmet.core.types.enums import StoreTrajectoryOption, TaskState, VaspObject
@@ -570,6 +570,67 @@ def _deser_dos_properties(
     return dos_properties  # type: ignore[return-value]
 
 
+class DielectricProperties(BaseModel):
+    """Store electronic response properties.
+
+    Note the units and tensor ranks:
+    - Dielectric tensors are dimensionless (no units apply), and are 3x3
+    - Piezoelectric tensors are in C(oulomb)/m^2, and are 3x6
+    - Strain tensors, for each atom, are in eV/Å, and are 3x6
+    - Born charges, for each atom, are in units of the elementary charge, and are 3x3
+
+    For both Born charges and strain, the tensors are listed for each site in the
+    structure. Thus one expects a list of 3x3 and 3x6 tensors, respectively.
+    """
+
+    born_charges: list[Matrix3D] | None = Field(
+        None,
+        description=(
+            "Born effective charges for each site in the structure "
+            "(units of elementary charge e)."
+        ),
+    )
+    dielectric_ionic_tensor: Matrix3D | None = Field(
+        None, description="Ionic contribution to the dielectric tensor (dimensionless)."
+    )
+    dielectric_tensor: Matrix3D | None = Field(
+        None, description="Overall dielectric tensor (dimensionless)."
+    )
+    internal_strain_tensor: list[tuple[Vector6D, Vector6D, Vector6D]] | None = Field(
+        None, description="The internal strain tensor (eV/Å)."
+    )
+    piezo_ionic_tensor: tuple[Vector6D, Vector6D, Vector6D] | None = Field(
+        None, description="Ionic contribution to the piezoelectric tensor (C/m^2)."
+    )
+    piezo_tensor: tuple[Vector6D, Vector6D, Vector6D] | None = Field(
+        None, description="Overall piezoelectric tensor (C/m^2)."
+    )
+
+    @classmethod
+    def from_outcar(cls, outcar: Outcar | dict[str, Any]) -> Self:
+        """Parse data from the OUTCAR.
+
+        Parameters
+        -----------
+        outcar : Outcar or its as_dict representation
+        """
+        aliases = {"born_charges": "born"}
+        config = {
+            k: (
+                getattr(outcar, aliases.get(k, k), None)
+                if isinstance(outcar, Outcar)
+                else outcar.get(aliases.get(k, k), None)
+            )
+            for k in cls.model_fields
+        }
+        return cls(
+            **{
+                k: v.tolist() if isinstance(v, np.ndarray) else v
+                for k, v in config.items()
+            }
+        )
+
+
 class CoreCalculationOutput(BaseModel):
     """Document defining core VASP calculation outputs."""
 
@@ -582,6 +643,10 @@ class CoreCalculationOutput(BaseModel):
     )
     density: float | None = Field(
         None, description="Density of final structure in units of g/cc."
+    )
+    dielectric_properties: DielectricProperties | None = Field(
+        None,
+        description="Dielectric, piezoelectric, and other electromechanical properties.",
     )
     direct_gap: float | None = Field(
         None, description="Direct band gap in eV (if system is not metallic)"
@@ -847,6 +912,9 @@ class CalculationOutput(CoreCalculationOutput):
             locpot=locpot_avg,
             outcar=outcar_dict,
             run_stats=RunStatistics.from_outcar(outcar) if outcar else None,
+            dielectric_properties=(
+                DielectricProperties.from_outcar(outcar) if outcar else None
+            ),
             **epsilons,  # type: ignore[arg-type]
             **electronic_output,
             **phonon_output,

--- a/emmet-core/tests/test_model_fields.py
+++ b/emmet-core/tests/test_model_fields.py
@@ -1064,6 +1064,7 @@ ref_model_fields = {
         "run_stats",
         "state",
         "task_label",
+        "vasp_version",
     ],
     "emmet.core.thermo.ThermoDoc": [
         "builder_meta",

--- a/emmet-core/tests/test_utils.py
+++ b/emmet-core/tests/test_utils.py
@@ -113,6 +113,7 @@ def test_model_flatten():
         "CalculationInput",
         "CalculationOutput",
         "CustodianDoc",
+        "DielectricProperties",
         "ElectronPhononDisplacedStructures",
         "ElectronicStep",
         "FrequencyDependentDielectric",


### PR DESCRIPTION
Adds in:
- `vasp_version` (used in task details page in `web`)
- Dielectric + piezoelectric properties promoted to `dielectric_properties` in (`Core`)`CalculationOutput` to allow for building dielectric and piezoelectric collections

For migrating `TaskDoc` --> `CoreTaskDoc`, this requires an additional step:

```python
from emmet.core.vasp.calculation import DielectricProperties

CoreTaskDoc(
  **other_migrated_kwargs,
  dielectric_properties = DielectricProperties.from_outcar(task_doc.output.outcar)
)
```