### PR TITLE
patches task-v8 

### DIFF
--- a/emmet-api/Dockerfile
+++ b/emmet-api/Dockerfile
@@ -19,7 +19,7 @@ RUN wget -q https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-
 
 FROM base
 ARG BUILDARCH
-ARG BUILDARCH=aarch64
+ENV BUILDARCH=x86_64
 COPY --from=builder /root/.local/lib/python3.11/site-packages /root/.local/lib/python3.11/site-packages
 COPY --from=builder /root/.local/bin /root/.local/bin
 COPY --from=builder /usr/lib/$BUILDARCH-linux-gnu/libsnappy* /usr/lib/$BUILDARCH-linux-gnu/

--- a/emmet-api/Dockerfile
+++ b/emmet-api/Dockerfile
@@ -19,7 +19,7 @@ RUN wget -q https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-
 
 FROM base
 ARG BUILDARCH
-ENV BUILDARCH=x86_64
+ARG BUILDARCH=aarch64
 COPY --from=builder /root/.local/lib/python3.11/site-packages /root/.local/lib/python3.11/site-packages
 COPY --from=builder /root/.local/bin /root/.local/bin
 COPY --from=builder /usr/lib/$BUILDARCH-linux-gnu/libsnappy* /usr/lib/$BUILDARCH-linux-gnu/

--- a/emmet-api/emmet/api/query_operator/__init__.py
+++ b/emmet-api/emmet/api/query_operator/__init__.py
@@ -4,6 +4,7 @@ from emmet.api.query_operator.pagination import AtlasPaginationQuery, Pagination
 from emmet.api.query_operator.sorting import SortQuery
 from emmet.api.query_operator.sparse_fields import SparseFieldsQuery
 from emmet.api.query_operator.submission import SubmissionQuery
+from emmet.api.query_operator.tasks import MultiTaskIDQuery
 
 __all__ = [
     "QueryOperator",
@@ -14,4 +15,5 @@ __all__ = [
     "SortQuery",
     "SparseFieldsQuery",
     "SubmissionQuery",
+    "MultiTaskIDQuery",
 ]

--- a/emmet-api/emmet/api/query_operator/tasks.py
+++ b/emmet-api/emmet/api/query_operator/tasks.py
@@ -1,6 +1,7 @@
 """Define common task query functionality."""
 
 from fastapi import Query
+from typing import Any
 from emmet.api.query_operator import QueryOperator
 from emmet.api.utils import STORE_PARAMS
 
@@ -23,17 +24,21 @@ class MultiTaskIDQuery(QueryOperator):
             None, description="Comma-separated list of task_ids to query on"
         ),
     ) -> STORE_PARAMS:
-        crit = {}
+        crit: dict[str, Any] = {}
 
         if task_ids:
             task_key = "task_id" + ("s" if self.use_plural else "")
             if (
-                len(task_ids := [task_id.strip() for task_id in task_ids.split(",")])
+                len(
+                    parsed_task_ids := [
+                        task_id.strip() for task_id in task_ids.split(",")
+                    ]
+                )
                 == 1
             ):
-                crit[task_key] = task_ids[0]
+                crit[task_key] = parsed_task_ids[0]
             else:
-                crit[task_key] = {"$in": task_ids}
+                crit[task_key] = {"$in": parsed_task_ids}
 
         return {"criteria": crit}
 

--- a/emmet-api/emmet/api/query_operator/tasks.py
+++ b/emmet-api/emmet/api/query_operator/tasks.py
@@ -1,0 +1,33 @@
+"""Define common task query functionality."""
+
+from fastapi import Query
+from emmet.api.query_operator import QueryOperator
+from emmet.api.utils import STORE_PARAMS
+
+
+class MultiTaskIDQuery(QueryOperator):
+    """
+    Method to generate a query for different task_ids
+    """
+
+    def query(
+        self,
+        task_ids: str | None = Query(
+            None, description="Comma-separated list of task_ids to query on"
+        ),
+    ) -> STORE_PARAMS:
+        crit = {}
+
+        if task_ids:
+            crit.update(
+                {
+                    "task_ids": {
+                        "$in": [task_id.strip() for task_id in task_ids.split(",")]
+                    }
+                }
+            )
+
+        return {"criteria": crit}
+
+    def ensure_indexes(self):  # pragma: no cover
+        return [("task_ids", False)]

--- a/emmet-api/emmet/api/query_operator/tasks.py
+++ b/emmet-api/emmet/api/query_operator/tasks.py
@@ -6,9 +6,16 @@ from emmet.api.utils import STORE_PARAMS
 
 
 class MultiTaskIDQuery(QueryOperator):
-    """
-    Method to generate a query for different task_ids
-    """
+    """Method to generate a query for different task_ids."""
+
+    def __init__(self, use_plural: bool = True) -> None:
+        """Set up a multi task ID query operator.
+
+        Args:
+            use_plural (bool) : Whether to use the plural `task_ids` when
+                querying (True, default), or the singular `task_id` (False)
+        """
+        self.use_plural = use_plural
 
     def query(
         self,
@@ -19,13 +26,14 @@ class MultiTaskIDQuery(QueryOperator):
         crit = {}
 
         if task_ids:
-            crit.update(
-                {
-                    "task_ids": {
-                        "$in": [task_id.strip() for task_id in task_ids.split(",")]
-                    }
-                }
-            )
+            task_key = "task_id" + ("s" if self.use_plural else "")
+            if (
+                len(task_ids := [task_id.strip() for task_id in task_ids.split(",")])
+                == 1
+            ):
+                crit[task_key] = task_ids[0]
+            else:
+                crit[task_key] = {"$in": task_ids}
 
         return {"criteria": crit}
 

--- a/emmet-api/emmet/api/routes/defects/tasks/resources.py
+++ b/emmet-api/emmet/api/routes/defects/tasks/resources.py
@@ -1,4 +1,8 @@
-from emmet.api.query_operator import PaginationQuery, SparseFieldsQuery
+from emmet.api.query_operator import (
+    PaginationQuery,
+    SparseFieldsQuery,
+    MultiTaskIDQuery,
+)
 from emmet.api.resource import ReadOnlyResource
 
 from emmet.api.routes.materials.materials.query_operators import (
@@ -8,7 +12,6 @@ from emmet.api.routes.materials.materials.query_operators import (
 )
 from emmet.api.routes.materials.tasks.hint_scheme import TasksHintScheme
 from emmet.api.routes.materials.tasks.query_operators import (
-    MultipleTaskIDsQuery,
     LastUpdatedQuery,
 )
 from emmet.api.core.global_header import GlobalHeaderProcessor
@@ -26,7 +29,7 @@ def task_resource(task_store):
             FormulaQuery(),
             ChemsysQuery(),
             ElementsQuery(),
-            MultipleTaskIDsQuery(),
+            MultiTaskIDQuery(),
             LastUpdatedQuery(),
             PaginationQuery(),
             SparseFieldsQuery(

--- a/emmet-api/emmet/api/routes/defects/tasks/resources.py
+++ b/emmet-api/emmet/api/routes/defects/tasks/resources.py
@@ -29,7 +29,7 @@ def task_resource(task_store):
             FormulaQuery(),
             ChemsysQuery(),
             ElementsQuery(),
-            MultiTaskIDQuery(),
+            MultiTaskIDQuery(use_plural=False),
             LastUpdatedQuery(),
             PaginationQuery(),
             SparseFieldsQuery(

--- a/emmet-api/emmet/api/routes/legacy/jcesr/resources.py
+++ b/emmet-api/emmet/api/routes/legacy/jcesr/resources.py
@@ -1,13 +1,17 @@
 from emmet.api.resource import ReadOnlyResource
 from emmet.core.molecules_jcesr import MoleculesDoc
 
-from emmet.api.query_operator import PaginationQuery, SortQuery, SparseFieldsQuery
+from emmet.api.query_operator import (
+    PaginationQuery,
+    SortQuery,
+    SparseFieldsQuery,
+    MultiTaskIDQuery,
+)
 from emmet.api.routes.legacy.jcesr.query_operators import (
     MoleculeBaseQuery,
     MoleculeElementsQuery,
     MoleculeFormulaQuery,
 )
-from emmet.api.routes.materials.tasks.query_operators import MultipleTaskIDsQuery
 from emmet.api.core.global_header import GlobalHeaderProcessor
 from emmet.api.core.settings import MAPISettings
 
@@ -27,7 +31,7 @@ def jcesr_resource(molecules_store):
             MoleculeBaseQuery(),
             MoleculeElementsQuery(),
             MoleculeFormulaQuery(),
-            MultipleTaskIDsQuery(),
+            MultiTaskIDQuery(),
             PaginationQuery(),
             SortQuery(fields=JCESR_SORT_FIELDS, max_num=1),
             SparseFieldsQuery(MoleculesDoc, default_fields=["task_id"]),

--- a/emmet-api/emmet/api/routes/legacy/jcesr/resources.py
+++ b/emmet-api/emmet/api/routes/legacy/jcesr/resources.py
@@ -31,7 +31,7 @@ def jcesr_resource(molecules_store):
             MoleculeBaseQuery(),
             MoleculeElementsQuery(),
             MoleculeFormulaQuery(),
-            MultiTaskIDQuery(),
+            MultiTaskIDQuery(use_plural=False),
             PaginationQuery(),
             SortQuery(fields=JCESR_SORT_FIELDS, max_num=1),
             SparseFieldsQuery(MoleculesDoc, default_fields=["task_id"]),

--- a/emmet-api/emmet/api/routes/materials/materials/query_operators.py
+++ b/emmet-api/emmet/api/routes/materials/materials/query_operators.py
@@ -276,34 +276,6 @@ class SymmetryQuery(QueryOperator):
         return [(key, False) for key in keys]
 
 
-class MultiTaskIDQuery(QueryOperator):
-    """
-    Method to generate a query for different task_ids
-    """
-
-    def query(
-        self,
-        task_ids: str | None = Query(
-            None, description="Comma-separated list of task_ids to query on"
-        ),
-    ) -> STORE_PARAMS:
-        crit = {}
-
-        if task_ids:
-            crit.update(
-                {
-                    "task_ids": {
-                        "$in": [task_id.strip() for task_id in task_ids.split(",")]
-                    }
-                }
-            )
-
-        return {"criteria": crit}
-
-    def ensure_indexes(self):  # pragma: no cover
-        return [("task_ids", False)]
-
-
 class BlessedCalcsQuery(QueryOperator):
     """
     Method to generate a query for nested blessed calculation data

--- a/emmet-api/emmet/api/routes/materials/materials/resources.py
+++ b/emmet-api/emmet/api/routes/materials/materials/resources.py
@@ -11,6 +11,7 @@ from emmet.api.query_operator import (
     PaginationQuery,
     SparseFieldsQuery,
     NumericQuery,
+    MultiTaskIDQuery,
 )
 
 from emmet.api.routes.materials.materials.query_operators import (
@@ -19,7 +20,6 @@ from emmet.api.routes.materials.materials.query_operators import (
     ChemsysQuery,
     DeprecationQuery,
     SymmetryQuery,
-    MultiTaskIDQuery,
     FindStructureQuery,
     FormulaAutoCompleteQuery,
     MultiMaterialIDQuery,

--- a/emmet-api/emmet/api/routes/molecules/association/resources.py
+++ b/emmet-api/emmet/api/routes/molecules/association/resources.py
@@ -8,6 +8,7 @@ from emmet.api.query_operator import (
     PaginationQuery,
     SparseFieldsQuery,
     NumericQuery,
+    MultiTaskIDQuery,
 )
 
 from emmet.api.routes.molecules.molecules.hint_scheme import MoleculesHintScheme
@@ -17,7 +18,6 @@ from emmet.api.routes.molecules.molecules.query_operators import (
     CompositionElementsQuery,
     ChargeSpinQuery,
     DeprecationQuery,
-    MultiTaskIDQuery,
     MultiMPculeIDQuery,
     FindMoleculeQuery,
     CalcMethodQuery,

--- a/emmet-api/emmet/api/routes/molecules/molecules/query_operators.py
+++ b/emmet-api/emmet/api/routes/molecules/molecules/query_operators.py
@@ -171,35 +171,6 @@ class DeprecationQuery(QueryOperator):
         return {"criteria": crit}
 
 
-class MultiTaskIDQuery(QueryOperator):
-    """
-    Method to generate a query for different task_ids
-    """
-
-    def query(
-        self,
-        task_ids: str | None = Query(
-            None, description="Comma-separated list of task_ids to query on"
-        ),
-    ) -> STORE_PARAMS:
-        crit = {}
-
-        if task_ids:
-            # TODO: do task_ids need to be converted to ints?
-            crit.update(
-                {
-                    "task_ids": {
-                        "$in": [task_id.strip() for task_id in task_ids.split(",")]
-                    }
-                }
-            )
-
-        return {"criteria": crit}
-
-    def ensure_indexes(self):  # pragma: no cover
-        return [("task_ids", False)]
-
-
 class MultiMPculeIDQuery(QueryOperator):
     """
     Method to generate a query for different root-level mpcule_id values

--- a/emmet-api/emmet/api/routes/molecules/molecules/resources.py
+++ b/emmet-api/emmet/api/routes/molecules/molecules/resources.py
@@ -8,6 +8,7 @@ from emmet.api.query_operator import (
     PaginationQuery,
     SparseFieldsQuery,
     NumericQuery,
+    MultiTaskIDQuery,
 )
 
 from emmet.api.routes.molecules.molecules.hint_scheme import MoleculesHintScheme
@@ -17,7 +18,6 @@ from emmet.api.routes.molecules.molecules.query_operators import (
     CompositionElementsQuery,
     ChargeSpinQuery,
     DeprecationQuery,
-    MultiTaskIDQuery,
     MultiMPculeIDQuery,
     FindMoleculeQuery,
     CalcMethodQuery,

--- a/emmet-api/tests/materials/materials/test_query_operators.py
+++ b/emmet-api/tests/materials/materials/test_query_operators.py
@@ -4,6 +4,7 @@ from pymatgen.core.structure import Structure
 import pytest
 
 from emmet.api.core.settings import MAPISettings
+from emmet.api.query_operator import MultiTaskIDQuery
 from emmet.api.routes.materials.materials.query_operators import (
     BlessedCalcsQuery,
     ChemsysQuery,
@@ -13,7 +14,6 @@ from emmet.api.routes.materials.materials.query_operators import (
     FormulaAutoCompleteQuery,
     FormulaQuery,
     MultiMaterialIDQuery,
-    MultiTaskIDQuery,
     SymmetryQuery,
 )
 from emmet.core.symmetry import CrystalSystem, _get_space_group_symbol_to_number_mapping

--- a/emmet-api/tests/molecules/molecules/test_query_operators.py
+++ b/emmet-api/tests/molecules/molecules/test_query_operators.py
@@ -2,13 +2,13 @@ import os
 import pytest
 
 from emmet.api.core.settings import MAPISettings
+from emmet.api.query_operator import MultiTaskIDQuery
 from emmet.api.routes.molecules.molecules.query_operators import (
     FormulaQuery,
     ChemsysQuery,
     CompositionElementsQuery,
     ChargeSpinQuery,
     DeprecationQuery,
-    MultiTaskIDQuery,
     MultiMPculeIDQuery,
     FindMoleculeQuery,
     CalcMethodQuery,

--- a/emmet-api/tests/query_operator/test_tasks.py
+++ b/emmet-api/tests/query_operator/test_tasks.py
@@ -1,0 +1,19 @@
+import pytest
+
+from emmet.api.query_operator.tasks import MultiTaskIDQuery
+
+
+@pytest.mark.parametrize("use_plural", [True, False])
+def test_multi_task_id(use_plural: bool):
+
+    key = "task_id" + ("s" if use_plural else "")
+
+    multi_idxs = "mp-149, mol-129, aaft"
+    # check space removal
+    for idxs in [multi_idxs, multi_idxs.replace(" ", "")]:
+        q = MultiTaskIDQuery(use_plural=use_plural).query(task_ids=idxs)
+        assert q == {"criteria": {key: {"$in": ["mp-149", "mol-129", "aaft"]}}}
+
+    assert MultiTaskIDQuery(use_plural=use_plural).query(task_ids="mp-abcdefg") == {
+        "criteria": {key: "mp-abcdefg"}
+    }


### PR DESCRIPTION
- Remove duplicate `MultiTaskIDQuery` classes
- Ensure JCESR does not use Atlas-specific multi task ID query
***Not to be merged until local deployments stable***