### PR TITLE
add is_dev_env to UserSettings

### DIFF
--- a/emmet-core/emmet/core/_user_settings.py
+++ b/emmet-core/emmet/core/_user_settings.py
@@ -13,6 +13,7 @@ class UserSettings(BaseModel):
     message_last_read: DateTimeType
     agreed_terms: bool = False
     render_legacy_id: bool = True
+    is_dev_env: bool = False
 
 
 class UserSettingsDoc(BaseModel):


### PR DESCRIPTION
Support `is_dev_env` in web `MPUserSettings`
```
class MPUserSettings(UserSettings):
    is_dev_env: bool = Field(
        default_factory=lambda: is_dev_env(
            localhosts=("localhost.", "localhost:", "127.0.0.1:", "0.0.0.0:")
        )
    )
```