### PR TITLE
CLI: restore validation test coverage

### DIFF
--- a/emmet-cli/tests/conftest.py
+++ b/emmet-cli/tests/conftest.py
@@ -1,8 +1,9 @@
 import os
 from pathlib import Path
+from uuid import uuid4
 from click.testing import CliRunner
 from emmet.cli.state_manager import StateManager
-from emmet.cli.submission import CalculationMetadata, Submission
+from emmet.cli.submission import Submission
 from emmet.cli.submit import _create_submission
 from emmet.cli.task_manager import TaskManager
 from emmet.core.vasp.validation import ValidationDoc
@@ -26,7 +27,7 @@ def cli_runner(task_manager):
 
 def wait_for_task_completion_and_assert_status(result, task_manager, status):
     task_id = result.output.split("\n")[0].split()[-1]
-    final_status = task_manager.wait_for_task_completion(task_id)
+    final_status = task_manager.wait_for_task_completion(task_id, timeout=10)
     assert final_status["status"] == status
     return final_status
 
@@ -49,6 +50,29 @@ def task_manager(state_manager, temp_state_dir):
         state_manager=state_manager,
         daemon_log=temp_state_dir / "task_manager_daemon.log",
     )
+
+
+@pytest.fixture
+def inline_task_manager(task_manager, monkeypatch):
+    """Run task bodies inline while preserving task status transitions."""
+
+    def start_task(func, *args, **kwargs):
+        task_id = str(uuid4())
+        task_manager._update_task_status(
+            task_id,
+            "running",
+            additional_data={"started_at": task_manager._get_current_timestamp()},
+        )
+        try:
+            result = func(*args, **kwargs)
+        except Exception as exc:
+            task_manager._update_task_status(task_id, "failed", error=str(exc))
+        else:
+            task_manager._update_task_status(task_id, "completed", result=result)
+        return task_id
+
+    monkeypatch.setattr(task_manager, "start_task", start_task)
+    return task_manager
 
 
 @pytest.fixture
@@ -135,9 +159,7 @@ def validation_test_path():
 
 
 @pytest.fixture()
-def validation_sub_file(
-    validation_test_path, cli_runner, tmp_path_factory, task_manager
-):
+def validation_sub_file(validation_test_path, tmp_path_factory):
     with DataArchive.extract(validation_test_path) as dir_name:
         result = _create_submission(paths=[str(dir_name)])
         matches = result[1]
@@ -153,24 +175,29 @@ def validation_sub_file(
         yield str(output_file)
 
 
-# TODO: remove this when monkeypatch tests to use fake POTCARs rather than skipping them
-@pytest.fixture(autouse=True)
-def patch_validate_calc(monkeypatch):
-    def validate_without_checking_potcar(self, locator):
-        try:
-            self.refresh()
-            if self.calc_valid is None:
-                validator = ValidationDoc.from_file_metadata(
-                    file_meta=self.files, fast=True, check_potcar=False
-                )
-                self.calc_valid = validator.valid
-                self.calc_validation_errors = validator.reasons
-        except Exception as e:
-            self.calc_valid = False
-            self.calc_validation_errors.append(f"Error validating calculation: {e}")
-        return self.calc_valid
+@pytest.fixture()
+def invalid_validation_sub_file(tmp_path):
+    calc_dir = tmp_path / "invalid_calc"
+    calc_dir.mkdir()
+    for file_name in ("INCAR", "POSCAR", "POTCAR", "CONTCAR", "OUTCAR", "vasprun.xml"):
+        (calc_dir / file_name).touch()
 
-    # Bind it onto the class under test
+    submission = Submission.from_paths(paths=[calc_dir])
+    output_file = tmp_path / "invalid_validation_sub.json"
+    submission.save(output_file)
+    return str(output_file)
+
+
+@pytest.fixture(autouse=True)
+def disable_potcar_validation(monkeypatch):
+    original = ValidationDoc.from_file_metadata.__func__
+
+    def from_file_metadata_without_potcar(cls, file_meta, **kwargs):
+        kwargs["check_potcar"] = False
+        return original(cls, file_meta, **kwargs)
+
     monkeypatch.setattr(
-        CalculationMetadata, "validate_calculation", validate_without_checking_potcar
+        ValidationDoc,
+        "from_file_metadata",
+        classmethod(from_file_metadata_without_potcar),
     )

--- a/emmet-cli/tests/test_submit.py
+++ b/emmet-cli/tests/test_submit.py
@@ -10,7 +10,6 @@ from emmet.cli.submit import (
 )
 from emmet.cli.utils import EmmetCliError
 from conftest import (
-    wait_for_task_completion_and_assert_status,
     wait_for_task_completion_and_assert_success,
 )
 
@@ -100,29 +99,41 @@ def test_remove_from(sub_file, cli_runner, task_manager):
     assert all(str(path_to_remove) in match for match in matches)
 
 
-@pytest.mark.skip(reason="Temporary skip. Fix when resume work on CLI.")
-def test_validate(validation_sub_file, cli_runner, task_manager):
+def test_validate_success(validation_sub_file, cli_runner, inline_task_manager):
     result = cli_runner(submit, ["validate", validation_sub_file])
 
     assert result.exit_code == 0
     assert "Validation started." in result.output
-    final_status = wait_for_task_completion_and_assert_success(result, task_manager)
-    assert (
-        final_status["result"] is False
-    )  # TODO: switch this to True when fix tests to use fake POTCAR
+    final_status = wait_for_task_completion_and_assert_success(
+        result, inline_task_manager
+    )
+    assert final_status["result"] is True
 
-    # TODO: add test that fails validation when fix tests to use fake POTCAR
+    submission = Submission.load(Path(validation_sub_file))
+    assert all(cm.calc_valid is True for _, cm in submission.calculations)
+    assert all(not cm.calc_validation_errors for _, cm in submission.calculations)
 
 
-@pytest.mark.skip(reason="Temporary skip. Fix when resume work on CLI.")
+def test_validate_failure(invalid_validation_sub_file, cli_runner, inline_task_manager):
+    result = cli_runner(submit, ["validate", invalid_validation_sub_file])
+
+    assert result.exit_code == 0
+    assert "Validation started." in result.output
+    final_status = wait_for_task_completion_and_assert_success(
+        result, inline_task_manager
+    )
+    assert final_status["result"] is False
+
+    submission = Submission.load(Path(invalid_validation_sub_file))
+    assert any(
+        cm.calc_valid is False and cm.calc_validation_errors
+        for _, cm in submission.calculations
+    )
+
+
+@pytest.mark.skip(reason="Push coverage is deferred to issue #1486.")
 def test_push(validation_sub_file, cli_runner, task_manager):
     result = cli_runner(submit, ["push", validation_sub_file])
 
     assert result.exit_code == 0
     assert "Push started." in result.output
-
-    wait_for_task_completion_and_assert_status(
-        result, task_manager, "failed"
-    )  # TODO: switch to success and check result when fix tests to use fake POTCAR
-
-    # TODO: add test that for failing cases when fix tests to use fake POTCAR


### PR DESCRIPTION
## Summary

- replace the copied calculation-validation monkeypatch with a test-only POTCAR-check override at the validator boundary
- add deterministic successful and failed CLI validation coverage, including persisted validation state
- bound task waits and use inline task execution for command tests while retaining task status transitions
- defer push coverage explicitly to #1486

Closes #1484

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
  - [x] add POTCAR-independent validation fixtures
  - [x] cover successful and failed CLI validation results
  - [x] retain the push skip with its owning issue identified
- [x] I have run the tests locally and they passed.
- [x] I have added tests, or extended existing tests, to cover the behavior changed in this PR.

## Testing

- `pytest -q emmet-cli/tests` — 68 passed, 1 skipped
- `mypy --config-file .mypy.ini emmet-cli/emmet` — passed
- `pre-commit run --all-files --show-diff-on-failure` — passed
