### PR TITLE
List-like search for symmetry + handle user error

### DIFF
--- a/emmet-api/emmet/api/routes/materials/materials/query_operators.py
+++ b/emmet-api/emmet/api/routes/materials/materials/query_operators.py
@@ -13,7 +13,11 @@ from emmet.api.routes.materials.materials.utils import (
     chemsys_to_criteria,
     formula_to_criteria,
 )
-from emmet.core.symmetry import CrystalSystem
+from emmet.core.symmetry import (
+    CrystalSystem,
+    _get_space_group_symbol_to_number_mapping,
+    get_crystal_system_from_international_number,
+)
 from emmet.core.vasp.calc_types import RunType
 from emmet.core.vasp.material import BlessedCalcs
 
@@ -144,34 +148,90 @@ class DeprecationQuery(QueryOperator):
 
 class SymmetryQuery(QueryOperator):
     """
-    Method to generate a query on symmetry information
+    Method to generate a query on symmetry information.
     """
 
     def query(
         self,
-        crystal_system: CrystalSystem | None = Query(
+        crystal_system: str | None = Query(
             None,
-            description="Crystal system of the material",
+            description=(
+                "Crystal system of the material. If a comma-separated string, "
+                "will query by multiple crystal systems."
+            ),
         ),
-        spacegroup_number: int | None = Query(
+        spacegroup_number: int | str | None = Query(
             None,
-            description="Space group number of the material",
+            description=(
+                "Space group number of the material. If a comma-separated string, "
+                "will query by multiple space group numbers."
+            ),
         ),
         spacegroup_symbol: str | None = Query(
             None,
-            description="Space group symbol of the material",
+            description=(
+                "Space group symbol of the material. If a comma-separated string, "
+                "will query by multiple space group numbers."
+            ),
         ),
     ) -> STORE_PARAMS:
         crit = {}  # type: dict
 
+        crystal_systems: list[CrystalSystem] = []
         if crystal_system:
-            crit.update({"symmetry.crystal_system": str(crystal_system.value)})
+            crystal_systems += [
+                CrystalSystem(cs.strip()).value for cs in str(crystal_system).split(",")
+            ]
+            crit["symmetry.crystal_system"] = (
+                crystal_systems[0]
+                if len(crystal_systems) == 1
+                else {"$in": crystal_systems}
+            )
 
+        spacegroup_numbers: list[int] = []
         if spacegroup_number:
-            crit.update({"symmetry.number": spacegroup_number})
+            spacegroup_numbers += (
+                [int(sgn) for sgn in spacegroup_number.split(",")]
+                if isinstance(spacegroup_number, str)
+                else [spacegroup_number]
+            )
 
         if spacegroup_symbol:
-            crit.update({"symmetry.symbol": spacegroup_symbol})
+            SPACE_GROUP_SYMBOL_TO_NUMBER = _get_space_group_symbol_to_number_mapping()
+            new_sgn: list[int] = [
+                SPACE_GROUP_SYMBOL_TO_NUMBER(sgs.strip())
+                for sgs in spacegroup_symbol.split(",")
+            ]
+            # Try to prevent user error
+            if (
+                len(spacegroup_numbers) == 1
+                and len(new_sgn) == 1
+                and spacegroup_numbers[0] != new_sgn[0]
+            ):
+                raise ValueError(
+                    "You have specified exact match of inequivalent space "
+                    f"group number ({spacegroup_numbers[0]}) and symbol ({new_sgn[0]})."
+                )
+            spacegroup_numbers += new_sgn
+
+        if len(spacegroup_numbers) > 0:
+            crit["symmetry.number"] = (
+                spacegroup_numbers[0]
+                if len(spacegroup_numbers) == 1
+                else {"$in": spacegroup_number}
+            )
+
+            if (
+                len(spacegroup_numbers) == 1
+                and len(crystal_systems) == 1
+                and get_crystal_system_from_international_number(spacegroup_numbers[0])
+                != crystal_systems[0]
+            ):
+                raise ValueError(
+                    "You have specified exact match of inequivalent space "
+                    f"group number ({spacegroup_numbers[0]}) and "
+                    f"crystal system ({crystal_systems[0]})."
+                )
 
         return {"criteria": crit}
 

--- a/emmet-api/emmet/api/routes/materials/materials/query_operators.py
+++ b/emmet-api/emmet/api/routes/materials/materials/query_operators.py
@@ -198,7 +198,7 @@ class SymmetryQuery(QueryOperator):
 
         if isinstance(spacegroup_symbol, str):
             SPACE_GROUP_SYMBOL_TO_NUMBER = _get_space_group_symbol_to_number_mapping()
-            space_group_symbols = [sgs.strip() for sgs in SPACE_GROUP_SYMBOL_TO_NUMBER]
+            space_group_symbols = [sgs.strip() for sgs in spacegroup_symbol.split(",")]
             if (
                 len(
                     invalid_sgs := {
@@ -210,7 +210,7 @@ class SymmetryQuery(QueryOperator):
                 > 0
             ):
                 raise ValueError(
-                    f"Unknown space group symbol(s): {', '.join(invalid_sgs)}"
+                    f"Unknown space group symbol(s): {', '.join(sorted(invalid_sgs))}"
                 )
 
             new_sgn: list[int] = [
@@ -222,7 +222,8 @@ class SymmetryQuery(QueryOperator):
             ):
                 raise ValueError(
                     "You have specified exact match of inequivalent space "
-                    f"group number ({spacegroup_numbers[0]}) and symbol ({new_sgn[0]})."
+                    f"group number(s) ({', '.join([str(sgn) for sgn in spacegroup_numbers])}) "
+                    f"and symbol ({new_sgn[0]})."
                 )
             spacegroup_numbers += new_sgn
 

--- a/emmet-api/emmet/api/routes/materials/materials/query_operators.py
+++ b/emmet-api/emmet/api/routes/materials/materials/query_operators.py
@@ -178,7 +178,7 @@ class SymmetryQuery(QueryOperator):
         crit = {}  # type: dict
 
         crystal_systems: list[CrystalSystem] = []
-        if crystal_system:
+        if isinstance(crystal_system, str | CrystalSystem):
             crystal_systems += [
                 CrystalSystem(cs.strip()).value for cs in str(crystal_system).split(",")
             ]
@@ -189,18 +189,18 @@ class SymmetryQuery(QueryOperator):
             )
 
         spacegroup_numbers: list[int] = []
-        if spacegroup_number:
+        if isinstance(spacegroup_number, str | int):
             spacegroup_numbers += (
-                [int(sgn) for sgn in spacegroup_number.split(",")]
+                [int(sgn) for sgn in str(spacegroup_number).split(",")]
                 if isinstance(spacegroup_number, str)
                 else [spacegroup_number]
             )
 
-        if spacegroup_symbol:
+        if isinstance(spacegroup_symbol, str):
             SPACE_GROUP_SYMBOL_TO_NUMBER = _get_space_group_symbol_to_number_mapping()
             new_sgn: list[int] = [
-                SPACE_GROUP_SYMBOL_TO_NUMBER(sgs.strip())
-                for sgs in spacegroup_symbol.split(",")
+                SPACE_GROUP_SYMBOL_TO_NUMBER[sgs.strip()]
+                for sgs in str(spacegroup_symbol).split(",")
             ]
             # Try to prevent user error
             if (
@@ -215,22 +215,29 @@ class SymmetryQuery(QueryOperator):
             spacegroup_numbers += new_sgn
 
         if len(spacegroup_numbers) > 0:
+            spacegroup_numbers = sorted(set(spacegroup_numbers))
             crit["symmetry.number"] = (
                 spacegroup_numbers[0]
                 if len(spacegroup_numbers) == 1
-                else {"$in": spacegroup_number}
+                else {"$in": spacegroup_numbers}
             )
 
             if (
                 len(spacegroup_numbers) == 1
-                and len(crystal_systems) == 1
                 and get_crystal_system_from_international_number(spacegroup_numbers[0])
-                != crystal_systems[0]
+                not in crystal_systems
+            ) or (
+                len(crystal_systems) == 1
+                and any(
+                    get_crystal_system_from_international_number(sgn)
+                    != crystal_systems[0]
+                    for sgn in spacegroup_numbers
+                )
             ):
                 raise ValueError(
                     "You have specified exact match of inequivalent space "
-                    f"group number ({spacegroup_numbers[0]}) and "
-                    f"crystal system ({crystal_systems[0]})."
+                    f"group number ({', '.join([str(sgn) for sgn in spacegroup_numbers])}) and "
+                    f"crystal system ({', '.join(crystal_systems)})."
                 )
 
         return {"criteria": crit}

--- a/emmet-api/emmet/api/routes/materials/materials/query_operators.py
+++ b/emmet-api/emmet/api/routes/materials/materials/query_operators.py
@@ -218,7 +218,7 @@ class SymmetryQuery(QueryOperator):
             ]
             # Try to prevent user error
             if len(new_sgn) == 1 and any(
-                sgn != new_sgn[0] for sgn in spacegroup_numbers[0]
+                sgn != new_sgn[0] for sgn in spacegroup_numbers
             ):
                 raise ValueError(
                     "You have specified exact match of inequivalent space "

--- a/emmet-api/emmet/api/routes/materials/materials/query_operators.py
+++ b/emmet-api/emmet/api/routes/materials/materials/query_operators.py
@@ -198,15 +198,27 @@ class SymmetryQuery(QueryOperator):
 
         if isinstance(spacegroup_symbol, str):
             SPACE_GROUP_SYMBOL_TO_NUMBER = _get_space_group_symbol_to_number_mapping()
+            space_group_symbols = [sgs.strip() for sgs in SPACE_GROUP_SYMBOL_TO_NUMBER]
+            if (
+                len(
+                    invalid_sgs := {
+                        sgs
+                        for sgs in space_group_symbols
+                        if sgs not in SPACE_GROUP_SYMBOL_TO_NUMBER
+                    }
+                )
+                > 0
+            ):
+                raise ValueError(
+                    f"Unknown space group symbol(s): {', '.join(invalid_sgs)}"
+                )
+
             new_sgn: list[int] = [
-                SPACE_GROUP_SYMBOL_TO_NUMBER[sgs.strip()]
-                for sgs in str(spacegroup_symbol).split(",")
+                SPACE_GROUP_SYMBOL_TO_NUMBER[sgs] for sgs in space_group_symbols
             ]
             # Try to prevent user error
-            if (
-                len(spacegroup_numbers) == 1
-                and len(new_sgn) == 1
-                and spacegroup_numbers[0] != new_sgn[0]
+            if len(new_sgn) == 1 and any(
+                sgn != new_sgn[0] for sgn in spacegroup_numbers[0]
             ):
                 raise ValueError(
                     "You have specified exact match of inequivalent space "

--- a/emmet-api/emmet/api/routes/materials/materials/query_operators.py
+++ b/emmet-api/emmet/api/routes/materials/materials/query_operators.py
@@ -177,7 +177,7 @@ class SymmetryQuery(QueryOperator):
     ) -> STORE_PARAMS:
         crit = {}  # type: dict
 
-        crystal_systems: list[CrystalSystem] = []
+        crystal_systems: list[str] = []
         if isinstance(crystal_system, str | CrystalSystem):
             crystal_systems += [
                 CrystalSystem(cs.strip()).value for cs in str(crystal_system).split(",")

--- a/emmet-api/tests/materials/materials/test_query_operators.py
+++ b/emmet-api/tests/materials/materials/test_query_operators.py
@@ -132,6 +132,9 @@ def test_symmetry_query():
         "criteria": {"symmetry.number": {"$in": [221, 229]}}
     }
 
+    with pytest.raises(ValueError, match=r"Unknown space group symbol(s)"):
+        op.query(spacegroup_symbol=["apple", "pear"])
+
     with pytest.raises(
         ValueError, match="inequivalent space group number.*and crystal system"
     ):

--- a/emmet-api/tests/materials/materials/test_query_operators.py
+++ b/emmet-api/tests/materials/materials/test_query_operators.py
@@ -1,6 +1,7 @@
 import os
 
 from pymatgen.core.structure import Structure
+import pytest
 
 from emmet.api.core.settings import MAPISettings
 from emmet.api.routes.materials.materials.query_operators import (
@@ -109,16 +110,47 @@ def test_deprecation_query():
 
 def test_symmetry_query():
     op = SymmetryQuery()
-    assert op.query(
-        crystal_system=CrystalSystem.cubic,
-        spacegroup_number=221,
-        spacegroup_symbol="Pm3m",
-    ) == {
-        "criteria": {
-            "symmetry.crystal_system": "Cubic",
-            "symmetry.number": 221,
-            "symmetry.symbol": "Pm3m",
+
+    for aux_query in [
+        {"spacegroup_number": 221},
+        {"spacegroup_symbol": "Pm-3m"},
+        {"spacegroup_number": 221, "spacegroup_symbol": "Pm-3m"},
+    ]:
+        # Assert correct reduction of space group symbol to number
+        assert op.query(crystal_system=CrystalSystem.cubic, **aux_query) == {
+            "criteria": {
+                "symmetry.crystal_system": "Cubic",
+                "symmetry.number": 221,
+            }
         }
+
+    with pytest.raises(
+        ValueError, match=r"inequivalent space group number.*and symbol"
+    ):
+        op.query(spacegroup_number=221, spacegroup_symbol="Im-3m")
+    assert op.query(spacegroup_number="229,221", spacegroup_symbol="Im-3m") == {
+        "criteria": {"symmetry.number": {"$in": [221, 229]}}
+    }
+
+    with pytest.raises(
+        ValueError, match="inequivalent space group number.*and crystal system"
+    ):
+        op.query(spacegroup_number=221, crystal_system="Trigonal")
+
+    with pytest.raises(
+        ValueError, match="inequivalent space group number.*and crystal system"
+    ):
+        assert op.query(spacegroup_number="229,221", crystal_system="Trigonal")
+
+    with pytest.raises(
+        ValueError, match="inequivalent space group number.*and crystal system"
+    ):
+        assert op.query(crystal_system="Trigonal", spacegroup_symbol="Im-3m")
+
+    crystal_systems = ["ortho", "mono"]
+    cs = [CrystalSystem[x].value for x in crystal_systems]
+    assert op.query(crystal_system=",".join(cs)) == {
+        "criteria": {"symmetry.crystal_system": {"$in": cs}}
     }
 
 

--- a/emmet-api/tests/materials/materials/test_query_operators.py
+++ b/emmet-api/tests/materials/materials/test_query_operators.py
@@ -128,12 +128,16 @@ def test_symmetry_query():
         ValueError, match=r"inequivalent space group number.*and symbol"
     ):
         op.query(spacegroup_number=221, spacegroup_symbol="Im-3m")
-    assert op.query(spacegroup_number="229,221", spacegroup_symbol="Im-3m") == {
+
+    with pytest.raises(ValueError, match="inequivalent space group number.*and symbol"):
+        op.query(spacegroup_number="229,221", spacegroup_symbol="Im-3m")
+
+    assert op.query(spacegroup_number="229,221") == {
         "criteria": {"symmetry.number": {"$in": [221, 229]}}
     }
 
-    with pytest.raises(ValueError, match=r"Unknown space group symbol(s)"):
-        op.query(spacegroup_symbol=["apple", "pear"])
+    with pytest.raises(ValueError, match="Unknown space group symbol.*apple, pear"):
+        op.query(spacegroup_symbol="pear,apple,Pnma")
 
     with pytest.raises(
         ValueError, match="inequivalent space group number.*and crystal system"

--- a/emmet-core/emmet/core/symmetry.py
+++ b/emmet-core/emmet/core/symmetry.py
@@ -68,10 +68,16 @@ def get_crystal_system_from_international_number(sgn: int) -> CrystalSystem:
 
 def _get_space_group_symbol_to_number_mapping() -> dict[str, int]:
     """Return a dict mapping space group symbol to its international number."""
-    return {
+    sg_map = {
         sgs: entry["int_number"]
         for sgs, entry in SYMM_DATA["space_group_encoding"].items()
     }
+
+    # Add in duplicate abbreviated space group symbols
+    # These abbreviated symbols are used by spglib
+    for abbr, full in SYMM_DATA["abbreviated_spacegroup_symbols"].items():
+        sg_map[abbr] = sg_map[full]
+    return sg_map
 
 
 class PointGroupData(BaseModel):

--- a/emmet-core/emmet/core/symmetry.py
+++ b/emmet-core/emmet/core/symmetry.py
@@ -12,6 +12,7 @@ from pymatgen.symmetry.analyzer import (
     SymmetryUndeterminedError,
     spglib,
 )
+from pymatgen.symmetry.groups import SYMM_DATA
 
 from emmet.core.settings import EmmetSettings
 from emmet.core.types.enums import IgnoreCaseEnum
@@ -34,6 +35,43 @@ class CrystalSystem(IgnoreCaseEnum):
     trig = "Trigonal"
     hex_ = "Hexagonal"
     cubic = "Cubic"
+
+
+def get_crystal_system_from_international_number(sgn: int) -> CrystalSystem:
+    """Identify the crystal system from the international space group number.
+
+    Parameters
+    -----------
+    sgn (int) : The international space group number
+
+    Returns
+    -----------
+    CrystalSystem
+    """
+    try:
+        return next(
+            CrystalSystem[family]
+            for family, sgn_range in {
+                "tri": (1, 3),
+                "mono": (3, 16),
+                "ortho": (16, 75),
+                "tet": (75, 143),
+                "trig": (143, 168),
+                "hex_": (168, 195),
+                "cubic": (195, 231),
+            }.items()
+            if sgn_range[0] <= sgn < sgn_range[1]
+        )
+    except StopIteration:
+        raise ValueError(f"Invalid space group number {sgn}.")
+
+
+def _get_space_group_symbol_to_number_mapping() -> dict[str, int]:
+    """Return a dict mapping space group symbol to its international number."""
+    return {
+        sgs: entry["int_number"]
+        for sgs, entry in SYMM_DATA["space_group_encoding"].items()
+    }
 
 
 class PointGroupData(BaseModel):

--- a/emmet-core/emmet/core/symmetry.py
+++ b/emmet-core/emmet/core/symmetry.py
@@ -50,7 +50,7 @@ def get_crystal_system_from_international_number(sgn: int) -> CrystalSystem:
     """
     try:
         return next(
-            CrystalSystem[family]
+            CrystalSystem[family]  # type: ignore[misc]
             for family, sgn_range in {
                 "tri": (1, 3),
                 "mono": (3, 16),

--- a/emmet-core/tests/test_symmetry.py
+++ b/emmet-core/tests/test_symmetry.py
@@ -1,5 +1,6 @@
 """Test symmetry-related utilities."""
 
+from pymatgen.symmetry.groups import SYMM_DATA
 import pytest
 
 from emmet.core.symmetry import (
@@ -22,6 +23,9 @@ def test_spacegroup_symbol_number_mapping():
             "Ia-3d": 230,
         }.items()
     )
+
+    assert all(k in sgsn for k in SYMM_DATA["abbreviated_spacegroup_symbols"])
+    assert sorted(set(sgsn.values())) == list(range(1, 231))
 
 
 def test_get_crystal_system():

--- a/emmet-core/tests/test_symmetry.py
+++ b/emmet-core/tests/test_symmetry.py
@@ -1,0 +1,36 @@
+"""Test symmetry-related utilities."""
+
+import pytest
+
+from emmet.core.symmetry import (
+    _get_space_group_symbol_to_number_mapping,
+    get_crystal_system_from_international_number,
+    CrystalSystem,
+)
+
+
+def test_spacegroup_symbol_number_mapping():
+
+    sgsn = _get_space_group_symbol_to_number_mapping()
+    assert all(isinstance(k, str) and isinstance(v, int) for k, v in sgsn.items())
+    assert all(
+        sgsn.get(k) == v
+        and get_crystal_system_from_international_number(v) == CrystalSystem.cubic
+        for k, v in {
+            "Fm-3m": 225,
+            "Im-3m": 229,
+            "Ia-3d": 230,
+        }.items()
+    )
+
+
+def test_get_crystal_system():
+
+    for sgn in range(232):
+        if sgn < 1 or sgn > 230:
+            with pytest.raises(ValueError, match="Invalid space group number"):
+                get_crystal_system_from_international_number(sgn)
+        else:
+            assert isinstance(
+                get_crystal_system_from_international_number(sgn), CrystalSystem
+            )


### PR DESCRIPTION
Related to [API client issue #902](https://github.com/materialsproject/api/issues/902):
- Make space group number, symbol, and crystal system support list-like queries
- Use mappings between these to not execute queries which contain user error (e.g., conflicting values of the space group symbol and number)

Needs testing