### PR TITLE
Parsing extra fields in phonon data

### DIFF
--- a/emmet-core/emmet/core/band_theory.py
+++ b/emmet-core/emmet/core/band_theory.py
@@ -59,7 +59,8 @@ class BandTheoryBase(BaseModel):
     def __str__(self) -> str:
         return (
             f"{self.__class__.__name__}({self.identifier or ''}"
-            f"{': ' + self.structure.formula if self.structure else ''})"
+            f"{': ' if self.identifier else ''}"
+            f"{self.structure.formula if self.structure else ''})"
         )
 
     def __repr__(self) -> str:
@@ -477,6 +478,8 @@ def obtain_path_type(
         Structure associated with the bandstructure
     kpoints : list of tuple[float,float,float]
         A list of (all) k-points included in the bandstructure.
+    user_kpoint_labels: dict of str to Vector3D, or None = None
+        An optional dict of user-defined k-point labels
     symprecs : list[float] = [SETTINGS.SYMPREC,0.01]
         List of `symprec` values to pass to `HighSymmKpath`
     angtols : list[float] = [SETTINGS.ANGLE_TOL]
@@ -490,6 +493,7 @@ def obtain_path_type(
     -----------
     BSPathType
     """
+    found_path_types: set[BSPathType] = set()
     for path_type in (bspt for bspt in BSPathType if bspt.value != "unknown"):  # type: ignore[attr-defined]
         found_path_type = False
         for symprec, angtol in product(symprecs, angtols):
@@ -525,9 +529,10 @@ def obtain_path_type(
                 or (num_extra > 0 and _coarse_list_superset(inferred_kpath, ref_path))
             ):
                 found_path_type = True
+                found_path_types.add(path_type)
                 yield path_type, inferred_kpath, kpoint_labels
 
-    if not found_path_type:
+    if not found_path_types:
         yield BSPathType.unknown, None, {}
 
 

--- a/emmet-core/emmet/core/phonon.py
+++ b/emmet-core/emmet/core/phonon.py
@@ -51,6 +51,7 @@ DEFAULT_PHONON_FILES = {
     "structure": "POSCAR",
     "phonon_bandstructure": "band.yaml",  # chosen as Phonopy default
     "phonon_dos": "total_dos.dat",  # chosen as Phonopy default
+    "projected_dos": "projected_dos.dat",  # chosen as Phonopy default
     "force_constants": "FORCE_CONSTANTS",  # chosen as Phonopy default
     "born": "born.npz",
     "epsilon_static": "epsilon_static.npz",
@@ -159,12 +160,26 @@ class PhononDOS(BandTheoryBase):
     def from_phonopy(
         cls,
         phonon_dos_file: FSPathType,
+        structure_file: FSPathType | None = None,
+        projected_dos_file: FSPathType | None = None,
+        **kwargs,
     ) -> Self:
         """Create a PhononDOS from phonopy .dat output.
+
+        Ref. for data formats used by phonopy:
+        - total_dos.dat :
+        https://phonopy.github.io/phonopy/output-files.html#total-dos-dat-and-projected-dos-dat
+        - projected_dos.dat :
+        https://phonopy.github.io/phonopy/output-files.html#file-format-of-projected-dos-dat
 
         Parameters
         -----------
         phonon_dos_file (FSPathType) : path to total_dos.dat
+        structure_file (FSPathType or None) : path to a POSCAR-like object,
+            either the base computational cell (POSCAR) or the supercell
+            used in the phonon calculation (SPOSCAR).
+        projected_dos_file (FSPathType or None) : path to projected_dos.dat
+        **kwargs : any other kwargs to pass into the PhononDOS constructor
         """
         phonopy_dos: dict[str, Any] = {
             k: []
@@ -173,19 +188,25 @@ class PhononDOS(BandTheoryBase):
                 "densities",
             )
         }
-        with zopen(phonon_dos_file, "rt") as f:
-            for line in f.read().splitlines():
-                non_comment_text = line.split("#")[0]  # type: ignore[arg-type]
-                if len(cols := non_comment_text.split()) == 2:
-                    phonopy_dos["frequencies"].append(float(cols[0]))
-                    phonopy_dos["densities"].append(float(cols[1]))
-                elif len(cols) > 2:
-                    raise ValueError(
-                        f"File {phonon_dos_file} does not have the correct "
-                        "phonopy total_dos.dat format."
-                    )
+        # can handle gzipped files
+        total_dos = np.loadtxt(phonon_dos_file)
+        phonopy_dos["frequencies"] = total_dos[:, 0].tolist()
+        phonopy_dos["densities"] = total_dos[:, 1].tolist()
 
-        return cls(**phonopy_dos)
+        if structure_file:
+            phonopy_dos["structure"] = Structure.from_file(
+                structure_file, format="poscar"
+            )
+
+        if projected_dos_file:
+            # First column are frequencies, can skip these in parsing since
+            # they should be the same as in the total DOS.
+            proj_dos = np.loadtxt(projected_dos_file)
+            phonopy_dos["projected_densities"] = [
+                proj_dos[:, i].tolist() for i in range(1, proj_dos.shape[1])
+            ]
+
+        return cls(**phonopy_dos, **kwargs)
 
 
 class ShreddedEigendisplacements(TypedDict):
@@ -257,6 +278,7 @@ class PhononBS(BandStructure):
 
         if isinstance(config["reciprocal_lattice"], dict):
             config["reciprocal_lattice"] = config["reciprocal_lattice"].get("matrix")
+
         return cls(**config)
 
     @property
@@ -302,8 +324,19 @@ class PhononBS(BandStructure):
         )
 
     @classmethod
-    def from_phonopy(cls, phonon_bandstructure_file: FSPathType):
-        """Create a PhononBS from phonopy .yaml output."""
+    def from_phonopy(
+        cls,
+        phonon_bandstructure_file: FSPathType,
+        structure_file: FSPathType | None = None,
+        **kwargs,
+    ) -> Self:
+        """Create a PhononBS from phonopy .yaml output.
+
+        Args:
+        phonon_bandstructure_file (FSPathType) : path to a band.yaml-like file.
+        structure_file (FSPathType or None) : path to a POSCAR-like structure file.
+        **kwargs : other kwargs to pass to the class constructor
+        """
         with zopen(phonon_bandstructure_file, "rt") as f:
             phonopy_bandstructure = yaml.safe_load(f.read())
 
@@ -314,7 +347,11 @@ class PhononBS(BandStructure):
                 for entry in phonopy_bandstructure["phonon"]
             ],
         )
-        return cls(**phonopy_bandstructure)
+        if structure_file:
+            phonopy_bandstructure["structure"] = Structure.from_file(
+                structure_file, fmt="poscar"
+            )
+        return cls(**phonopy_bandstructure, **kwargs)
 
 
 class SumRuleChecks(BaseModel):
@@ -756,6 +793,7 @@ class PhononBSDOSTask(StructureMetadata):
         structure_file: FSPathType,
         phonon_bandstructure_file: FSPathType | None = None,
         phonon_dos_file: FSPathType | None = None,
+        projected_dos_file: FSPathType | None = None,
         force_constants_file: FSPathType | None = None,
         born_file: FSPathType | None = None,
         epsilon_static_file: FSPathType | None = None,
@@ -775,11 +813,16 @@ class PhononBSDOSTask(StructureMetadata):
 
         if phonon_bandstructure_file:
             cls_config["phonon_bandstructure"] = PhononBS.from_phonopy(
-                phonon_bandstructure_file
+                phonon_bandstructure_file,
+                structure=cls_config["structure"],
             )
 
         if phonon_dos_file:
-            cls_config["phonon_dos"] = PhononDOS.from_phonopy(phonon_dos_file)
+            cls_config["phonon_dos"] = PhononDOS.from_phonopy(
+                phonon_dos_file,
+                projected_dos_file=projected_dos_file,
+                structure=cls_config["structure"],
+            )
 
         if force_constants_file:
             # read FORCE_CONSTANTS manually
@@ -844,12 +887,15 @@ class PhononBSDOSTask(StructureMetadata):
         Parameters
         -----------
         phonon_dir : str or Path
-        **kwargs to pass to `PhononBSDOSDoc.from_phonopy_pheasy_files`
+        **kwargs to pass to `PhononBSDOSDoc.from_phonopy_pheasy_files`.
+            The user can override the default file paths for select files
+            using this.
         """
         phonon_path = Path(phonon_dir).resolve()
         file_paths = {}
         for k, file_name in DEFAULT_PHONON_FILES.items():
-            if (file_path := Path(zpath(str(phonon_path / file_name)))).exists():
+            file_path = phonon_path / kwargs.pop(f"{k}_file", file_name)
+            if (file_path := Path(zpath(file_path))).exists():
                 file_paths[f"{k}_file"] = file_path
         return cls.from_phonopy_pheasy_files(**file_paths, **kwargs)
 

--- a/emmet-core/emmet/core/phonon.py
+++ b/emmet-core/emmet/core/phonon.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from enum import Enum
 from functools import cached_property
-import gzip
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
 
@@ -46,11 +45,6 @@ if TYPE_CHECKING:
     from typing import Any
 
     from typing_extensions import Self
-
-    try:
-        from phonopy.structure.atoms import PhonopyAtoms
-    except ImportError:
-        PhonopyAtoms = None
 
 DEFAULT_PHONON_FILES = {
     "structure": "POSCAR",
@@ -768,7 +762,7 @@ class PhononBSDOSTask(StructureMetadata):
         try:
             import phonopy
         except ImportError:
-            phonopy = None
+            phonopy = None  # type: ignore[assignment]
 
         cls_config: dict[str, Any] = {
             "structure": Structure.from_file(structure_file),
@@ -840,14 +834,9 @@ class PhononBSDOSTask(StructureMetadata):
                 raise ImportError("You must `pip install phonopy` to parse BORN.")
 
             phonopy_calc = phonopy.load(phonopy_output_file)
-            if ".gz" in Path(epsilon_static_and_born_file).suffixes:
-                with gzip.open(epsilon_static_and_born_file, "rt") as f:
-                    born_data = phonopy.file_IO.parse_BORN_from_strings(
-                        f.read(), phonopy_calc.unitcell
-                    )
-            else:
-                born_data = phonopy.file_IO.parse_BORN(
-                    phonopy_calc.unitcell, filename=epsilon_static_and_born_file
+            with zopen(epsilon_static_and_born_file, "rt") as f:
+                born_data = phonopy.file_IO.parse_BORN_from_strings(
+                    f.read(), phonopy_calc.unitcell
                 )
 
             cls_config.update(

--- a/emmet-core/emmet/core/phonon.py
+++ b/emmet-core/emmet/core/phonon.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from enum import Enum
 from functools import cached_property
+import gzip
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
 
@@ -46,6 +47,10 @@ if TYPE_CHECKING:
 
     from typing_extensions import Self
 
+    try:
+        from phonopy.structure.atoms import PhonopyAtoms
+    except ImportError:
+        PhonopyAtoms = None
 
 DEFAULT_PHONON_FILES = {
     "structure": "POSCAR",
@@ -66,51 +71,6 @@ class PhononMethod(Enum):
     DFPT = "dfpt"
     PHONOPY = "phonopy"
     PHEASY = "pheasy"
-
-
-def parse_phonopy_born_file(file: FSPathType) -> tuple[np.ndarray, np.ndarray]:
-    """Parse a phonopy BORN file into static dielectric and Born charge tensors.
-
-    From the phonopy manual
-    (https://phonopy.github.io/phonopy/input-files.html#born-optional)
-    the BORN file is structured as:
-        line 0: metadata, including maximum number of atoms
-        line 1: static dielectric tensor
-        lines 2+: Born effective charges on each atomic site
-
-    For both the dielectric tensor and Born charges, the order of
-    components is: xx, xy, xz, yx, yy, yz, zx, zy, and zz, or
-    ```py
-    [(j,i) for j in range(3) for i in range(3)]
-
-    Args:
-    file (FSPathType) : path to the BORN file.
-
-    Returns:
-    Matrix3D : The static, high-frequency limit of the dielectric tensor
-    list of Matrix3D : The Born effective charges, a 3x3 matrix for
-        each atom in the cell.
-    ```
-    """
-    natom = 0
-    iatom = 0
-    idxs = [(j, i) for j in range(3) for i in range(3)]
-    eps_inf = np.zeros((3, 3), dtype=float)
-    with open(file, "rt") as f:
-        for idx, line in enumerate(f):
-            if idx == 0:
-                natom = int(line.split()[-1])
-                bec = np.zeros((natom, 3, 3), dtype=float)
-            elif idx == 1:
-                vals = [float(x) for x in line.split()]
-                for i, ibec in enumerate(idxs):
-                    eps_inf[ibec[0], ibec[1]] = vals[i]
-            else:
-                vals = [float(x) for x in line.split()]
-                for i, ibec in enumerate(idxs):
-                    bec[iatom][ibec[0], ibec[1]] = vals[i]
-                iatom += 1
-    return eps_inf, bec
 
 
 class PhononDOS(BandTheoryBase):
@@ -805,6 +765,11 @@ class PhononBSDOSTask(StructureMetadata):
         Create a PhononBSDOSDoc from a list of explicit Phonopy/Pheasy file paths.
         """
 
+        try:
+            import phonopy
+        except ImportError:
+            phonopy = None
+
         cls_config: dict[str, Any] = {
             "structure": Structure.from_file(structure_file),
         }
@@ -853,6 +818,12 @@ class PhononBSDOSTask(StructureMetadata):
                         irow += 1
             cls_config["force_constants"] = force_constant_matrix.tolist()
 
+        if phonopy_output_file:
+            with zopen(phonopy_output_file, "rt") as f:
+                phonopy_output = yaml.safe_load(f.read())
+            for k in ("primitive_matrix", "supercell_matrix"):
+                cls_config[k] = phonopy_output.get(k)
+
         if all(
             fs is not None and ".npz" in Path(fs).name
             for fs in (born_file, epsilon_static_file)
@@ -861,18 +832,30 @@ class PhononBSDOSTask(StructureMetadata):
             cls_config["epsilon_static"] = np.load(epsilon_static_file)  # type: ignore[arg-type]
 
         elif (
-            epsilon_static_and_born_file
+            phonopy_output_file
+            and epsilon_static_and_born_file
             and "BORN" in Path(epsilon_static_and_born_file).name
         ):
-            cls_config["epsilon_static"], cls_config["born"] = parse_phonopy_born_file(
-                epsilon_static_and_born_file
-            )
+            if phonopy is None:
+                raise ImportError("You must `pip install phonopy` to parse BORN.")
 
-        if phonopy_output_file:
-            with zopen(phonopy_output_file, "rt") as f:
-                phonopy_output = yaml.safe_load(f.read())
-            for k in ("primitive_matrix", "supercell_matrix"):
-                cls_config[k] = phonopy_output.get(k)
+            phonopy_calc = phonopy.load(phonopy_output_file)
+            if ".gz" in Path(epsilon_static_and_born_file).suffixes:
+                with gzip.open(epsilon_static_and_born_file, "rt") as f:
+                    born_data = phonopy.file_IO.parse_BORN_from_strings(
+                        f.read(), phonopy_calc.unitcell
+                    )
+            else:
+                born_data = phonopy.file_IO.parse_BORN(
+                    phonopy_calc.unitcell, filename=epsilon_static_and_born_file
+                )
+
+            cls_config.update(
+                {
+                    k: born_data[v]
+                    for k, v in {"epsilon_static": "dielectric", "born": "born"}.items()
+                }
+            )
 
         return cls.from_structure(cls_config["structure"], **cls_config, **kwargs)
 

--- a/emmet-core/pyproject.toml
+++ b/emmet-core/pyproject.toml
@@ -56,6 +56,7 @@ all = [
     "pymongo",
     "pycodcif",
     "lobsterpy",
+    "phonopy>=3.0.0",
 ]
 test = [
     "pre-commit",


### PR DESCRIPTION
parsing additional phonon data fields for phonopy-style output:
- structure + projected DOS
- structure (for path order determination) for bandstructure
- Parse BORN charges using phonopy (lots of symmetry expansion here that is not worth trying to re-engineer)
  - Note that phonopy is only loaded if constructing a `PhononBSDOSTask.from_phonopy_pheasy_*` and only used for BORN right now. The other output is simple 

Other changes:
- Faster parsing by using `numpy` directly 
- Ensure `obtain_path_type` doesn't return `unknown` if a path type has already been determined