### PR TITLE
cli: harden task state handling

### DIFF
--- a/emmet-cli/emmet/cli/state_manager.py
+++ b/emmet-cli/emmet/cli/state_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import Any, Self, TextIO
+from typing import Any, Callable, Self, TextIO
 import fcntl
 
 logger = logging.getLogger("emmet")
@@ -69,6 +69,15 @@ class StateManager:
             state = self._load_state()
             state[key] = value
             self._save_state(state)
+
+    def update(self, key: str, updater: Callable[[Any], Any]) -> Any:
+        """Atomically update one top-level state value and return the new value."""
+        with self._state_lock():
+            state = self._load_state()
+            value = updater(state.get(key))
+            state[key] = value
+            self._save_state(state)
+            return value
 
     def _state_lock(self) -> FileLock:
         """Context manager for file locking."""

--- a/emmet-cli/emmet/cli/task_manager.py
+++ b/emmet-cli/emmet/cli/task_manager.py
@@ -161,11 +161,21 @@ class TaskManager:
 
     def _store_task_result(self, task_id: str, result: dict[str, Any]) -> None:
         """Store the task result in the state manager."""
-        tasks = self.state_manager.get("tasks", {})
-        if task_id not in tasks:
-            tasks[task_id] = {}
-        tasks[task_id].update(result)
-        self.state_manager.set("tasks", tasks)
+        terminal_statuses = {"completed", "failed", "terminated"}
+
+        def update_task(tasks: dict[str, Any] | None) -> dict[str, Any]:
+            tasks = tasks or {}
+            task = tasks.setdefault(task_id, {})
+            current_status = task.get("status")
+            updated_result = result
+            if current_status in terminal_statuses and result.get("status") is not None:
+                updated_result = {
+                    key: value for key, value in result.items() if key != "status"
+                }
+            task.update(updated_result)
+            return tasks
+
+        self.state_manager.update("tasks", update_task)
 
     def start_task(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> str:
         """Start a new task in a separate, fully detached process."""
@@ -291,9 +301,16 @@ class TaskManager:
         finished_tasks = [
             task_id for task_id in tasks.keys() if not self.is_task_running(task_id)
         ]
-        for task_id in finished_tasks:
-            del tasks[task_id]
-        self.state_manager.set("tasks", tasks)
+
+        def remove_finished_tasks(
+            current_tasks: dict[str, Any] | None,
+        ) -> dict[str, Any]:
+            current_tasks = current_tasks or {}
+            for task_id in finished_tasks:
+                current_tasks.pop(task_id, None)
+            return current_tasks
+
+        self.state_manager.update("tasks", remove_finished_tasks)
 
     def terminate_task(self, task_id: str) -> dict[str, Any]:
         """Terminate a running task."""

--- a/emmet-cli/tests/conftest.py
+++ b/emmet-cli/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import time
 from pathlib import Path
 from click.testing import CliRunner
 from emmet.cli.state_manager import StateManager
@@ -45,10 +46,53 @@ def temp_state_dir(tmp_path):
 @pytest.fixture
 def task_manager(state_manager, temp_state_dir):
     """Creates a TaskManager instance with a temporary state directory."""
-    return TaskManager(
+    manager = TaskManager(
         state_manager=state_manager,
-        daemon_log=temp_state_dir / "task_manager_daemon.log",
+        daemon_log=str(temp_state_dir / "task_manager_daemon.log"),
     )
+    yield manager
+
+    tasks = manager.state_manager.get("tasks", {})
+    for task_id in tasks:
+        if manager.get_task_status(task_id).get("status") == "running":
+            manager.terminate_task(task_id)
+
+
+@pytest.fixture
+def wait_for_task_state():
+    """Wait until a task state satisfies a predicate."""
+
+    def wait(task_manager, task_id, predicate, timeout=5.0, interval=0.05):
+        deadline = time.monotonic() + timeout
+        while True:
+            status = task_manager.get_task_status(task_id)
+            if predicate(status):
+                return status
+            if time.monotonic() >= deadline:
+                pytest.fail(
+                    f"Task {task_id} did not reach the expected state within "
+                    f"{timeout} seconds; last status: {status}"
+                )
+            time.sleep(interval)
+
+    return wait
+
+
+@pytest.fixture
+def wait_until():
+    """Wait until a predicate returns a truthy value."""
+
+    def wait(predicate, timeout=5.0, interval=0.05):
+        deadline = time.monotonic() + timeout
+        while True:
+            result = predicate()
+            if result:
+                return result
+            if time.monotonic() >= deadline:
+                pytest.fail(f"Condition was not met within {timeout} seconds")
+            time.sleep(interval)
+
+    return wait
 
 
 @pytest.fixture

--- a/emmet-cli/tests/test_state_manager.py
+++ b/emmet-cli/tests/test_state_manager.py
@@ -43,6 +43,35 @@ def test_set_and_get(state_manager):
     )
 
 
+def test_update_atomically_transforms_value(state_manager, monkeypatch):
+    state_manager.set("other_key", "preserved")
+    load_calls = 0
+    save_calls = 0
+    original_load = state_manager._load_state
+    original_save = state_manager._save_state
+
+    def load_state():
+        nonlocal load_calls
+        load_calls += 1
+        return original_load()
+
+    def save_state(state):
+        nonlocal save_calls
+        save_calls += 1
+        original_save(state)
+
+    monkeypatch.setattr(state_manager, "_load_state", load_state)
+    monkeypatch.setattr(state_manager, "_save_state", save_state)
+
+    updated = state_manager.update("items", lambda value: [*(value or []), "new"])
+
+    assert updated == ["new"]
+    assert load_calls == 1
+    assert save_calls == 1
+    assert state_manager.get("items") == ["new"]
+    assert state_manager.get("other_key") == "preserved"
+
+
 def test_save_and_load_state(temp_state_dir):
     """Test that state is properly saved and loaded."""
     manager1 = StateManager(state_dir=temp_state_dir)

--- a/emmet-cli/tests/test_task_manager.py
+++ b/emmet-cli/tests/test_task_manager.py
@@ -2,11 +2,12 @@ import pytest
 import time
 import os
 import signal
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
 from unittest.mock import patch
 import psutil
 from datetime import datetime, timedelta
 from emmet.cli.task_manager import TaskManager, _is_process_running
-from emmet.cli.state_manager import StateManager
 
 
 def task_test_function():
@@ -58,17 +59,6 @@ class MockDateTime:
         return datetime.fromisoformat(date_string)
 
 
-@pytest.fixture
-def task_manager(temp_state_dir):
-    """Creates a TaskManager instance with a temporary state directory."""
-    state_manager = StateManager(state_dir=temp_state_dir)
-    return TaskManager(
-        state_manager=state_manager,
-        running_status_update_interval=1,
-        daemon_log=temp_state_dir / "test_task_manager_daemon.log",
-    )
-
-
 def test_start_task(task_manager):
     """Test starting a new task."""
     task_id = task_manager.start_task(task_test_function)
@@ -79,7 +69,7 @@ def test_start_task(task_manager):
     assert "started_at" in initial_status
 
     final_status = task_manager.wait_for_task_completion(
-        task_id, timeout=1, check_interval=0.1
+        task_id, timeout=5, check_interval=0.1
     )
     assert final_status["status"] == "completed"
     assert final_status["result"] == "completed"
@@ -91,7 +81,7 @@ def test_failing_task_handling(task_manager):
     task_id = task_manager.start_task(failing_task_test_function)
 
     final_status = task_manager.wait_for_task_completion(
-        task_id, timeout=1, check_interval=0.1
+        task_id, timeout=5, check_interval=0.1
     )
     assert final_status["status"] == "failed"
     assert "Task failed" in final_status["error"]
@@ -113,12 +103,10 @@ def test_task_status_checking(task_manager):
 
     # Wait for task to complete and verify status
     final_status = task_manager.wait_for_task_completion(
-        task_id, timeout=1, check_interval=0.1
+        task_id, timeout=5, check_interval=0.1
     )
     assert final_status["status"] == "completed"
 
-    # Give some time for the process to be cleaned up
-    time.sleep(0.1)
     assert task_manager.is_task_running(task_id) is False
 
 
@@ -130,19 +118,71 @@ def test_nonexistent_task_status(task_manager):
     assert task_manager.is_task_running("nonexistent-task") is False
 
 
+def test_concurrent_task_updates_preserve_fields(task_manager):
+    """Test that concurrent process registration preserves both PIDs."""
+    task_id = "concurrent-task"
+    task_manager._store_task_result(
+        task_id,
+        {"status": "running", "started_at": datetime.now().isoformat()},
+    )
+    barrier = Barrier(3)
+
+    def store_result(result):
+        barrier.wait()
+        task_manager._store_task_result(task_id, result)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        initial_update = executor.submit(
+            store_result, {"status": "running", "initial_pid": 12345}
+        )
+        detached_update = executor.submit(
+            store_result, {"status": "running", "detached_pid": 12346}
+        )
+        barrier.wait()
+        initial_update.result()
+        detached_update.result()
+
+    status = task_manager.get_task_status(task_id)
+    assert status["initial_pid"] == 12345
+    assert status["detached_pid"] == 12346
+
+
+@pytest.mark.parametrize("late_status", ["running", "failed", "terminated"])
+def test_late_status_update_preserves_terminal_status(task_manager, late_status):
+    """Test that a late status update cannot change a completed task."""
+    task_id = "quick-task"
+    task_manager._store_task_result(
+        task_id,
+        {
+            "status": "completed",
+            "started_at": datetime.now().isoformat(),
+            "result": "done",
+        },
+    )
+
+    task_manager._store_task_result(
+        task_id, {"status": late_status, "initial_pid": 12345}
+    )
+
+    status = task_manager.get_task_status(task_id)
+    assert status["status"] == "completed"
+    assert status["result"] == "done"
+    assert status["initial_pid"] == 12345
+
+
 def test_sequential_tasks(task_manager):
     """Test handling multiple tasks sequentially."""
     # Start and complete first task
     task_id1 = task_manager.start_task(task_test_function)
     status1 = task_manager.wait_for_task_completion(
-        task_id1, timeout=2, check_interval=0.1
+        task_id1, timeout=5, check_interval=0.1
     )
     assert status1["status"] == "completed"
 
     # Start and complete second task
     task_id2 = task_manager.start_task(task_test_function)
     status2 = task_manager.wait_for_task_completion(
-        task_id2, timeout=2, check_interval=0.1
+        task_id2, timeout=5, check_interval=0.1
     )
     assert status2["status"] == "completed"
 
@@ -151,7 +191,7 @@ def test_sequential_tasks(task_manager):
     assert task_manager.get_task_status(task_id2)["status"] == "completed"
 
 
-def test_task_pid_storage(task_manager):
+def test_task_pid_storage(task_manager, wait_for_task_state):
     """Test that task PIDs are properly stored."""
     # Start a task
     task_id = task_manager.start_task(long_task_test_function)
@@ -162,11 +202,9 @@ def test_task_pid_storage(task_manager):
     assert isinstance(initial_status["initial_pid"], int)
     assert initial_status["initial_pid"] > 0
 
-    # Wait a bit for the detached process to start and store its PID
-    time.sleep(0.5)
-
-    # Check detached status
-    detached_status = task_manager.get_task_status(task_id)
+    detached_status = wait_for_task_state(
+        task_manager, task_id, lambda status: "detached_pid" in status
+    )
     assert "detached_pid" in detached_status
     assert isinstance(detached_status["detached_pid"], int)
     assert detached_status["detached_pid"] > 0
@@ -183,7 +221,7 @@ def test_task_pid_storage(task_manager):
     assert final_status["detached_pid"] == detached_status["detached_pid"]
 
 
-def test_failing_task_pid_storage(task_manager):
+def test_failing_task_pid_storage(task_manager, wait_for_task_state):
     """Test that PIDs are properly stored even for failing tasks."""
     # Start a failing task
     task_id = task_manager.start_task(failing_task_test_function)
@@ -193,11 +231,9 @@ def test_failing_task_pid_storage(task_manager):
     assert "initial_pid" in initial_status
     assert isinstance(initial_status["initial_pid"], int)
 
-    # Wait a bit for the detached process to start and store its PID
-    time.sleep(0.5)
-
-    # Check detached status
-    detached_status = task_manager.get_task_status(task_id)
+    detached_status = wait_for_task_state(
+        task_manager, task_id, lambda status: "detached_pid" in status
+    )
     assert "detached_pid" in detached_status
     assert isinstance(detached_status["detached_pid"], int)
 
@@ -210,17 +246,14 @@ def test_failing_task_pid_storage(task_manager):
     assert final_status["detached_pid"] == detached_status["detached_pid"]
 
 
-def test_terminated_task_detection(task_manager):
+def test_terminated_task_detection(task_manager, wait_for_task_state, wait_until):
     """Test detection of terminated tasks."""
     # Start a long-running task
     task_id = task_manager.start_task(infinite_task_function)
 
-    # Wait for the detached process to start
-    time.sleep(0.5)
-
-    # Get the detached PID
-    status = task_manager.get_task_status(task_id)
-    assert "detached_pid" in status
+    status = wait_for_task_state(
+        task_manager, task_id, lambda task_status: "detached_pid" in task_status
+    )
     pid = status["detached_pid"]
 
     # Verify the process is running
@@ -230,8 +263,7 @@ def test_terminated_task_detection(task_manager):
     # Terminate the process
     os.kill(pid, signal.SIGTERM)
 
-    # Give some time for the termination to be processed
-    time.sleep(0.1)
+    wait_until(lambda: not _is_process_running(pid))
 
     # Verify the task is detected as terminated
     assert not task_manager.is_task_running(task_id)
@@ -244,10 +276,17 @@ def test_terminated_task_detection(task_manager):
 
 def test_terminated_task_wait_completion(task_manager):
     """Test that wait_for_task_completion properly handles terminated tasks."""
-    task_id = task_manager.start_task(infinite_task_function)
-
-    # Wait for the detached process to start
-    time.sleep(0.5)
+    task_id = "terminated-task"
+    task_manager.state_manager.set(
+        "tasks",
+        {
+            task_id: {
+                "status": "running",
+                "started_at": datetime.now().isoformat(),
+                "detached_pid": 12345,
+            }
+        },
+    )
 
     # Mock the process as not running
     mock_dead = MockProcess(is_running=False, status=psutil.STATUS_DEAD)
@@ -256,7 +295,7 @@ def test_terminated_task_wait_completion(task_manager):
         # First check should mark it as terminated
         assert not task_manager.is_task_running(task_id)
         # Now wait_for_task_completion should see the terminated status
-        final_status = task_manager.wait_for_task_completion(task_id, timeout=1)
+        final_status = task_manager.wait_for_task_completion(task_id, timeout=5)
         assert final_status["status"] == "terminated"
         assert "completed_at" in final_status
         assert "error" in final_status
@@ -294,10 +333,17 @@ def test_no_such_process():
 
 def test_zombie_process_task_status(task_manager):
     """Test that tasks with zombie processes are marked as terminated."""
-    task_id = task_manager.start_task(infinite_task_function)
-
-    # Wait for the detached process to start
-    time.sleep(0.5)
+    task_id = "zombie-task"
+    task_manager.state_manager.set(
+        "tasks",
+        {
+            task_id: {
+                "status": "running",
+                "started_at": datetime.now().isoformat(),
+                "detached_pid": 12345,
+            }
+        },
+    )
 
     # Mock the process as a zombie
     mock_zombie = MockProcess(is_running=True, status=psutil.STATUS_ZOMBIE)
@@ -313,10 +359,17 @@ def test_zombie_process_task_status(task_manager):
 
 def test_permission_denied_task_status(task_manager):
     """Test task status handling when process check permission is denied."""
-    task_id = task_manager.start_task(infinite_task_function)
-
-    # Wait for the detached process to start
-    time.sleep(0.5)
+    task_id = "inaccessible-task"
+    task_manager.state_manager.set(
+        "tasks",
+        {
+            task_id: {
+                "status": "running",
+                "started_at": datetime.now().isoformat(),
+                "detached_pid": 12345,
+            }
+        },
+    )
 
     def mock_process(*args):
         raise psutil.AccessDenied()
@@ -350,10 +403,18 @@ def test_various_process_states(process_status):
 
 def test_initial_pid_grace_period(task_manager):
     """Test that tasks with only initial PID get proper grace period."""
-    task_id = task_manager.start_task(infinite_task_function)
-
-    # Set up our initial time just after task start
+    task_id = "initializing-task"
     start_time = datetime.now()
+    task_manager.state_manager.set(
+        "tasks",
+        {
+            task_id: {
+                "status": "running",
+                "started_at": start_time.isoformat(),
+                "initial_pid": 12345,
+            }
+        },
+    )
 
     # Within grace period - process should appear running
     within_grace = TaskManager.DETACH_GRACE_PERIOD * 0.6
@@ -378,23 +439,17 @@ def test_initial_pid_grace_period(task_manager):
             assert not task_manager.is_task_running(task_id)
             status = task_manager.get_task_status(task_id)
             assert status["status"] == "terminated"
-            assert (
-                "failed to detach" in status["error"].lower()
-                or "process was terminated unexpectedly" in status["error"].lower()
-            )
+            assert "failed to detach" in status["error"].lower()
 
 
 def test_no_pid_grace_period(task_manager):
     """Test that tasks with no PID get proper grace period."""
-    task_id = task_manager.start_task(infinite_task_function)
-
-    # Simulate a task that hasn't registered any PID yet
-    tasks = task_manager.state_manager.get("tasks", {})
-    tasks[task_id] = {"status": "running", "started_at": datetime.now().isoformat()}
-    task_manager.state_manager.set("tasks", tasks)
-
-    # Set up our initial time just after task start
+    task_id = "initializing-task"
     start_time = datetime.now()
+    task_manager.state_manager.set(
+        "tasks",
+        {task_id: {"status": "running", "started_at": start_time.isoformat()}},
+    )
 
     # Test within grace period (at 50% of grace period)
     within_grace = TaskManager.INIT_GRACE_PERIOD * 0.5
@@ -418,12 +473,10 @@ def test_no_pid_grace_period(task_manager):
 
 def test_missing_start_time(task_manager):
     """Test handling of tasks with missing start time."""
-    task_id = task_manager.start_task(infinite_task_function)
-
-    # Simulate a task with no start time
-    tasks = task_manager.state_manager.get("tasks", {})
-    tasks[task_id] = {"status": "running", "initial_pid": 12345}  # Some dummy PID
-    task_manager.state_manager.set("tasks", tasks)
+    task_id = "task-without-start-time"
+    task_manager.state_manager.set(
+        "tasks", {task_id: {"status": "running", "initial_pid": 12345}}
+    )
 
     # Should be marked as terminated immediately
     assert not task_manager.is_task_running(task_id)
@@ -442,13 +495,12 @@ def test_missing_start_time(task_manager):
 )
 def test_no_pid_various_times(task_manager, time_factor, expected_running):
     """Test task status at various times when no PID is registered."""
-    task_id = task_manager.start_task(infinite_task_function)
-
-    # Simulate a task that hasn't registered any PID yet
+    task_id = "initializing-task"
     start_time = datetime.now()
-    tasks = task_manager.state_manager.get("tasks", {})
-    tasks[task_id] = {"status": "running", "started_at": start_time.isoformat()}
-    task_manager.state_manager.set("tasks", tasks)
+    task_manager.state_manager.set(
+        "tasks",
+        {task_id: {"status": "running", "started_at": start_time.isoformat()}},
+    )
 
     # Test at the specified time
     elapsed_time = TaskManager.INIT_GRACE_PERIOD * time_factor
@@ -460,15 +512,13 @@ def test_no_pid_various_times(task_manager, time_factor, expected_running):
             assert status["status"] == "terminated"
 
 
-def test_terminate_running_task(task_manager):
+def test_terminate_running_task(task_manager, wait_for_task_state):
     """Test terminating a running task."""
     task_id = task_manager.start_task(infinite_task_function)
 
-    # Wait for the detached process to start
-    time.sleep(0.5)
-
-    # Get initial status
-    status = task_manager.get_task_status(task_id)
+    status = wait_for_task_state(
+        task_manager, task_id, lambda task_status: "detached_pid" in task_status
+    )
     assert status["status"] == "running"
     assert "detached_pid" in status
 
@@ -494,7 +544,7 @@ def test_terminate_completed_task(task_manager):
     task_id = task_manager.start_task(task_test_function)
 
     # Wait for task to complete
-    task_manager.wait_for_task_completion(task_id, timeout=1)
+    task_manager.wait_for_task_completion(task_id, timeout=5)
 
     # Try to terminate the completed task
     status = task_manager.terminate_task(task_id)
@@ -508,7 +558,7 @@ def test_terminate_failed_task(task_manager):
     task_id = task_manager.start_task(failing_task_test_function)
 
     # Wait for task to fail
-    task_manager.wait_for_task_completion(task_id, timeout=1)
+    task_manager.wait_for_task_completion(task_id, timeout=5)
 
     # Try to terminate the failed task
     status = task_manager.terminate_task(task_id)
@@ -517,12 +567,13 @@ def test_terminate_failed_task(task_manager):
     assert "Task failed" in status["error"]
 
 
-def test_terminate_already_terminated_task(task_manager):
+def test_terminate_already_terminated_task(task_manager, wait_for_task_state):
     """Test attempting to terminate an already terminated task."""
     task_id = task_manager.start_task(infinite_task_function)
 
-    # Wait for the detached process to start
-    time.sleep(0.5)
+    wait_for_task_state(
+        task_manager, task_id, lambda task_status: "detached_pid" in task_status
+    )
 
     # Terminate the task first time
     first_status = task_manager.terminate_task(task_id)
@@ -536,10 +587,24 @@ def test_terminate_already_terminated_task(task_manager):
 
 def test_terminate_task_with_only_initial_pid(task_manager):
     """Test terminating a task that only has initial PID."""
-    task_id = task_manager.start_task(infinite_task_function)
+    task_id = "initial-process-task"
+    task_manager.state_manager.set(
+        "tasks",
+        {
+            task_id: {
+                "status": "running",
+                "started_at": datetime.now().isoformat(),
+                "initial_pid": 12345,
+            }
+        },
+    )
 
-    # Immediately try to terminate before detached PID is set
-    status = task_manager.terminate_task(task_id)
+    with patch.object(
+        task_manager, "_try_terminate_process", return_value=True
+    ) as terminate:
+        status = task_manager.terminate_task(task_id)
+
+    terminate.assert_called_once_with(12345)
     assert status["status"] == "terminated"
     assert "error" in status
     assert "terminated by user request" in status["error"].lower()
@@ -558,10 +623,17 @@ def test_terminate_task_with_only_initial_pid(task_manager):
 )
 def test_terminate_task_with_process_errors(task_manager, exception_class):
     """Test terminating a task when process operations raise exceptions."""
-    task_id = task_manager.start_task(infinite_task_function)
-
-    # Wait for the detached process to start
-    time.sleep(0.5)
+    task_id = "process-error-task"
+    task_manager.state_manager.set(
+        "tasks",
+        {
+            task_id: {
+                "status": "running",
+                "started_at": datetime.now().isoformat(),
+                "detached_pid": 12345,
+            }
+        },
+    )
 
     def mock_process(*args):
         pid = args[0]  # Get the actual PID being passed
@@ -576,18 +648,22 @@ def test_terminate_task_with_process_errors(task_manager, exception_class):
         assert "terminated by user request" in status["error"].lower()
 
 
-def test_sequential_task_termination(task_manager):
+def test_sequential_task_termination(task_manager, wait_for_task_state):
     """Test terminating tasks in sequence."""
     # Start and terminate first task
     task_id1 = task_manager.start_task(infinite_task_function)
-    time.sleep(0.5)  # Wait for task to start
+    wait_for_task_state(
+        task_manager, task_id1, lambda task_status: "detached_pid" in task_status
+    )
     status1 = task_manager.terminate_task(task_id1)
     assert status1["status"] == "terminated"
     assert "terminated by user request" in status1["error"].lower()
 
     # Start and terminate second task
     task_id2 = task_manager.start_task(infinite_task_function)
-    time.sleep(0.5)  # Wait for task to start
+    wait_for_task_state(
+        task_manager, task_id2, lambda task_status: "detached_pid" in task_status
+    )
     status2 = task_manager.terminate_task(task_id2)
     assert status2["status"] == "terminated"
     assert "terminated by user request" in status2["error"].lower()
@@ -597,19 +673,23 @@ def test_sequential_task_termination(task_manager):
     assert task_manager.get_task_status(task_id2)["status"] == "terminated"
 
 
-def test_terminate_mixed_tasks(task_manager):
+def test_terminate_mixed_tasks(task_manager, wait_for_task_state):
     """Test terminating a mix of running, completed, and failed tasks."""
     # Start a task that will complete
     completed_task_id = task_manager.start_task(task_test_function)
-    task_manager.wait_for_task_completion(completed_task_id, timeout=2)
+    task_manager.wait_for_task_completion(completed_task_id, timeout=5)
 
     # Start a task that will fail
     failed_task_id = task_manager.start_task(failing_task_test_function)
-    task_manager.wait_for_task_completion(failed_task_id, timeout=2)
+    task_manager.wait_for_task_completion(failed_task_id, timeout=5)
 
     # Start a task that will be terminated
     running_task_id = task_manager.start_task(infinite_task_function)
-    time.sleep(0.5)  # Wait for task to start
+    wait_for_task_state(
+        task_manager,
+        running_task_id,
+        lambda task_status: "detached_pid" in task_status,
+    )
 
     # Try to terminate all tasks
     completed_status = task_manager.terminate_task(completed_task_id)
@@ -629,15 +709,13 @@ def test_terminate_mixed_tasks(task_manager):
     assert "terminated by user request" in running_status["error"].lower()
 
 
-def test_terminate_task_cleanup(task_manager):
+def test_terminate_task_cleanup(task_manager, wait_for_task_state):
     """Test that terminated tasks are properly cleaned up."""
     # Start and terminate a task
     task_id = task_manager.start_task(infinite_task_function)
-    time.sleep(0.5)  # Wait for task to start
-
-    # Get the PID before termination
-    status = task_manager.get_task_status(task_id)
-    assert "detached_pid" in status
+    status = wait_for_task_state(
+        task_manager, task_id, lambda task_status: "detached_pid" in task_status
+    )
     pid = status["detached_pid"]
 
     # Terminate the task

--- a/emmet-cli/tests/test_tasks.py
+++ b/emmet-cli/tests/test_tasks.py
@@ -1,6 +1,5 @@
 from emmet.cli.tasks import tasks
 from emmet.cli.utils import EmmetCliError
-import time
 
 
 def mock_task_function():
@@ -123,10 +122,10 @@ def test_clean_command(cli_runner, task_manager):
     assert len(tasks_after) == 0
 
 
-def test_terminate_command_running_task(cli_runner, task_manager):
+def test_terminate_command_running_task(cli_runner, task_manager, wait_for_task_state):
     """Test terminate command for a running task."""
     task_id = task_manager.start_task(slow_task_function)
-    time.sleep(0.5)  # Wait for task to start
+    wait_for_task_state(task_manager, task_id, lambda status: "detached_pid" in status)
 
     # Test with force flag to skip confirmation
     result = cli_runner(tasks, ["terminate", task_id, "--force"])
@@ -168,10 +167,12 @@ def test_terminate_command_nonexistent_task(cli_runner, task_manager):
     assert "Invalid task ID" in str(result.exception)
 
 
-def test_terminate_command_confirmation(cli_runner, task_manager, monkeypatch):
+def test_terminate_command_confirmation(
+    cli_runner, task_manager, monkeypatch, wait_for_task_state
+):
     """Test terminate command with user confirmation."""
     task_id = task_manager.start_task(slow_task_function)
-    time.sleep(0.5)  # Wait for task to start
+    wait_for_task_state(task_manager, task_id, lambda status: "detached_pid" in status)
 
     # Test with 'y' confirmation
     result = cli_runner(tasks, ["terminate", task_id], input="y\n")
@@ -180,7 +181,7 @@ def test_terminate_command_confirmation(cli_runner, task_manager, monkeypatch):
 
     # Start another task
     task_id = task_manager.start_task(slow_task_function)
-    time.sleep(0.5)  # Wait for task to start
+    wait_for_task_state(task_manager, task_id, lambda status: "detached_pid" in status)
 
     # Test with 'n' confirmation
     result = cli_runner(tasks, ["terminate", task_id], input="n\n")


### PR DESCRIPTION
This PR fixes flaky CLI background-task tests and hardens task state updates against parent/child races.

- Atomically merge task-state updates under the state-file lock.
- Preserve the first terminal task status while still accepting late PID metadata.
- Replace timing sleeps with bounded state polling.
- Use synthetic task state for mocked process scenarios and clean up live tasks during teardown.

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   - [x] Harden concurrent task-state updates
   - [x] Remove race-prone process test setup
- [x] I have run the tests locally and they passed.
- [x] I have added tests, or extended existing tests, to cover the bugs fixed in this PR.

## Testing

- pre-commit run --all-files
- Mypy: passed for emmet-cli/emmet
- CLI tests with coverage: 71 passed, 2 skipped

The local pytest environment did not include pytest-xdist, so the suite ran serially rather than with -n auto.