### PR TITLE
Fix acoustic_sum_rule computation in PhononBSDOSDoc

### DIFF
--- a/emmet-core/emmet/core/phonon.py
+++ b/emmet-core/emmet/core/phonon.py
@@ -51,6 +51,7 @@ DEFAULT_PHONON_FILES = {
     "force_constants": "FORCE_CONSTANTS",  # chosen as Phonopy default
     "born": "born.npz",
     "epsilon_static": "epsilon_static.npz",
+    "epsilon_static_and_born": "BORN",
     "phonopy_output": "phonopy.yaml",
 }
 
@@ -61,6 +62,51 @@ class PhononMethod(Enum):
     DFPT = "dfpt"
     PHONOPY = "phonopy"
     PHEASY = "pheasy"
+
+
+def parse_phonopy_born_file(file: FSPathType) -> tuple[Matrix3D, list[Matrix3D]]:
+    """Parse a phonopy BORN file into static dielectric and Born charge tensors.
+
+    From the phonopy manual
+    (https://phonopy.github.io/phonopy/input-files.html#born-optional)
+    the BORN file is structured as:
+        line 0: metadata, including maximum number of atoms
+        line 1: static dielectric tensor
+        lines 2+: Born effective charges on each atomic site
+
+    For both the dielectric tensor and Born charges, the order of
+    components is: xx, xy, xz, yx, yy, yz, zx, zy, and zz, or
+    ```py
+    [(j,i) for j in range(3) for i in range(3)]
+
+    Args:
+    file (FSPathType) : path to the BORN file.
+
+    Returns:
+    Matrix3D : The static, high-frequency limit of the dielectric tensor
+    list of Matrix3D : The Born effective charges, a 3x3 matrix for
+        each atom in the cell.
+    ```
+    """
+    natom = 0
+    iatom = 0
+    idxs = [(j, i) for j in range(3) for i in range(3)]
+    eps_inf = np.zeros((3, 3), dtype=float)
+    with open(file, "rt") as f:
+        for idx, line in enumerate(f):
+            if idx == 0:
+                natom = int(line.split()[-1])
+                bec = np.zeros((natom, 3, 3), dtype=float)
+            elif idx == 1:
+                vals = [float(x) for x in line.split()]
+                for i, ibec in enumerate(idxs):
+                    eps_inf[ibec[0], ibec[1]] = vals[i]
+            else:
+                vals = [float(x) for x in line.split()]
+                for i, ibec in enumerate(idxs):
+                    bec[iatom][ibec[0], ibec[1]] = vals[i]
+                iatom += 1
+    return eps_inf, bec
 
 
 class PhononDOS(BandTheoryBase):
@@ -516,7 +562,20 @@ class PhononBSDOSTask(StructureMetadata):
     @computed_field  # type: ignore[prop-decorator]
     @cached_property
     def charge_neutral_sum_rule(self) -> Matrix3D | None:
-        """Sum of Born effective charges over sites should be zero."""
+        r"""Sum of Born effective charges over sites should be zero.
+
+        See Eq. 46 of https://doi.org/10.1103/PhysRevB.55.10355:
+        $$
+        \sum_{i=1}^N Z_{i\alpha\beta}
+        $$
+        where $Z_{i\alpha\beta}$ is the N x 3 x 3 Born effective
+        charge tensor, $i = 1,2,...,N$ ranges up to the number of
+        atoms $N$, and $\alpha, \beta = x, y, z$ are Cartesian
+        directions.
+
+        This returns a 3 x 3 matrix. The maximum deviation
+        from the sum rule is checked by `check_sum_rule_deviations`.
+        """
         if self.born:
             bec = np.array(self.born)
             return tuple(tuple(row) for row in np.sum(bec, axis=0).tolist())
@@ -524,16 +583,26 @@ class PhononBSDOSTask(StructureMetadata):
 
     @computed_field  # type: ignore[prop-decorator]
     @cached_property
-    def acoustic_sum_rule(self) -> float | None:
-        """Largest absolute violation of the acoustic sum rule.
+    def acoustic_sum_rule(self) -> list[Matrix3D] | None:
+        r"""Determine violations of the acoustic sum rule.
 
-        Returns max_{i, alpha, beta} |sum_j Phi_ij,alpha,beta|, where Phi
-        is the force-constant tensor of shape (N_atoms, N_atoms, 3, 3).
+        The acoustic sum rule for the interatomic force constant (IFC) tensor
+        is (Eq. 44 of https://doi.org/10.1103/PhysRevB.55.10355):
+        $$
+        \sum_{j=1}^N C_{ij\alpha\beta} = 0.
+        $$
+        The IFCs are an N x N x 3 x 3 tensor, where N = number of atoms
+        in the structure (`structure.num_sites`).
+        $i, j = 1,2,3,...,N$, and $\alpha,\beta = x,y,z$ are the Cartesian
+        directions.
+
+        The maximum deviation from the sum rule is checked
+        by `check_sum_rule_deviations`.
+
         For an ASR-corrected force-constant set, this is numerically zero.
         """
         if self.force_constants:
-            fcs = np.asarray(self.force_constants)
-            return float(np.abs(fcs.sum(axis=1)).max())
+            return np.asarray(self.force_constants).sum(axis=1)
         return None
 
     @computed_field  # type: ignore[prop-decorator]
@@ -544,8 +613,8 @@ class PhononBSDOSTask(StructureMetadata):
             self.sum_rules_breaking = SumRuleChecks(
                 **{
                     k: (
-                        np.max(np.abs(getattr(self, attr)))
-                        if getattr(self, attr)
+                        np.abs(getattr(self, attr)).max()
+                        if getattr(self, attr) is not None
                         else None
                     )
                     for k, attr in {
@@ -691,6 +760,7 @@ class PhononBSDOSTask(StructureMetadata):
         force_constants_file: FSPathType | None = None,
         born_file: FSPathType | None = None,
         epsilon_static_file: FSPathType | None = None,
+        epsilon_static_and_born_file: FSPathType | None = None,
         phonopy_output_file: FSPathType | None = None,
         **kwargs,
     ) -> Self:
@@ -741,10 +811,19 @@ class PhononBSDOSTask(StructureMetadata):
                         irow += 1
             cls_config["force_constants"] = force_constant_matrix.tolist()
 
-        if born_file:
+        if all(
+            fs and ".npz" in Path(fs).name for fs in (born_file, epsilon_static_file)
+        ):
             cls_config["born"] = np.load(born_file)
-        if epsilon_static_file:
             cls_config["epsilon_static"] = np.load(epsilon_static_file)
+
+        elif (
+            epsilon_static_and_born_file
+            and "BORN" in Path(epsilon_static_and_born_file).name
+        ):
+            cls_config["epsilon_static"], cls_config["born"] = parse_phonopy_born_file(
+                epsilon_static_and_born_file
+            )
 
         if phonopy_output_file:
             with zopen(phonopy_output_file, "rt") as f:

--- a/emmet-core/emmet/core/phonon.py
+++ b/emmet-core/emmet/core/phonon.py
@@ -15,7 +15,6 @@ from pydantic import (
     BaseModel,
     Field,
     PrivateAttr,
-    computed_field,
     PlainSerializer,
     BeforeValidator,
 )
@@ -542,7 +541,6 @@ class PhononBSDOSTask(StructureMetadata):
             **config,
         )
 
-    @computed_field  # type: ignore[prop-decorator]
     @cached_property
     def has_imaginary_modes(self) -> bool | None:
         tol: float = 1e-5
@@ -559,7 +557,6 @@ class PhononBSDOSTask(StructureMetadata):
             )
         return None
 
-    @computed_field  # type: ignore[prop-decorator]
     @cached_property
     def charge_neutral_sum_rule(self) -> Matrix3D | None:
         r"""Sum of Born effective charges over sites should be zero.
@@ -581,7 +578,6 @@ class PhononBSDOSTask(StructureMetadata):
             return tuple(tuple(row) for row in np.sum(bec, axis=0).tolist())
         return None
 
-    @computed_field  # type: ignore[prop-decorator]
     @cached_property
     def acoustic_sum_rule(self) -> list[Matrix3D] | None:
         r"""Determine violations of the acoustic sum rule.
@@ -605,7 +601,6 @@ class PhononBSDOSTask(StructureMetadata):
             return np.asarray(self.force_constants).sum(axis=1)
         return None
 
-    @computed_field  # type: ignore[prop-decorator]
     @property
     def check_sum_rule_deviations(self) -> SumRuleChecks:
         """Report deviations from sum rules."""

--- a/emmet-core/emmet/core/phonon.py
+++ b/emmet-core/emmet/core/phonon.py
@@ -64,7 +64,7 @@ class PhononMethod(Enum):
     PHEASY = "pheasy"
 
 
-def parse_phonopy_born_file(file: FSPathType) -> tuple[Matrix3D, list[Matrix3D]]:
+def parse_phonopy_born_file(file: FSPathType) -> tuple[np.ndarray, np.ndarray]:
     """Parse a phonopy BORN file into static dielectric and Born charge tensors.
 
     From the phonopy manual
@@ -812,10 +812,11 @@ class PhononBSDOSTask(StructureMetadata):
             cls_config["force_constants"] = force_constant_matrix.tolist()
 
         if all(
-            fs and ".npz" in Path(fs).name for fs in (born_file, epsilon_static_file)
+            fs is not None and ".npz" in Path(fs).name
+            for fs in (born_file, epsilon_static_file)
         ):
-            cls_config["born"] = np.load(born_file)
-            cls_config["epsilon_static"] = np.load(epsilon_static_file)
+            cls_config["born"] = np.load(born_file)  # type: ignore[arg-type]
+            cls_config["epsilon_static"] = np.load(epsilon_static_file)  # type: ignore[arg-type]
 
         elif (
             epsilon_static_and_born_file

--- a/emmet-core/emmet/core/phonon.py
+++ b/emmet-core/emmet/core/phonon.py
@@ -524,24 +524,16 @@ class PhononBSDOSTask(StructureMetadata):
 
     @computed_field  # type: ignore[prop-decorator]
     @cached_property
-    def acoustic_sum_rule(self) -> Matrix3D | None:
-        """Largest per-atom violation of the acoustic sum rule, as a 3x3 matrix.
+    def acoustic_sum_rule(self) -> float | None:
+        """Largest absolute violation of the acoustic sum rule.
 
-        For each atom i, sum the force constants over its neighbours j; this
-        sum should be zero for an ASR-corrected force-constant set. We pick
-        the atom whose row sum has the largest Frobenius norm and return that
-        row sum.
-
-        The previous version of this function used einsum("iijk->jk", fcs),
-        which sums only the on-site (i==j) blocks and is not related to the
-        acoustic sum rule.
+        Returns max_{i, alpha, beta} |sum_j Phi_ij,alpha,beta|, where Phi
+        is the force-constant tensor of shape (N_atoms, N_atoms, 3, 3).
+        For an ASR-corrected force-constant set, this is numerically zero.
         """
         if self.force_constants:
             fcs = np.asarray(self.force_constants)
-            row_sums = fcs.sum(axis=1)
-            norms = np.linalg.norm(row_sums, axis=(1, 2))
-            worst_atom = int(np.argmax(norms))
-            return tuple(tuple(row) for row in row_sums[worst_atom])
+            return float(np.abs(fcs.sum(axis=1)).max())
         return None
 
     @computed_field  # type: ignore[prop-decorator]

--- a/emmet-core/emmet/core/phonon.py
+++ b/emmet-core/emmet/core/phonon.py
@@ -525,12 +525,23 @@ class PhononBSDOSTask(StructureMetadata):
     @computed_field  # type: ignore[prop-decorator]
     @cached_property
     def acoustic_sum_rule(self) -> Matrix3D | None:
-        """Sum of q=0 atomic force constants should be zero."""
+        """Largest per-atom violation of the acoustic sum rule, as a 3x3 matrix.
+
+        For each atom i, sum the force constants over its neighbours j; this
+        sum should be zero for an ASR-corrected force-constant set. We pick
+        the atom whose row sum has the largest Frobenius norm and return that
+        row sum.
+
+        The previous version of this function used einsum("iijk->jk", fcs),
+        which sums only the on-site (i==j) blocks and is not related to the
+        acoustic sum rule.
+        """
         if self.force_constants:
-            return tuple(
-                tuple(row)
-                for row in np.einsum("iijk->jk", np.array(self.force_constants))
-            )
+            fcs = np.asarray(self.force_constants)
+            row_sums = fcs.sum(axis=1)
+            norms = np.linalg.norm(row_sums, axis=(1, 2))
+            worst_atom = int(np.argmax(norms))
+            return tuple(tuple(row) for row in row_sums[worst_atom])
         return None
 
     @computed_field  # type: ignore[prop-decorator]

--- a/emmet-core/tests/test_phonon.py
+++ b/emmet-core/tests/test_phonon.py
@@ -161,7 +161,7 @@ def test_phonopy_dos_integration(tmp_dir):
 def test_acoustic_sum_rule_per_atom_row_sum():
     """Regression test for the acoustic_sum_rule formula.
 
-    The per-atom row sum sum_j Phi_ij; 
+    The per-atom row sum sum_j Phi_ij;
     this property returns the row sum with the largest Frobenius norm.
     """
     rng = np.random.default_rng(seed=0)

--- a/emmet-core/tests/test_phonon.py
+++ b/emmet-core/tests/test_phonon.py
@@ -156,3 +156,27 @@ def test_phonopy_dos_integration(tmp_dir):
 
     for idx, attr in enumerate(["frequencies", "densities"]):
         assert np.all(np.abs(ph_data[:, idx] - np.array(getattr(ph_dos, attr))) < 1e-6)
+
+
+def test_acoustic_sum_rule_per_atom_row_sum():
+    """Regression test for the acoustic_sum_rule formula.
+
+    The per-atom row sum sum_j Phi_ij; 
+    this property returns the row sum with the largest Frobenius norm.
+    """
+    rng = np.random.default_rng(seed=0)
+    n_atoms = 4
+
+    # ASR-correct: zero out each row's mean so sum_j Phi_ij = 0 for every i.
+    fcs = rng.standard_normal((n_atoms, n_atoms, 3, 3))
+    fcs -= fcs.mean(axis=1, keepdims=True)
+    doc = PhononBSDOSDoc(force_constants=fcs.tolist())
+    asr = np.array(doc.acoustic_sum_rule)
+    assert np.linalg.norm(asr) < 1e-12
+
+    # Obvious violation: all-ones FCs -> every row sum is the (3,3) matrix
+    # full of n_atoms, so the worst-Frobenius row sum is also that matrix.
+    fcs_bad = np.ones((n_atoms, n_atoms, 3, 3))
+    doc_bad = PhononBSDOSDoc(force_constants=fcs_bad.tolist())
+    asr_bad = np.array(doc_bad.acoustic_sum_rule)
+    assert np.allclose(asr_bad, float(n_atoms))

--- a/emmet-core/tests/test_phonon.py
+++ b/emmet-core/tests/test_phonon.py
@@ -159,11 +159,8 @@ def test_phonopy_dos_integration(tmp_dir):
 
 
 def test_acoustic_sum_rule_per_atom_row_sum():
-    """Regression test for the acoustic_sum_rule formula.
+    """Test for the acoustic_sum_rule formula."""
 
-    The per-atom row sum sum_j Phi_ij;
-    this property returns the row sum with the largest Frobenius norm.
-    """
     rng = np.random.default_rng(seed=0)
     n_atoms = 4
 
@@ -171,12 +168,9 @@ def test_acoustic_sum_rule_per_atom_row_sum():
     fcs = rng.standard_normal((n_atoms, n_atoms, 3, 3))
     fcs -= fcs.mean(axis=1, keepdims=True)
     doc = PhononBSDOSDoc(force_constants=fcs.tolist())
-    asr = np.array(doc.acoustic_sum_rule)
-    assert np.linalg.norm(asr) < 1e-12
+    assert doc.acoustic_sum_rule < 1e-12
 
-    # Obvious violation: all-ones FCs -> every row sum is the (3,3) matrix
-    # full of n_atoms, so the worst-Frobenius row sum is also that matrix.
+    # Violation: all-ones FCs --> every row sum is n_atoms.
     fcs_bad = np.ones((n_atoms, n_atoms, 3, 3))
     doc_bad = PhononBSDOSDoc(force_constants=fcs_bad.tolist())
-    asr_bad = np.array(doc_bad.acoustic_sum_rule)
-    assert np.allclose(asr_bad, float(n_atoms))
+    assert doc_bad.acoustic_sum_rule == float(n_atoms)

--- a/emmet-core/tests/test_phonon.py
+++ b/emmet-core/tests/test_phonon.py
@@ -168,9 +168,11 @@ def test_acoustic_sum_rule_per_atom_row_sum():
     fcs = rng.standard_normal((n_atoms, n_atoms, 3, 3))
     fcs -= fcs.mean(axis=1, keepdims=True)
     doc = PhononBSDOSDoc(force_constants=fcs.tolist())
-    assert doc.acoustic_sum_rule < 1e-12
+    max_dev = np.abs(doc.acoustic_sum_rule).max()
+    assert max_dev < 1e-12
+    assert max_dev == doc.check_sum_rule_deviations.asr
 
     # Violation: all-ones FCs --> every row sum is n_atoms.
     fcs_bad = np.ones((n_atoms, n_atoms, 3, 3))
     doc_bad = PhononBSDOSDoc(force_constants=fcs_bad.tolist())
-    assert doc_bad.acoustic_sum_rule == float(n_atoms)
+    assert doc_bad.check_sum_rule_deviations.asr == float(n_atoms)


### PR DESCRIPTION
The previous einsum('iijk->jk', fcs) summed only the on-site (i==j) self-interaction blocks, which is unrelated to the acoustic sum rule. The ASR condition is sum_j Phi_ij = 0 for every atom i.

Compute per-atom row sums and return the one with the largest Frobenius norm, so the field reports the worst per-atom violation.

## Contributor Checklist

- [X] I have broken down my PR scope into the following TODO tasks
   -  [X] Replace the on-site einsum with a per-atom row sum
- [X] I have run the tests locally and they passed.
- [X] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR